### PR TITLE
Revert to using http in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,21 +60,7 @@ RUN \
  usermod --groups users abc && \
  mkdir -p $Storage__UploadDirectory
 
-# Install temp CA and SSL cert so that the SSL port can be exposed.
-# The cert is self-signed and only valid for localhost. Because a valid and dynamic
-# SSL cert is used for hosting, the cert is only used to expose the SSL port.
-ENV Kestrel:Certificates:Default:Path=/etc/ssl/private/cert.pfx
-ENV Kestrel:Certificates:Default:Password=changeit
-ENV Kestrel:Certificates:Default:AllowInvalid=true
-ENV Kestrel:EndPointDefaults:Protocols=Http1AndHttp2
-
-RUN apt-get update && apt-get install curl -y && \
-	curl -L https://github.com/FiloSottile/mkcert/releases/download/v1.4.4/mkcert-v1.4.4-linux-amd64 > /usr/local/bin/mkcert && \
-	chmod +x /usr/local/bin/mkcert
-RUN mkcert -install
-RUN mkcert -p12-file /etc/ssl/private/cert.pfx -pkcs12 'localhost 127.0.0.1 ::1'
-
-EXPOSE 443
+EXPOSE 80
 VOLUME $Storage__UploadDirectory
 
 # Set default locale

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,7 +4,6 @@ set -e
 # Change owner for our uploads folder
 echo -n "Fix permissions for mounted volumes ..." && \
   chown -R abc:abc $Storage__UploadDirectory && \
-  chown -R abc:abc /etc/ssl/private && \
   echo "done!"
 
 


### PR DESCRIPTION
This change was good for local testing purposes but is not needed anymore and not support by our hosting environment. See also: https://learn.microsoft.com/en-us/azure/app-service/configure-custom-container?pivots=container-linux&tabs=debian#detect-https-session.

#94 