### PR TITLE
Use https in Dockerfile

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,6 +4,7 @@ set -e
 # Change owner for our uploads folder
 echo -n "Fix permissions for mounted volumes ..." && \
   chown -R abc:abc $Storage__UploadDirectory && \
+  chown -R abc:abc /etc/ssl/private && \
   echo "done!"
 
 


### PR DESCRIPTION
Install temp CA and SSL cert so that the SSL port can be exposed. We use a flexible and valid SSL cert from Azure in the hosting environment; this cert is only used to support https all the way through so that the underlying HttpContext can generate valid https links for us.