### PR TITLE
Remember Me in Login

### DIFF
--- a/config/realms/keycloak-geopilot.json
+++ b/config/realms/keycloak-geopilot.json
@@ -2,6 +2,7 @@
   "id": "7c2a35a2-08b5-4a64-9883-f9ac20197f7d",
   "realm": "geopilot",
   "enabled": true,
+  "rememberMe": true,
   "clients": [
     {
       "id": "cec9ffa8-92fd-4a73-ac8b-ed4407dd83e0",


### PR DESCRIPTION
## Resolves: #261 

- Can set check on "Remember me" to automatically log in when the token expires. This is for our local ID Provider (keycloak)

### Remarks

- `Remember me` does not persist when completely removing the docker container. Not a bug, a feature! If we want to test logins with different users, we can just remove the container and start it up again.
- If we want "Remember me" to persist, we'd have to mount a shared volume where the data persists on the host machine. If that sounds interesting i can gladly expand that functionality. We'd have to create some extra folders that we add to .gitignore and stuff. It seems too much hassle for an already not too crucial feature imho.