### PR TITLE
chore: rename frontend variable for more clearity

### DIFF
--- a/src/Geopilot.Frontend/src/auth/authInterfaces.ts
+++ b/src/Geopilot.Frontend/src/auth/authInterfaces.ts
@@ -1,7 +1,7 @@
 import { User } from "../api/apiInterfaces.ts";
 
 export interface GeopilotAuthContextInterface {
-  authEnabled: boolean;
+  authLoaded: boolean;
   isLoading: boolean;
   user: User | null | undefined;
   isAdmin: boolean;

--- a/src/Geopilot.Frontend/src/auth/geopilotAuthComponent.tsx
+++ b/src/Geopilot.Frontend/src/auth/geopilotAuthComponent.tsx
@@ -8,7 +8,7 @@ import { useAuth } from "react-oidc-context";
 import { CookieSynchronizer } from "./cookieSynchronizer";
 
 export const GeopilotAuthContext = createContext<GeopilotAuthContextInterface>({
-  authEnabled: false,
+  authLoaded: false,
   isLoading: false,
   user: undefined,
   isAdmin: false,
@@ -38,8 +38,8 @@ const GeopilotAuthContextMerger: FC<PropsWithChildren> = ({ children }) => {
   const user = useUser();
   const apiSetting = useApiAuthConfiguration();
 
-  const authEnabled = !!(apiSetting && apiSetting.clientAudience && apiSetting.authority);
-  const isLoading = !((!!apiSetting && !authEnabled) || user !== undefined);
+  const authLoaded = !!(apiSetting && apiSetting.clientAudience && apiSetting.authority);
+  const isLoading = !((!!apiSetting && !authLoaded) || user !== undefined);
 
   const getLoginFunction = () => {
     if (!auth) return () => {};
@@ -53,7 +53,7 @@ const GeopilotAuthContextMerger: FC<PropsWithChildren> = ({ children }) => {
   return (
     <GeopilotAuthContext.Provider
       value={{
-        authEnabled: authEnabled,
+        authLoaded: authLoaded,
         isLoading: isLoading,
         user: user,
         isAdmin: !!user?.isAdmin,

--- a/src/Geopilot.Frontend/src/components/header/header.tsx
+++ b/src/Geopilot.Frontend/src/components/header/header.tsx
@@ -36,7 +36,7 @@ const Header: FC<HeaderProps> = ({ openSubMenu }) => {
   const { navigateTo } = useControlledNavigate();
   const location = useLocation();
   const { clientSettings } = useAppSettings();
-  const { user, authEnabled, isAdmin, login, logout } = useGeopilotAuth();
+  const { user, authLoaded, isAdmin, login, logout } = useGeopilotAuth();
 
   const [userMenuOpen, setUserMenuOpen] = useState<boolean>(false);
 
@@ -124,7 +124,7 @@ const Header: FC<HeaderProps> = ({ openSubMenu }) => {
           </FlexRowBox>
           <FlexRowBox sx={{ flexWrap: "nowrap" }}>
             <LanguagePopup />
-            {authEnabled &&
+            {authLoaded &&
               (user ? (
                 <IconButton
                   sx={{


### PR DESCRIPTION
rename 'authEnabled' to 'authLoaded'

we do not enable the authorization but wait until it is loded

Issue-Id: #546