### PR TITLE
#289 Mandate filtering case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- File extensions of uploaded files are now checked case-insensitive.
+
 ## v2.0.180 - 2025-02-20
 
 ### Added

--- a/src/Geopilot.Api/Controllers/MandateController.cs
+++ b/src/Geopilot.Api/Controllers/MandateController.cs
@@ -65,9 +65,9 @@ public class MandateController : ControllerBase
             }
 
             logger.LogTrace("Filtering mandates for job with id <{JobId}>", jobId);
-            var extension = Path.GetExtension(job.OriginalFileName);
+            var extension = Path.GetExtension(job.OriginalFileName).ToLowerInvariant();
             mandates = mandates
-                .Where(m => m.FileTypes.Contains(".*") || m.FileTypes.Contains(extension));
+                .Where(m => m.FileTypes.Contains(".*") || m.FileTypes.Select(filetype => filetype.ToLowerInvariant()).Contains(extension));
         }
 
         var result = mandates.ToList();

--- a/tests/Geopilot.Api.Test/Controllers/MandateControllerTest.cs
+++ b/tests/Geopilot.Api.Test/Controllers/MandateControllerTest.cs
@@ -102,6 +102,25 @@ namespace Geopilot.Api.Controllers
         }
 
         [TestMethod]
+        public async Task GetWithJobIdIncludesMatchingMandatesIgnoresCase()
+        {
+            var jobId = Guid.NewGuid();
+            mandateController.SetupTestUser(editUser);
+            validationServiceMock
+                .Setup(m => m.GetJob(jobId))
+                .Returns(new ValidationJob(jobId, "Original.XTF", "tmp.XTF"));
+            xtfMandate.SetCoordinateListFromPolygon();
+
+            var result = (await mandateController.Get(jobId)) as OkObjectResult;
+            var mandates = (result?.Value as IEnumerable<Mandate>)?.ToList();
+
+            Assert.IsNotNull(mandates);
+            ContainsMandate(mandates, unrestrictedMandate);
+            ContainsMandate(mandates, xtfMandate);
+            DoesNotContainMandate(mandates, unassociatedMandate);
+        }
+
+        [TestMethod]
         public async Task GetWithJobIdExcludesNonMatchinMandates()
         {
             var jobId = Guid.NewGuid();


### PR DESCRIPTION
CLOSES: #289 

- Added new test in `MandateControllerTest` to specifically check for case insensitivity on file extensions
- Updated the filtering logic in `MandateController` to ignore cases of file extensions when selecting for valid mandates