### PR TITLE
Fix directory permissions for docker host users & groups

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,5 +21,7 @@
 **/obj
 **/secrets.dev.yaml
 **/values.dev.yaml
+src/Geopilot.Api/Uploads/*
+src/Geopilot.Api/Persistent/*
 LICENSE
 README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Localisation support for configurable markdown content (Impressum, Privacy Policy etc.), which allows to provide different versions for different languages.
 - Localisation support for application name.
+- Optional configuration via environmental variables of User and Group IDs for shared volume ownership.
 
 ### Changed
 
@@ -13,6 +14,7 @@
 
 ### Fixed
 
+- Fixed permission issues on shared volumes for docker host and admin group.
 - Sorting and filtering now works consistently across all admin tables.
 - File extensions of uploaded files are now checked case-insensitive.
 - Fixed an issue where autocomplete dropdown items would duplicate under certain conditions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Localisation support for configurable markdown content (Impressum, Privacy Policy etc.), which allows to provide different versions for different languages.
 - Localisation support for application name.
-- Optional configuration via environmental variables of User and Group IDs for shared volume ownership.
+- Added new optional `PUID` and `PGID` environment variables to avoid permissions issues between the host OS and the container when using shared directories.
 
 ### Changed
 
@@ -14,7 +14,7 @@
 
 ### Fixed
 
-- Fixed permission issues on shared volumes for docker host and admin group.
+- Fixed permission issues on shared volumes.
 - Sorting and filtering now works consistently across all admin tables.
 - File extensions of uploaded files are now checked case-insensitive.
 - Fixed an issue where autocomplete dropdown items would duplicate under certain conditions.

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,14 +17,6 @@ RUN apt-get update && \
   apt-get install nodejs -y && \
   rm -rf /var/lib/apt/lists/*
 
-# Install gosu, a tool to run commands as a specific user
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y gosu; \
-	rm -rf /var/lib/apt/lists/*; \
-# verify that the binary works
-	gosu nobody true
-
 # Restore dependencies and tools
 COPY src/Geopilot.Api/Geopilot.Api.csproj Geopilot.Api/
 COPY src/Geopilot.Frontend/nuget.config Geopilot.Frontend/
@@ -70,7 +62,7 @@ RUN \
   DEBIAN_FRONTEND=noninteractive && \
   mkdir -p /usr/share/man/man1 /usr/share/man/man2 && \
   apt-get update && \
-  apt-get install -y curl sudo vim htop && \
+  apt-get install -y curl sudo vim htop gosu && \
   rm -rf /var/lib/apt/lists/*
 
 # Create directories
@@ -88,7 +80,6 @@ ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 
 # Copy gosu binaries to the image
-COPY --from=build /usr/sbin/gosu /usr/local/bin
 COPY --from=build /app/publish $HOME
 COPY docker-entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,14 @@ RUN apt-get update && \
   apt-get install nodejs -y && \
   rm -rf /var/lib/apt/lists/*
 
+# Install gosu, a tool to run commands as a specific user
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y gosu; \
+	rm -rf /var/lib/apt/lists/*; \
+# verify that the binary works
+	gosu nobody true
+
 # Restore dependencies and tools
 COPY src/Geopilot.Api/Geopilot.Api.csproj Geopilot.Api/
 COPY src/Geopilot.Frontend/nuget.config Geopilot.Frontend/

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,8 @@ VOLUME $Storage__AssetsDirectory
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 
+# Copy gosu binaries to the image
+COPY --from=build /usr/sbin/gosu /usr/local/bin
 COPY --from=build /app/publish $HOME
 COPY docker-entrypoint.sh /entrypoint.sh
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,8 @@ services:
       Auth__TokenUrl: http://localhost:4011/realms/geopilot/protocol/openid-connect/token
       Auth__ApiOrigin: http://localhost:5173
       Validation__InterlisCheckServiceUrl: http://interlis-check-service:8080/
+      PUID: 1000
+      PGID: 1000
     volumes:
       - ./src/Geopilot.Api/Uploads:/uploads
       - ./src/Geopilot.Api/Persistent:/assets

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,6 +5,10 @@ set -e
 # will have the group write permission set. With the default 0022, groups that own these directories won't be able to edit them.
 umask 0002
 
+# Use default user:group if no $PUID and/or $PGID is provided.
+groupmod -o -g ${PGID:-1654} app && \
+  usermod -o -u ${PUID:-1654} app &> /dev/null
+
 # Change owner for our uploads folder
 echo -n "Fix permissions for mounted volumes ..." && \
   chown -R app:app $Storage__UploadDirectory && \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+# Sets the umask from the docker default 0022, to 0002. This has the effect that newly created files and directories
+# will have the group write permission set. With the default 0022, groups that own these directories won't be able to edit them.
+umask 0002
+
 # Change owner for our uploads folder
 echo -n "Fix permissions for mounted volumes ..." && \
   chown -R app:app $Storage__UploadDirectory && \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -31,4 +31,4 @@ timezone:                         $TZ
 "
 
 echo -e "geopilot app is up and running!\n" && \
-  sudo -H --preserve-env --user app dotnet Geopilot.Api.dll
+  gosu app dotnet Geopilot.Api.dll

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,6 +10,11 @@ echo -n "Fix permissions for mounted volumes ..." && \
   chown -R app:app $Storage__UploadDirectory && \
   chown -R app:app $Storage__AssetsDirectory && \
   chown -R app:app $PublicAssetsOverride && \
+
+  # Sets group permission and sticky bit at the end, which makes all children inherit group ownership
+  chmod -R g+rwXs $Storage__UploadDirectory && \
+  chmod -R g+rwXs $Storage__AssetsDirectory && \
+  chmod -R g+rwXs $PublicAssetsOverride && \
   echo "done!"
 
 # Override public assets in app's public directory.


### PR DESCRIPTION
## Resolves: #311 

- Fixed permission issues for the docker host user, who couldn't manipulate shared volumes and their contents with the container after the entrypoint script ran.
- Used the interlis-check-service pattern with PUID and GUID for this, thanks to the helpful support of @flenny.
- Added ability for multiple users of an authorized "admin group" to also manipulate these directories, by extending the previous code with additional commands that set the proper group ownership and permissions. This allows users of a whitelisted group (PGID) to have full control of these directories, opening up the possibilities for multiple admins per docker host.

### Remarks

- For group permissions to work correctly, i ran into a lot of issues. The problem is not the initial setup with entrypoint.sh, but files and directories that are created by the application during runtime. While the user permissions get "inherited", the group permissions for writing are not. This means users whose group owns the directory cannot change or edit files. Long story short, responsible for this is the `umask` setting, which defaults in docker to 0022. Changing it to 0002 resolves this issue, by allowing write permission of new directories and files to be set.
- Why `gosu`? It's a free open source tool primarily developed for docker workflows, which allows us to run commands as other users. Important here is, that gosu persists the same process when switching users, meaning we don't lose environmental variables, or more crucially, settings like `umask` which reset to the default 0022 when using something like sudo instead. I have attempted mutliple ways to not include gosu into this workflow: Tried moving most of the workflow to the `dockerfile`, tried using complex permission setting commands in the entrypoint, tried adjusting sudo config files within the docker container etc. Most didn't work or added an unreasonable amount of complexity, fragility and confusion. gosu seems to provide the most "pain free" solution to this specific problem, but i'm of course open to suggestions.

## Resolves: #409 

- Added the Uploads and Persistent contents to .dockerignore, so they don't get built into the container via docker compose.