### PR TITLE
Require spatial extent for mandates

### DIFF
--- a/src/Geopilot.Api/Controllers/MandateController.cs
+++ b/src/Geopilot.Api/Controllers/MandateController.cs
@@ -94,11 +94,13 @@ public class MandateController : ControllerBase
             if (mandate == null)
                 return BadRequest();
 
+            if (!mandate.SetPolygonFromCoordinates())
+                return BadRequest("Invalid coordinates for spatial extent.");
+
             var organisationIds = mandate.Organisations.Select(o => o.Id).ToList();
             mandate.Organisations = await context.Organisations
                 .Where(o => organisationIds.Contains(o.Id))
                 .ToListAsync();
-            mandate.SetPolygonFromCoordinates();
 
             var entityEntry = await context.AddAsync(mandate).ConfigureAwait(false);
             await context.SaveChangesAsync().ConfigureAwait(false);
@@ -146,7 +148,8 @@ public class MandateController : ControllerBase
             if (existingMandate == null)
                 return NotFound();
 
-            mandate.SetPolygonFromCoordinates();
+            if (!mandate.SetPolygonFromCoordinates())
+                return BadRequest("Invalid coordinates for spatial extent.");
 
             context.Entry(existingMandate).CurrentValues.SetValues(mandate);
 

--- a/src/Geopilot.Api/Models/Mandate.cs
+++ b/src/Geopilot.Api/Models/Mandate.cs
@@ -53,23 +53,23 @@ public class Mandate
     /// <summary>
     /// Transforms the <see cref="Coordinates"/> list to a <see cref="SpatialExtent"/> polygon.
     /// </summary>
-    public void SetPolygonFromCoordinates()
+    /// <returns><c>true</c> if this mandate has 2 coordinates to create the spatial extent; otherwise, <c>false</c>.</returns>
+    public bool SetPolygonFromCoordinates()
     {
         if (Coordinates.Count != 2)
         {
-            SpatialExtent = Geometry.DefaultFactory.CreatePolygon();
+            return false;
         }
-        else
+
+        SpatialExtent = Geometry.DefaultFactory.CreatePolygon(new NetTopologySuite.Geometries.Coordinate[]
         {
-            SpatialExtent = Geometry.DefaultFactory.CreatePolygon(new NetTopologySuite.Geometries.Coordinate[]
-            {
-                new (Coordinates[0].X, Coordinates[0].Y),
-                new (Coordinates[0].X, Coordinates[1].Y),
-                new (Coordinates[1].X, Coordinates[1].Y),
-                new (Coordinates[1].X, Coordinates[0].Y),
-                new (Coordinates[0].X, Coordinates[0].Y),
-            });
-        }
+            new (Coordinates[0].X, Coordinates[0].Y),
+            new (Coordinates[0].X, Coordinates[1].Y),
+            new (Coordinates[1].X, Coordinates[1].Y),
+            new (Coordinates[1].X, Coordinates[0].Y),
+            new (Coordinates[0].X, Coordinates[0].Y),
+        });
+        return true;
     }
 
     /// <summary>

--- a/tests/Geopilot.Api.Test/Controllers/MandateControllerTest.cs
+++ b/tests/Geopilot.Api.Test/Controllers/MandateControllerTest.cs
@@ -181,6 +181,21 @@ namespace Geopilot.Api.Controllers
         }
 
         [TestMethod]
+        public async Task CreateMandateRequiresSpatialExtent()
+        {
+            mandateController.SetupTestUser(adminUser);
+            var mandate = new Mandate()
+            {
+                FileTypes = new string[] { ".*" },
+                Name = "ACCORDIANWALK",
+                Organisations = new List<Organisation>() { new () { Id = 1 } },
+                Coordinates = new List<Models.Coordinate>(),
+            };
+            var result = await mandateController.Create(mandate);
+            ActionResultAssert.IsBadRequest(result);
+        }
+
+        [TestMethod]
         public async Task EditMandate()
         {
             mandateController.SetupTestUser(adminUser);
@@ -238,6 +253,22 @@ namespace Geopilot.Api.Controllers
             {
                 Assert.AreEqual(mandateToUpdate.Organisations[i].Id, updatedMandate.Organisations[i].Id);
             }
+        }
+
+        [TestMethod]
+        public async Task EditMandateRequiresSpatialExtent()
+        {
+            mandateController.SetupTestUser(adminUser);
+            var mandate = new Mandate()
+            {
+                Id = xtfMandate.Id,
+                FileTypes = new string[] { ".*", ".zip" },
+                Name = "PEARLFOLLOWER",
+                Organisations = new List<Organisation>() { new () { Id = 1 } },
+                Coordinates = new List<Models.Coordinate>(),
+            };
+            var result = await mandateController.Edit(mandate);
+            ActionResultAssert.IsBadRequest(result);
         }
 
         [TestCleanup]


### PR DESCRIPTION
Verhindert, dass #284 wieder auftritt. Den Extent (ganze Schweiz) beim Mandat auf app.geopilot.ch habe ich manuell hinzugefügt.

Resolves #284 