### PR TITLE
Create basefolder for devcerts

### DIFF
--- a/src/Geopilot.Frontend/aspnetcore-https.js
+++ b/src/Geopilot.Frontend/aspnetcore-https.js
@@ -22,6 +22,7 @@ if (!certificateName) {
 const certFilePath = path.join(baseFolder, `${certificateName}.pem`);
 const keyFilePath = path.join(baseFolder, `${certificateName}.key`);
 
+fs.mkdirSync(baseFolder, { recursive: true });
 if (!fs.existsSync(certFilePath) || !fs.existsSync(keyFilePath)) {
   spawn("dotnet", ["dev-certs", "https", "--export-path", certFilePath, "--format", "Pem", "--no-password"], {
     stdio: "inherit",


### PR DESCRIPTION
Small hotfix that creates the basefolder for certificates if it doesn't exist already.