### PR TITLE
Fix for language settings not persisting when opening a new tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed bug where language preference is reset in certain circumstances.
+
 ## v2.0.203 - 2025-05-01
 
 ### Added

--- a/src/Geopilot.Frontend/src/i18n.js
+++ b/src/Geopilot.Frontend/src/i18n.js
@@ -9,7 +9,7 @@ i18n
   .use(LanguageDetector)
   .init({
     detection: {
-      order: ["navigator", "cookie", "htmlTag"],
+      order: ["cookie", "navigator", "htmlTag"],
       lookupCookie: "i18next",
       caches: ["cookie"],
     },


### PR DESCRIPTION
## Resolves #432 

### Changes

- Switched the lookup priority of i18n's language detector. Before, it used to first check the browsers preferred language, then the cookies, and lastly html tags. If a new tab was opened, i18n would reinitialize and overwrite the cookie with the browsers preferred language. Now, the cookie is the first thing it checks, before falling back to the browser and html tags respectively.