### PR TITLE
Add nuget component detection

### DIFF
--- a/.github/workflows/component-detection.yml
+++ b/.github/workflows/component-detection.yml
@@ -25,7 +25,7 @@ jobs:
           dotnet-version: '10.0'
 
       - name: Install dependencies
-        run: dotnet restore
+        run: dotnet restore Geopilot.slnx
 
       - name: NuGet component detection
         uses: advanced-security/component-detection-dependency-submission-action@v0.1.0


### PR DESCRIPTION
Seit #485 wird die [Automatic Dependency Submission](https://github.com/geowerkstatt/geopilot/actions/workflows/dependency-graph/auto-submission) nicht mehr ausgeführt (wird benötigt für nuget Packages bei Dependabot). Ich vermute, dass das neue slnx-Format nicht richtig erkannt wird, deshalb habe ich hier einen expliziten Workflow erstellt.