### PR TITLE
Fixup: Remove DTO PR

### DIFF
--- a/src/Geopilot.Api/Context.cs
+++ b/src/Geopilot.Api/Context.cs
@@ -89,6 +89,8 @@ public class Context : DbContext
                 .Include(m => m.Organisations)
                 .ThenInclude(o => o.Users)
                 .Include(m => m.Deliveries)
+                .ThenInclude(d => d.DeclaringUser)
+                .Include(m => m.Deliveries)
                 .ThenInclude(d => d.Assets);
         }
     }

--- a/src/Geopilot.Api/Context.cs
+++ b/src/Geopilot.Api/Context.cs
@@ -104,5 +104,8 @@ public class Context : DbContext
         ArgumentNullException.ThrowIfNull(modelBuilder);
 
         modelBuilder.Entity<Delivery>().HasQueryFilter(d => !d.Deleted);
+        modelBuilder.Entity<Asset>()
+            .HasQueryFilter(a => !a.Delivery.Deleted)
+            .HasQueryFilter(a => !a.Deleted);
     }
 }

--- a/src/Geopilot.Api/ContextExtensions.cs
+++ b/src/Geopilot.Api/ContextExtensions.cs
@@ -114,10 +114,12 @@ internal static class ContextExtensions
         var knownFileFormats = new string[] { ".xtf", ".gpkg", ".*", ".itf", ".xml", ".zip", ".csv" };
         var mandateFaker = new Faker<Mandate>()
             .UseDateTimeReference(referenceDateTime)
+            .StrictMode(true)
             .RuleFor(o => o.Id, f => 0)
             .RuleFor(o => o.Name, f => f.Commerce.ProductName())
             .RuleFor(o => o.FileTypes, f => f.PickRandom(knownFileFormats, 4).Distinct().ToArray())
             .RuleFor(o => o.SpatialExtent, f => GetExtent())
+            .Ignore(o => o.Coordinates)
             .RuleFor(o => o.Organisations, f => f.PickRandom(context.Organisations.ToList(), 1).ToList())
             .RuleFor(o => o.Deliveries, _ => new List<Delivery>());
 

--- a/src/Geopilot.Api/Models/Asset.cs
+++ b/src/Geopilot.Api/Models/Asset.cs
@@ -38,7 +38,7 @@ public class Asset
     /// <summary>
     /// Backreference to the delivery the asset belongs to.
     /// </summary>
-    public Delivery Delivery { get; set; } = new Delivery();
+    public Delivery Delivery { get; set; } = null!;
 
     /// <summary>
     /// The deletion status of the asset.

--- a/src/Geopilot.Api/Models/Asset.cs
+++ b/src/Geopilot.Api/Models/Asset.cs
@@ -38,7 +38,7 @@ public class Asset
     /// <summary>
     /// Backreference to the delivery the asset belongs to.
     /// </summary>
-    public Delivery? Delivery { get; set; } = new Delivery();
+    public Delivery Delivery { get; set; } = new Delivery();
 
     /// <summary>
     /// The deletion status of the asset.

--- a/src/Geopilot.Api/Models/Delivery.cs
+++ b/src/Geopilot.Api/Models/Delivery.cs
@@ -23,12 +23,12 @@ public class Delivery
     /// <summary>
     /// The user that declared the delivery.
     /// </summary>
-    public User DeclaringUser { get; set; } = new User();
+    public User DeclaringUser { get; set; } = null!;
 
     /// <summary>
     /// The mandate the delivery fulfills.
     /// </summary>
-    public Mandate Mandate { get; set; } = new Mandate();
+    public Mandate Mandate { get; set; } = null!;
 
     /// <summary>
     /// Assets delivered or created by the validation and delivery process.

--- a/src/Geopilot.Api/Models/Delivery.cs
+++ b/src/Geopilot.Api/Models/Delivery.cs
@@ -28,7 +28,7 @@ public class Delivery
     /// <summary>
     /// The mandate the delivery fulfills.
     /// </summary>
-    public Mandate? Mandate { get; set; } = new Mandate();
+    public Mandate Mandate { get; set; } = new Mandate();
 
     /// <summary>
     /// Assets delivered or created by the validation and delivery process.

--- a/src/Geopilot.Frontend/src/pages/admin/mandates.tsx
+++ b/src/Geopilot.Frontend/src/pages/admin/mandates.tsx
@@ -43,6 +43,7 @@ export const Mandates = () => {
   }, [fetchApi]);
 
   async function saveMandate(mandate: Mandate) {
+    mandate.deliveries = [];
     mandate.organisations = mandate.organisations?.map(value =>
       typeof value === "number"
         ? ({ id: value } as Organisation)

--- a/tests/Geopilot.Api.Test/Controllers/DeliveryControllerTest.cs
+++ b/tests/Geopilot.Api.Test/Controllers/DeliveryControllerTest.cs
@@ -165,7 +165,7 @@ public class DeliveryControllerTest
     public void Delete()
     {
         var guid = Guid.NewGuid();
-        var delivery = new Delivery { JobId = guid };
+        var delivery = new Delivery { JobId = guid, Mandate = context.Mandates.First(), DeclaringUser = context.Users.First() };
         delivery.Assets.Add(new Asset());
         context.Deliveries.Add(delivery);
         context.SaveChanges();
@@ -196,7 +196,7 @@ public class DeliveryControllerTest
     {
         assetHandlerMock.Setup(p => p.DownloadAssetAsync(It.IsAny<Guid>(), It.IsAny<string>())).ReturnsAsync((Encoding.UTF8.GetBytes("Test"), "text/xml"));
         var guid = Guid.NewGuid();
-        var delivery = new Delivery { JobId = guid };
+        var delivery = new Delivery { JobId = guid, Mandate = context.Mandates.First(), DeclaringUser = context.Users.First() };
         delivery.Assets.Add(new Asset() { OriginalFilename = "Test.xml", SanitizedFilename = "xyz.xml" });
         context.Deliveries.Add(delivery);
         context.SaveChanges();


### PR DESCRIPTION
#232 hat:

- Geopilot.Api Models angepasst, sodass diese nicht mehr zum EF Snapshot & DB Modell gepasst haben.
- StrictMode bei SeedMandates entfernt.

Aufgefallen bei der Umsetzung von [#343](https://github.com/GeoWerkstatt/geopilot/issues/343)
