### PR TITLE
Bug fixes

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Setup dev-certs
         uses: ./.github/actions/setup-dev-certs
 
+      - name: Debug external requests
+        run: |
+          set -x
+          curl -I https://downloads.interlis.ch/ilivalidator/ilivalidator-1.14.5.zip
+          # etc.
+
       - name: Start db and api's
         run: docker compose up --wait
 

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Debug external requests
         run: |
           set -x
-          curl -v https://downloads.interlis.ch/ilivalidator/ilivalidator-1.14.5.zip --output test
+          curl -v https://jars.interlis.ch/ch/interlis/ilivalidator/1.14.5/ilivalidator-1.14.5-bindist.zip --output test
           # etc.
 
       - name: Start db and api's

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -22,12 +22,6 @@ jobs:
       - name: Setup dev-certs
         uses: ./.github/actions/setup-dev-certs
 
-      - name: Debug external requests
-        run: |
-          set -x
-          curl -v https://jars.interlis.ch/ch/interlis/ilivalidator/1.14.5/ilivalidator-1.14.5-bindist.zip --output test
-          # etc.
-
       - name: Start db and api's
         run: docker compose up --wait
 

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Setup dev-certs
         uses: ./.github/actions/setup-dev-certs
 
+      - name: Debug external requests
+        run: |
+          set -x
+          curl -I -v https://downloads.interlis.ch/ilivalidator/ilivalidator-1.14.5.zip
+          # etc.
+
       - name: Start db and api's
         run: docker compose up --wait
 

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -22,12 +22,6 @@ jobs:
       - name: Setup dev-certs
         uses: ./.github/actions/setup-dev-certs
 
-      - name: Debug external requests
-        run: |
-          set -x
-          curl -I https://downloads.interlis.ch/ilivalidator/ilivalidator-1.14.5.zip
-          # etc.
-
       - name: Start db and api's
         run: docker compose up --wait
 

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Debug external requests
         run: |
           set -x
-          curl -I -v https://downloads.interlis.ch/ilivalidator/ilivalidator-1.14.5.zip
+          curl -v https://downloads.interlis.ch/ilivalidator/ilivalidator-1.14.5.zip --output test
           # etc.
 
       - name: Start db and api's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Sorting and filtering now works consistently across all admin tables.
 - File extensions of uploaded files are now checked case-insensitive.
 - Fixed an issue where autocomplete dropdown items would duplicate under certain conditions.
+- Stale ID tokens won't cause infinite API calls anymore.
 
 ## v2.0.180 - 2025-02-20
 

--- a/src/Geopilot.Frontend/src/api/apiContext.tsx
+++ b/src/Geopilot.Frontend/src/api/apiContext.tsx
@@ -56,7 +56,7 @@ export const ApiProvider: FC<PropsWithChildren> = ({ children }) => {
     }
   }
 
-  const fetchLocalizedMarkdown = async (markdown: string, language: string): Promise<string | undefined> => {
+  const fetchLocalizedMarkdown = async (markdown: string, language: string): Promise<string | null> => {
     try {
       if (!language) {
         throw new Error("Language undefined");
@@ -71,7 +71,7 @@ export const ApiProvider: FC<PropsWithChildren> = ({ children }) => {
         return await fetchApi<string>(`/${markdown}.md`, { responseType: ContentType.Markdown });
       } catch (fallbackError) {
         console.error("Failed to fetch markdown:", fallbackError);
-        return undefined;
+        return null;
       }
     }
   };

--- a/src/Geopilot.Frontend/src/api/apiContext.tsx
+++ b/src/Geopilot.Frontend/src/api/apiContext.tsx
@@ -56,7 +56,7 @@ export const ApiProvider: FC<PropsWithChildren> = ({ children }) => {
     }
   }
 
-  const fetchLocalizedMarkdown = async (markdown: string, language: string): Promise<string> => {
+  const fetchLocalizedMarkdown = async (markdown: string, language: string): Promise<string | undefined> => {
     try {
       if (!language) {
         throw new Error("Language undefined");
@@ -71,7 +71,7 @@ export const ApiProvider: FC<PropsWithChildren> = ({ children }) => {
         return await fetchApi<string>(`/${markdown}.md`, { responseType: ContentType.Markdown });
       } catch (fallbackError) {
         console.error("Failed to fetch markdown:", fallbackError);
-        return "";
+        return undefined;
       }
     }
   };

--- a/src/Geopilot.Frontend/src/api/apiContext.tsx
+++ b/src/Geopilot.Frontend/src/api/apiContext.tsx
@@ -56,16 +56,24 @@ export const ApiProvider: FC<PropsWithChildren> = ({ children }) => {
     }
   }
 
-  const fetchLocalizedMarkdown = (markdown: string, language: string): Promise<string> => {
-    return fetchApi<string>(`/${markdown}.${language}.md`, { responseType: ContentType.Markdown })
-      .then(response => {
-        if (response) {
-          return response;
-        } else {
-          throw new Error("Language-specific markdown not found");
-        }
-      })
-      .catch(() => fetchApi<string>(`/${markdown}.md`, { responseType: ContentType.Markdown }));
+  const fetchLocalizedMarkdown = async (markdown: string, language: string): Promise<string> => {
+    try {
+      if (!language) {
+        throw new Error("Language undefined");
+      }
+      const response = await fetchApi<string>(`/${markdown}.${language}.md`, { responseType: ContentType.Markdown });
+      if (response) {
+        return response;
+      }
+      throw new Error("Language-specific markdown not found");
+    } catch (error) {
+      try {
+        return await fetchApi<string>(`/${markdown}.md`, { responseType: ContentType.Markdown });
+      } catch (fallbackError) {
+        console.error("Failed to fetch markdown:", fallbackError);
+        return "";
+      }
+    }
   };
 
   return <ApiContext.Provider value={{ fetchApi, fetchLocalizedMarkdown }}>{children}</ApiContext.Provider>;

--- a/src/Geopilot.Frontend/src/api/apiInterfaces.ts
+++ b/src/Geopilot.Frontend/src/api/apiInterfaces.ts
@@ -22,7 +22,7 @@ export class ApiError extends Error {
 
 export interface ApiContextInterface {
   fetchApi: <T>(url: string, options?: Partial<FetchParams>) => Promise<T>;
-  fetchLocalizedMarkdown: (markdown: string, language: string) => Promise<string>;
+  fetchLocalizedMarkdown: (markdown: string, language: string) => Promise<string | undefined>;
 }
 
 export enum FieldEvaluationType {

--- a/src/Geopilot.Frontend/src/api/apiInterfaces.ts
+++ b/src/Geopilot.Frontend/src/api/apiInterfaces.ts
@@ -22,7 +22,7 @@ export class ApiError extends Error {
 
 export interface ApiContextInterface {
   fetchApi: <T>(url: string, options?: Partial<FetchParams>) => Promise<T>;
-  fetchLocalizedMarkdown: (markdown: string, language: string) => Promise<string | undefined>;
+  fetchLocalizedMarkdown: (markdown: string, language: string) => Promise<string | null>;
 }
 
 export enum FieldEvaluationType {

--- a/src/Geopilot.Frontend/src/auth/userContext.tsx
+++ b/src/Geopilot.Frontend/src/auth/userContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, FC, PropsWithChildren, useCallback, useEffect, useState } from "react";
-import { User } from "../api/apiInterfaces";
+import { ApiError, User } from "../api/apiInterfaces";
 import { useAuth } from "react-oidc-context";
 import { useApi } from "../api";
 
@@ -16,8 +16,15 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
         Authorization: `Bearer ${auth.user?.id_token}`,
       },
       errorMessageLabel: "userLoadingError",
-    }).then(setUser);
-  }, [auth?.user?.id_token, fetchApi]);
+    })
+      .then(setUser)
+      .catch(error => {
+        if (error instanceof ApiError && error.status === 401) {
+          auth.removeUser();
+          setUser(null);
+        }
+      });
+  }, [auth, fetchApi]);
 
   useEffect(() => {
     if (auth?.isAuthenticated) {

--- a/src/Geopilot.Frontend/src/auth/userContext.tsx
+++ b/src/Geopilot.Frontend/src/auth/userContext.tsx
@@ -10,7 +10,7 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
   const auth = useAuth();
   const { fetchApi } = useApi();
 
-  const fetchUserInfo = useCallback(async () => {
+  const fetchUserInfo = useCallback(() => {
     fetchApi<User>("/api/v1/user/self", {
       headers: {
         Authorization: `Bearer ${auth.user?.id_token}`,

--- a/src/Geopilot.Frontend/src/auth/userContext.tsx
+++ b/src/Geopilot.Frontend/src/auth/userContext.tsx
@@ -29,10 +29,10 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
   useEffect(() => {
     if (auth?.isAuthenticated) {
       fetchUserInfo();
-    } else if (!!auth && !auth?.isLoading) {
+    } else if (!auth?.isLoading) {
       setUser(null);
     }
-  }, [auth, auth?.isAuthenticated, auth?.isLoading, fetchUserInfo]);
+  }, [auth?.isAuthenticated, auth?.isLoading, fetchUserInfo]);
 
   return <UserContext.Provider value={user}>{children}</UserContext.Provider>;
 };

--- a/src/Geopilot.Frontend/src/auth/userContext.tsx
+++ b/src/Geopilot.Frontend/src/auth/userContext.tsx
@@ -29,10 +29,10 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
   useEffect(() => {
     if (auth?.isAuthenticated) {
       fetchUserInfo();
-    } else if (!auth?.isLoading) {
+    } else if (auth && !auth.isLoading) {
       setUser(null);
     }
-  }, [auth?.isAuthenticated, auth?.isLoading, fetchUserInfo]);
+  }, [auth, auth?.isAuthenticated, auth?.isLoading, fetchUserInfo]);
 
   return <UserContext.Provider value={user}>{children}</UserContext.Provider>;
 };

--- a/src/Geopilot.Frontend/src/components/appSettings/appSettingsContext.tsx
+++ b/src/Geopilot.Frontend/src/components/appSettings/appSettingsContext.tsx
@@ -21,9 +21,6 @@ export const AppSettingsProvider: FC<PropsWithChildren> = ({ children }) => {
       .then(setClientSettings)
       .catch(() => setClientSettings(null));
 
-    if (!i18n.language) {
-      return;
-    }
     fetchLocalizedMarkdown("terms-of-use", i18n.language).then(setTermsOfUse);
   }, [fetchApi, fetchLocalizedMarkdown, i18n.language]);
 

--- a/src/Geopilot.Frontend/src/components/appSettings/appSettingsContext.tsx
+++ b/src/Geopilot.Frontend/src/components/appSettings/appSettingsContext.tsx
@@ -13,8 +13,8 @@ export const AppSettingsContext = createContext<AppSettingsContextInterface>({
 export const AppSettingsProvider: FC<PropsWithChildren> = ({ children }) => {
   const { i18n } = useTranslation();
   const { fetchApi, fetchLocalizedMarkdown } = useApi();
-  const [clientSettings, setClientSettings] = useState<ClientSettings | null>();
-  const [termsOfUse, setTermsOfUse] = useState<string | undefined>();
+  const [clientSettings, setClientSettings] = useState<ClientSettings | null | undefined>(undefined);
+  const [termsOfUse, setTermsOfUse] = useState<string | null | undefined>(undefined);
 
   useEffect(() => {
     fetchApi<ClientSettings>("/client-settings.json", { responseType: ContentType.Json })

--- a/src/Geopilot.Frontend/src/components/appSettings/appSettingsContext.tsx
+++ b/src/Geopilot.Frontend/src/components/appSettings/appSettingsContext.tsx
@@ -21,6 +21,9 @@ export const AppSettingsProvider: FC<PropsWithChildren> = ({ children }) => {
       .then(setClientSettings)
       .catch(() => setClientSettings(null));
 
+    if (!i18n.language) {
+      return;
+    }
     fetchLocalizedMarkdown("terms-of-use", i18n.language).then(setTermsOfUse);
   }, [fetchApi, fetchLocalizedMarkdown, i18n.language]);
 

--- a/src/Geopilot.Frontend/src/components/appSettings/appSettingsContext.tsx
+++ b/src/Geopilot.Frontend/src/components/appSettings/appSettingsContext.tsx
@@ -14,7 +14,7 @@ export const AppSettingsProvider: FC<PropsWithChildren> = ({ children }) => {
   const { i18n } = useTranslation();
   const { fetchApi, fetchLocalizedMarkdown } = useApi();
   const [clientSettings, setClientSettings] = useState<ClientSettings | null>();
-  const [termsOfUse, setTermsOfUse] = useState<string | null>();
+  const [termsOfUse, setTermsOfUse] = useState<string | undefined>();
 
   useEffect(() => {
     fetchApi<ClientSettings>("/client-settings.json", { responseType: ContentType.Json })

--- a/src/Geopilot.Frontend/src/pages/footer/about.tsx
+++ b/src/Geopilot.Frontend/src/pages/footer/about.tsx
@@ -10,7 +10,7 @@ import { useAppSettings } from "../../components/appSettings/appSettingsInterfac
 
 export const About = () => {
   const { t, i18n } = useTranslation();
-  const [info, setInfo] = useState<string>();
+  const [info, setInfo] = useState<string | undefined>();
   const [version, setVersion] = useState<string | null>();
   const { termsOfUse } = useAppSettings();
   const { fetchApi, fetchLocalizedMarkdown } = useApi();

--- a/src/Geopilot.Frontend/src/pages/footer/about.tsx
+++ b/src/Geopilot.Frontend/src/pages/footer/about.tsx
@@ -10,7 +10,7 @@ import { useAppSettings } from "../../components/appSettings/appSettingsInterfac
 
 export const About = () => {
   const { t, i18n } = useTranslation();
-  const [info, setInfo] = useState<string | undefined>();
+  const [info, setInfo] = useState<string | null>();
   const [version, setVersion] = useState<string | null>();
   const { termsOfUse } = useAppSettings();
   const { fetchApi, fetchLocalizedMarkdown } = useApi();

--- a/src/Geopilot.Frontend/src/pages/footer/imprint.tsx
+++ b/src/Geopilot.Frontend/src/pages/footer/imprint.tsx
@@ -7,7 +7,7 @@ import { CenteredBox } from "../../components/styledComponents.ts";
 
 export const Imprint = () => {
   const { t, i18n } = useTranslation();
-  const [content, setContent] = useState<string | undefined>();
+  const [content, setContent] = useState<string | null>();
   const { fetchLocalizedMarkdown } = useApi();
 
   useEffect(() => {

--- a/src/Geopilot.Frontend/src/pages/footer/imprint.tsx
+++ b/src/Geopilot.Frontend/src/pages/footer/imprint.tsx
@@ -7,7 +7,7 @@ import { CenteredBox } from "../../components/styledComponents.ts";
 
 export const Imprint = () => {
   const { t, i18n } = useTranslation();
-  const [content, setContent] = useState<string>();
+  const [content, setContent] = useState<string | undefined>();
   const { fetchLocalizedMarkdown } = useApi();
 
   useEffect(() => {

--- a/src/Geopilot.Frontend/src/pages/footer/privacyPolicy.tsx
+++ b/src/Geopilot.Frontend/src/pages/footer/privacyPolicy.tsx
@@ -7,7 +7,7 @@ import { CenteredBox } from "../../components/styledComponents.ts";
 
 export const PrivacyPolicy = () => {
   const { t, i18n } = useTranslation();
-  const [content, setContent] = useState<string>();
+  const [content, setContent] = useState<string | undefined>();
   const { fetchLocalizedMarkdown } = useApi();
 
   useEffect(() => {

--- a/src/Geopilot.Frontend/src/pages/footer/privacyPolicy.tsx
+++ b/src/Geopilot.Frontend/src/pages/footer/privacyPolicy.tsx
@@ -7,7 +7,7 @@ import { CenteredBox } from "../../components/styledComponents.ts";
 
 export const PrivacyPolicy = () => {
   const { t, i18n } = useTranslation();
-  const [content, setContent] = useState<string | undefined>();
+  const [content, setContent] = useState<string | null>();
   const { fetchLocalizedMarkdown } = useApi();
 
   useEffect(() => {


### PR DESCRIPTION
- Fixed an issue where a stale id_token causes the api to be called on a loop indefinitely. This happens when the client thinks their token is still valid, while the backend rejects it. To reproduce the issue:
```
1. Launch geopilot either as docker compose or through VS and successfully log in through our ID-Provider.
2. Shut down all docker containers and terminals running geopilot (do not close the Browser running the frontend however)
3. Relaunch geopilot again.
```
- Refactored markdown fetch helper method `fetchLocalizedMarkdown` to handle undefined language parameter. Otherwise the console is full of ugly 404 trying to fetch markdowns with undefined in their name, which is a waste of API resources.