### PR TITLE
Fix pipeline validation on startup

### DIFF
--- a/src/Geopilot.Api/Pipeline/PipelineValidationErrors.cs
+++ b/src/Geopilot.Api/Pipeline/PipelineValidationErrors.cs
@@ -13,7 +13,7 @@ internal class PipelineValidationErrors : List<PipelineValidationError>
 
     internal bool HasErrors => this.Count > 0;
 
-    internal string ErrorMessage => string.Join(", ", this.Select(e => $"{e.SourceObject.Name}: {e.Message}"));
+    internal string ErrorMessage => string.Join(Environment.NewLine, this.Select(e => $"{e.SourceObject.Name}: {e.Message}"));
 
     public override string ToString()
     {

--- a/src/Geopilot.Api/Program.cs
+++ b/src/Geopilot.Api/Program.cs
@@ -159,7 +159,7 @@ builder.Services.AddTransient<IFileProvider, PhysicalFileProvider>();
 builder.Services.AddTransient<IAssetHandler, AssetHandler>();
 builder.Services.AddHostedService<ValidationRunner>();
 builder.Services.AddHostedService<ValidationJobCleanupService>();
-builder.Services.RegisterPipelineFactory();
+builder.Services.AddPipelineFactory();
 
 builder.Services
     .AddHttpClient<IValidator, InterlisValidator>("INTERLIS_VALIDATOR_HTTP_CLIENT")
@@ -211,6 +211,9 @@ if (context.Database.GetPendingMigrations().Any())
 {
     context.MigrateDatabase();
 }
+
+// Validate pipeline configuration on startup and crash if configuration is invalid
+app.ValidatePipelineConfiguration();
 
 app.UseSwagger();
 app.UseSwaggerUI(options =>

--- a/src/Geopilot.Api/WebApplicationExtensions.cs
+++ b/src/Geopilot.Api/WebApplicationExtensions.cs
@@ -1,0 +1,31 @@
+﻿using Geopilot.Api.Pipeline;
+using Microsoft.EntityFrameworkCore;
+
+namespace Geopilot.Api;
+
+/// <summary>
+/// Provides extension methods for configuring the WebApplication during startup.
+/// </summary>
+public static class WebApplicationExtensions
+{
+    /// <summary>
+    /// Validates the pipeline configuration on startup and throws if invalid.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when pipeline configuration is invalid.</exception>
+    public static void ValidatePipelineConfiguration(this WebApplication app)
+    {
+        ArgumentNullException.ThrowIfNull(app, nameof(app));
+
+        var pipelineFactory = app.Services.GetRequiredService<IPipelineFactory>() as PipelineFactory;
+        if (pipelineFactory == null)
+        {
+            throw new InvalidOperationException("PipelineFactory is not registered correctly.");
+        }
+
+        var validationErrors = pipelineFactory.PipelineProcessConfig.Validate();
+        if (validationErrors.HasErrors)
+        {
+            throw new InvalidOperationException($"errors in pipeline definition:{Environment.NewLine}{validationErrors.ErrorMessage}");
+        }
+    }
+}

--- a/tests/Geopilot.Api.Test/Pipeline/PipelineValidationTest.cs
+++ b/tests/Geopilot.Api.Test/Pipeline/PipelineValidationTest.cs
@@ -9,40 +9,40 @@ namespace Geopilot.Api.Test.Pipeline;
 public class PipelineValidationTest
 {
     [TestMethod(DisplayName = "Pipeline Validation")]
-    [DataRow("noProcesses", "PipelineProcessConfig: The Processes field is required., StepConfig: process reference for 'xtf_validator'", DisplayName = "No Processes")]
-    [DataRow("noPipelines", "PipelineProcessConfig: The Pipelines field is required.", DisplayName = "No Pipelines")]
-    [DataRow("noStepProcess", "StepConfig: The ProcessId field is required., StepConfig: process reference for ''", DisplayName = "No Process in Step defined")]
-    [DataRow("noStepId", "StepConfig: The Id field is required.", DisplayName = "Step has no Id")]
-    [DataRow("noStepOutput", "StepConfig: The Output field is required.", DisplayName = "Step has no output defined")]
-    [DataRow("noStepInputConfigFrom", "InputConfig: The From field is required., InputConfig: illegal input from reference from: '', take: 'ili_file' in step 'validation'", DisplayName = "Step has no input config 'from'")]
-    [DataRow("noStepInputConfigTake", "InputConfig: The Take field is required., InputConfig: illegal input from reference from: 'upload', take: '' in step 'validation'", DisplayName = "Step has no input config 'take'")]
-    [DataRow("noStepInputConfigAs", "InputConfig: The As field is required.", DisplayName = "Step has no input config 'as'")]
-    [DataRow("noStepOutputConfigTake", "OutputConfig: The Take field is required.", DisplayName = "Step has no output config 'take'")]
-    [DataRow("noStepOutputConfigAs", "OutputConfig: The As field is required.", DisplayName = "Step has no output config 'as'")]
-    [DataRow("noProcessId", "ProcessConfig: The Id field is required., StepConfig: process reference for 'xtf_validator'", DisplayName = "Process has no Id")]
-    [DataRow("noProcessImplementation", "ProcessConfig: The Implementation field is required.", DisplayName = "Process has no Implementation")]
-    [DataRow("noPipelineId", "PipelineConfig: The Id field is required.", DisplayName = "Pipeline has no Id")]
-    [DataRow("noPipelineParameters", "PipelineConfig: The Parameters field is required., InputConfig: illegal input from reference from: 'upload', take: 'ili_file' in step 'validation'", DisplayName = "Pipeline has no Parameters")]
-    [DataRow("noPipelineSteps", "PipelineConfig: The Steps field is required.", DisplayName = "Pipeline has no Steps")]
-    [DataRow("noPipelineUploadStep", "PipelineParametersConfig: The UploadStep field is required., InputConfig: illegal input from reference from: 'upload', take: 'ili_file' in step 'validation'", DisplayName = "Pipeline has no Upload Step")]
-    [DataRow("noPipelineFileMapping", "PipelineParametersConfig: The Mappings field is required., InputConfig: illegal input from reference from: 'upload', take: 'ili_file' in step 'validation'", DisplayName = "Pipeline has no File Mapping")]
-    [DataRow("noPipelineFileMappingExtension", "FileMappingsConfig: The FileExtension field is required.", DisplayName = "Pipeline has no File Mapping Extension")]
-    [DataRow("noPipelineFileMappingAttribute", "FileMappingsConfig: The Attribute field is required., InputConfig: illegal input from reference from: 'upload', take: 'ili_file' in step 'validation'", DisplayName = "Pipeline has no File Mapping Attribute")]
-    [DataRow("stepWithInvalidProcessReference", "StepConfig: process reference for 'invalid_reference'", DisplayName = "Step has invalid process reference")]
-    [DataRow("unknownProcessImplementation", "ProcessConfig: unknown implementation 'this.is.unknown.ProcessorClass' for process 'xtf_validator'", DisplayName = "Process has unknown implementation")]
-    [DataRow("pipelineNotUnique", "PipelineProcessConfig: duplicate pipeline ids found: ili_validation", DisplayName = "Pipeline has duplicate ids")]
-    [DataRow("processNotUnique", "PipelineProcessConfig: duplicate process ids found: xtf_validator", DisplayName = "Process has duplicate ids")]
-    [DataRow("stepNotUnique", "PipelineProcessConfig: duplicate step ids found: not_unique", DisplayName = "Step has duplicate ids")]
-    [DataRow("invalidStepInputFromReference_01", "InputConfig: illegal input from reference from: 'zip', take: 'zip_package' in step 'validation'", DisplayName = "Step has invalid input 'from' reference (invalid process reference)")]
-    [DataRow("invalidStepInputFromReference_02", "InputConfig: illegal input from reference from: 'invalidUploadStep', take: 'ili_file' in step 'validation'", DisplayName = "Step has invalid input 'from' reference (invalid upload reference)")]
-    [DataRow("notUniqueOutputAs", "OutputConfig: not unique output as: 'error' in step 'validation'", DisplayName = "Step has not unique output 'as' reference")]
-    [DataRow("invalidFileExtension", "FileMappingsConfig: invalid file extension '.xtf' in step 'ili_validation'", DisplayName = "Step has invalid file extension")]
-    public void PipelineValidation(string pipelineFile, string expectedErrorMessage)
+    [DataRow("noProcesses", new string[] { "PipelineProcessConfig: The Processes field is required.", "StepConfig: process reference for 'xtf_validator'" }, DisplayName = "No Processes")]
+    [DataRow("noPipelines", new string[] { "PipelineProcessConfig: The Pipelines field is required." }, DisplayName = "No Pipelines")]
+    [DataRow("noStepProcess", new string[] { "StepConfig: The ProcessId field is required.", "StepConfig: process reference for ''" }, DisplayName = "No Process in Step defined")]
+    [DataRow("noStepId", new string[] { "StepConfig: The Id field is required." }, DisplayName = "Step has no Id")]
+    [DataRow("noStepOutput", new string[] { "StepConfig: The Output field is required." }, DisplayName = "Step has no output defined")]
+    [DataRow("noStepInputConfigFrom", new string[] { "InputConfig: The From field is required.", "InputConfig: illegal input from reference from: '', take: 'ili_file' in step 'validation'" }, DisplayName = "Step has no input config 'from'")]
+    [DataRow("noStepInputConfigTake", new string[] { "InputConfig: The Take field is required.", "InputConfig: illegal input from reference from: 'upload', take: '' in step 'validation'" }, DisplayName = "Step has no input config 'take'")]
+    [DataRow("noStepInputConfigAs", new string[] { "InputConfig: The As field is required." }, DisplayName = "Step has no input config 'as'")]
+    [DataRow("noStepOutputConfigTake", new string[] { "OutputConfig: The Take field is required." }, DisplayName = "Step has no output config 'take'")]
+    [DataRow("noStepOutputConfigAs", new string[] { "OutputConfig: The As field is required." }, DisplayName = "Step has no output config 'as'")]
+    [DataRow("noProcessId", new string[] { "ProcessConfig: The Id field is required.", "StepConfig: process reference for 'xtf_validator'" }, DisplayName = "Process has no Id")]
+    [DataRow("noProcessImplementation", new string[] { "ProcessConfig: The Implementation field is required." }, DisplayName = "Process has no Implementation")]
+    [DataRow("noPipelineId", new string[] { "PipelineConfig: The Id field is required." }, DisplayName = "Pipeline has no Id")]
+    [DataRow("noPipelineParameters", new string[] { "PipelineConfig: The Parameters field is required.", "InputConfig: illegal input from reference from: 'upload', take: 'ili_file' in step 'validation'" }, DisplayName = "Pipeline has no Parameters")]
+    [DataRow("noPipelineSteps", new string[] { "PipelineConfig: The Steps field is required." }, DisplayName = "Pipeline has no Steps")]
+    [DataRow("noPipelineUploadStep", new string[] { "PipelineParametersConfig: The UploadStep field is required.", "InputConfig: illegal input from reference from: 'upload', take: 'ili_file' in step 'validation'" }, DisplayName = "Pipeline has no Upload Step")]
+    [DataRow("noPipelineFileMapping", new string[] { "PipelineParametersConfig: The Mappings field is required.", "InputConfig: illegal input from reference from: 'upload', take: 'ili_file' in step 'validation'" }, DisplayName = "Pipeline has no File Mapping")]
+    [DataRow("noPipelineFileMappingExtension", new string[] { "FileMappingsConfig: The FileExtension field is required." }, DisplayName = "Pipeline has no File Mapping Extension")]
+    [DataRow("noPipelineFileMappingAttribute", new string[] { "FileMappingsConfig: The Attribute field is required.", "InputConfig: illegal input from reference from: 'upload', take: 'ili_file' in step 'validation'" }, DisplayName = "Pipeline has no File Mapping Attribute")]
+    [DataRow("stepWithInvalidProcessReference", new string[] { "StepConfig: process reference for 'invalid_reference'" }, DisplayName = "Step has invalid process reference")]
+    [DataRow("unknownProcessImplementation", new string[] { "ProcessConfig: unknown implementation 'this.is.unknown.ProcessorClass' for process 'xtf_validator'" }, DisplayName = "Process has unknown implementation")]
+    [DataRow("pipelineNotUnique", new string[] { "PipelineProcessConfig: duplicate pipeline ids found: ili_validation" }, DisplayName = "Pipeline has duplicate ids")]
+    [DataRow("processNotUnique", new string[] { "PipelineProcessConfig: duplicate process ids found: xtf_validator" }, DisplayName = "Process has duplicate ids")]
+    [DataRow("stepNotUnique", new string[] { "PipelineProcessConfig: duplicate step ids found: not_unique" }, DisplayName = "Step has duplicate ids")]
+    [DataRow("invalidStepInputFromReference_01", new string[] { "InputConfig: illegal input from reference from: 'zip', take: 'zip_package' in step 'validation'" }, DisplayName = "Step has invalid input 'from' reference (invalid process reference)")]
+    [DataRow("invalidStepInputFromReference_02", new string[] { "InputConfig: illegal input from reference from: 'invalidUploadStep', take: 'ili_file' in step 'validation'" }, DisplayName = "Step has invalid input 'from' reference (invalid upload reference)")]
+    [DataRow("notUniqueOutputAs", new string[] { "OutputConfig: not unique output as: 'error' in step 'validation'" }, DisplayName = "Step has not unique output 'as' reference")]
+    [DataRow("invalidFileExtension", new string[] { "FileMappingsConfig: invalid file extension '.xtf' in step 'ili_validation'" }, DisplayName = "Step has invalid file extension")]
+    public void PipelineValidation(string pipelineFile, string[] expectedErrorMessages)
     {
         PipelineFactory factory = CreatePipelineFactory(pipelineFile);
         var validationErrors = factory.PipelineProcessConfig.Validate();
         Assert.IsTrue(validationErrors.HasErrors, "expected validation errors but none found");
-        Assert.AreEqual(expectedErrorMessage, validationErrors.ErrorMessage);
+        Assert.AreEqual(string.Join(Environment.NewLine, expectedErrorMessages), validationErrors.ErrorMessage);
     }
 
     private PipelineFactory CreatePipelineFactory(string filename)


### PR DESCRIPTION
- makes sure the pipeline definiton is validated on startup and crashes the app if its invalid
- improves the error messages in case the definition is invalid

Issue-ID: #551