### PR TITLE
Duplicate Key Error Fix

### DIFF
--- a/src/Geopilot.Api/StacServices/StacConverter.cs
+++ b/src/Geopilot.Api/StacServices/StacConverter.cs
@@ -124,7 +124,7 @@ public class StacConverter
         }
 
         var stacApiContext = StacApiContextFactory.Create();
-        var assets = delivery.Assets.Select(file => ToStacAsset(file, item, stacApiContext.BaseUri)).ToDictionary(asset => asset.Title);
+        var assets = delivery.Assets.Select(file => ToStacAsset(file, item, stacApiContext.BaseUri)).ToDictionary(asset => Guid.NewGuid().ToString());
         item.Assets.AddRange(assets);
         StacLinker.Link(item, stacApiContext);
 

--- a/tests/Geopilot.Api.Test/StacServices/StacConverterTest.cs
+++ b/tests/Geopilot.Api.Test/StacServices/StacConverterTest.cs
@@ -155,7 +155,8 @@ public class StacConverterTest
         Assert.AreNotEqual(0, item.Links.Count);
 
         Assert.AreEqual(2, item.Assets.Count);
-        var stacAsset = item.Assets[testDelivery.Assets[0].OriginalFilename];
+        var stacAsset = item.Assets.Values.FirstOrDefault(a => a.Title == testDelivery.Assets[0].OriginalFilename);
+        Assert.IsNotNull(stacAsset, "Asset with title matching original filename not found");
         Assert.AreEqual(item, stacAsset.ParentStacObject);
         Assert.AreEqual("TestFile.xtf", stacAsset.Title);
         Assert.AreEqual("PrimaryData", stacAsset.Roles.First());


### PR DESCRIPTION
## Resolves: #357 

- Per [STAC API specs](https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md#assets), the dictionary (or map) key for each entry in `assets` in a given `STAC Item` needs to be unique, but it is not specified that it has to be the filename of the asset or related to it in any way. I updated the keys to be UUIDs now, which will ensure uniqueness no matter how many assets we have or if they have duplicate filenames.