### PR TITLE
Revert "Migrate JavaScript.Sdk to non alpha version"

### DIFF
--- a/src/Geopilot.Frontend/Geopilot.Frontend.esproj
+++ b/src/Geopilot.Frontend/Geopilot.Frontend.esproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.VisualStudio.JavaScript.Sdk/1.0.628833">
+﻿<Project Sdk="Microsoft.VisualStudio.JavaScript.Sdk/0.5.94-alpha">
   <!-- Workaround for issue: https://github.com/dotnet/sdk/issues/32891 -->
   <PropertyGroup Condition=" '$(OS)' == 'Unix' " >
       <FrameworkPathOverride>/usr/local/share/dotnet/shared/Microsoft.NETCore.App/7.0.5/mscorlib.dll</FrameworkPathOverride>


### PR DESCRIPTION
Reverts GeoWerkstatt/geopilot#160
Current Versions break `dotnet publish`: https://github.com/dotnet/sdk/issues/39148