### PR TITLE
ZITADEL Related Changes with User Identification

### DIFF
--- a/config/realms/keycloak-geopilot.json
+++ b/config/realms/keycloak-geopilot.json
@@ -59,7 +59,7 @@
       ]
     },
     {
-      "id": "1ed45832-2880-4fd4-a274-bbcc101c3307",
+      "id": "1ed45832-2880-4fd4-a274-bbcc101c3308",
       "username": "uploader",
       "enabled": true,
       "emailVerified": true,

--- a/config/realms/keycloak-geopilot.json
+++ b/config/realms/keycloak-geopilot.json
@@ -59,13 +59,13 @@
       ]
     },
     {
-      "id": "1ed45832-2880-4fd4-a274-bbcc101c3308",
+      "id": "1ed45832-2880-4fd4-a274-bbcc101c33087",
       "username": "uploader",
       "enabled": true,
       "emailVerified": true,
-      "email": "uploader@geopilot.ch",
+      "email": "user@geopilot.ch",
       "firstName": "Ursula",
-      "lastName": "Uploader",
+      "lastName": "User",
       "credentials": [
         {
           "type": "password",

--- a/src/Geopilot.Api/Authorization/GeopilotUserHandler.cs
+++ b/src/Geopilot.Api/Authorization/GeopilotUserHandler.cs
@@ -58,7 +58,7 @@ public class GeopilotUserHandler : AuthorizationHandler<GeopilotUserRequirement>
             return null;
         }
 
-        var user = await dbContext.Users.FirstOrDefaultAsync(u => u.AuthIdentifier == sub);
+        var user = await dbContext.Users.FirstOrDefaultAsync(u => u.Email == email);
         if (user == null)
         {
             user = new User { AuthIdentifier = sub, Email = email, FullName = name };
@@ -72,10 +72,10 @@ public class GeopilotUserHandler : AuthorizationHandler<GeopilotUserRequirement>
             await dbContext.Users.AddAsync(user);
             logger.LogInformation("New user (with sub <{Sub}>) has been registered in database.", sub);
         }
-        else if (user.Email != email || user.FullName != name)
+        else if (user.AuthIdentifier != sub || user.FullName != name)
         {
             // Update user information in database from provided principal
-            user.Email = email;
+            user.AuthIdentifier = sub;
             user.FullName = name;
         }
 


### PR DESCRIPTION
## Changes

- Users are now identified first and foremost by their email address in our Backend. The reason for this, is that switching Auth-Providers causes users that are already registered with us to create duplicate accounts, because the internal "sub" ID is different. The new code checks if the email exists already, however, and then updates the AuthIdentifier and/or Name instead. This change should work with every Auth Provider, and should not lead to breaking changes. If there was on oversight on my part, i'm happy to rethink this approach.

- Since our tests relied on mapping our keycloak user to our db-user via "sub", this caused the tests to fail or had unexpected behaviours. I switched the data to match the users Email to the Email in the DB. Now the emails match and the tests pass.