### PR TITLE
Refactor pipeline error handling

### DIFF
--- a/src/Geopilot.Api/Pipeline/IPipeline.cs
+++ b/src/Geopilot.Api/Pipeline/IPipeline.cs
@@ -37,5 +37,7 @@ public interface IPipeline : IDisposable
     /// </summary>
     /// <param name="cancellationToken">Cancellation token to cancel the pipeline run.</param>
     /// <returns>The context containing the results of the pipeline execution.</returns>
+    /// <exception cref="PipelineRunException">The pipeline run failed due to a misconfigured pipeline or an misbehaving process.</exception>
+    /// <exception cref="OperationCanceledException">The pipeline run was cancelled.</exception>
     Task<PipelineContext> Run(CancellationToken cancellationToken);
 }

--- a/src/Geopilot.Api/Pipeline/PipelineRunException.cs
+++ b/src/Geopilot.Api/Pipeline/PipelineRunException.cs
@@ -1,0 +1,37 @@
+﻿namespace Geopilot.Api.Pipeline;
+
+/// <summary>
+/// The exception that is thrown when a pipeline run failed due to a misconfigured pipeline or an misbehaving process.
+/// </summary>
+[Serializable]
+public class PipelineRunException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PipelineRunException"/> class.
+    /// </summary>
+    public PipelineRunException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PipelineRunException"/> class
+    /// with a specified error <paramref name="message"/>.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public PipelineRunException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PipelineRunException"/> class
+    /// with a specified error <paramref name="message"/> and a reference to the
+    /// <paramref name="innerException"/> that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public PipelineRunException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/Geopilot.Api/Pipeline/PipelineStep.cs
+++ b/src/Geopilot.Api/Pipeline/PipelineStep.cs
@@ -67,50 +67,44 @@ public sealed class PipelineStep : IPipelineStep
     /// <inheritdoc/>
     public async Task<StepResult> Run(PipelineContext context, CancellationToken cancellationToken)
     {
-        if (context != null)
+        try
         {
+            ArgumentNullException.ThrowIfNull(context, nameof(context));
+
             this.State = StepState.Running;
+
+            var runMethod = GetProcessRunMethod();
+            var runParams = CreateProcessRunParamList(context, runMethod.GetParameters().ToList(), cancellationToken).ToArray();
+
+            var resultTask = runMethod.Invoke(Process, runParams) as Task<Dictionary<string, object>>;
+
+            if (resultTask == null)
+            {
+                throw new PipelineRunException($"The process <{Process.GetType().Name}> did not return a task.");
+            }
 
             try
             {
-                var runMethod = GetProcessRunMethod();
-
-                if (runMethod != null)
-                {
-                    var runParams = CreateProcessRunParamList(context, runMethod.GetParameters().ToList(), cancellationToken).ToArray();
-                    var resultTask = runMethod.Invoke(Process, runParams);
-                    if (resultTask != null)
-                    {
-                        var result = await (Task<Dictionary<string, object>>)resultTask;
-                        var stepResult = CreateStepResult(result);
-
-                        this.State = StepState.Success;
-
-                        return stepResult;
-                    }
-                    else
-                    {
-                        this.State = StepState.Failed;
-                        logger.LogError($"error in step '{this.Id}': no result returned from process.");
-                    }
-                }
+                await resultTask;
             }
             catch (Exception ex)
             {
-                this.State = StepState.Failed;
-                logger.LogError(ex, $"error in step '{this.Id}': exception occurred during step execution: {ex.Message}.");
+                throw new PipelineRunException($"The process <{Process.GetType().Name}> threw an exception.", ex);
             }
+
+            var stepResult = CreateStepResult(resultTask.Result);
+            this.State = StepState.Success;
+            return stepResult;
         }
-        else
+        catch (Exception ex)
         {
             this.State = StepState.Failed;
-            logger.LogError($"error in step '{this.Id}': pipeline context is null.");
+            logger.LogError(ex, $"Error in step <{this.Id}>.");
+            throw;
         }
-
-        return new StepResult();
     }
 
-    private MethodInfo? GetProcessRunMethod()
+    private MethodInfo GetProcessRunMethod()
     {
         var processRunMethods = Process.GetType().GetMethods(BindingFlags.Public | BindingFlags.Instance)
                     .Where(m => Attribute.IsDefined(m, typeof(PipelineProcessRunAttribute)))
@@ -118,13 +112,11 @@ public sealed class PipelineStep : IPipelineStep
 
         if (processRunMethods.Count() > 1)
         {
-            logger.LogError($"error in step '{this.Id}': multiple methods found with PipelineProcessRunAttribute. there should only be one. please consolidate the pipeline validation logic.");
-            return null;
+            throw new PipelineRunException($"Multiple methods found with PipelineProcessRunAttribute on process <{Process.GetType().Name}>.");
         }
         else if (!processRunMethods.Any())
         {
-            logger.LogError($"error in step '{this.Id}': no method found with PipelineProcessRunAttribute. there should be exactly one. please consolidate the pipeline validation logic.");
-            return null;
+            throw new PipelineRunException($"No method found with PipelineProcessRunAttribute on process <{Process.GetType().Name}>. There should be exactly one.");
         }
         else
         {
@@ -160,9 +152,8 @@ public sealed class PipelineStep : IPipelineStep
             return GenerateSingleParameter(parameterInfo, mappedValues[0]);
         }
 
-        var errorMessage = $"Error in step <{this.Id}>: could not find matching data for parameter <{parameterInfo.Name}> of type <{parameterInfo.ParameterType.FullName}> in process run method. please consolidate the pipeline validation logic.";
-        logger.LogError(errorMessage);
-        throw new InvalidOperationException(errorMessage);
+        var errorMessage = $"Could not find matching data for parameter <{parameterInfo.Name}> of type <{parameterInfo.ParameterType.FullName}> in process run method.";
+        throw new PipelineRunException(errorMessage);
     }
 
     private List<object?> CollectMappedValues(ParameterInfo parameterInfo, PipelineContext context)
@@ -185,7 +176,7 @@ public sealed class PipelineStep : IPipelineStep
         return mappedValues;
     }
 
-    private Array? GenerateArrayParameter(ParameterInfo parameterInfo, List<object?> mappedValues)
+    private Array GenerateArrayParameter(ParameterInfo parameterInfo, List<object?> mappedValues)
     {
         var elementType = parameterInfo.ParameterType.GetElementType()
             ?? throw new InvalidOperationException("Could not get type of element.");
@@ -195,18 +186,16 @@ public sealed class PipelineStep : IPipelineStep
 
         if (!isElementNullable && hasNullValues)
         {
-            var errorMessage = $"Error in step <{this.Id}>: parameter <{parameterInfo.Name}> of type <{parameterInfo.ParameterType.FullName}> is a non-nullable array, but at least one input was null.";
-            logger.LogError(errorMessage);
-            throw new InvalidOperationException(errorMessage);
+            var errorMessage = $"Parameter <{parameterInfo.Name}> of type <{parameterInfo.ParameterType.FullName}> is a non-nullable array, but at least one input was null.";
+            throw new PipelineRunException(errorMessage);
         }
 
         var hasAnyNonAssignableValues = mappedValues.Any(p => p != null && !elementType.IsAssignableFrom(p.GetType()));
 
         if (hasAnyNonAssignableValues)
         {
-            var errorMessage = $"Error in step <{this.Id}>: at least one of the mapped input values was not assignable to the element type <{elementType.Name}> of parameter <{parameterInfo.Name}> of type <{parameterInfo.ParameterType.FullName}>.";
-            logger.LogError(errorMessage);
-            throw new InvalidOperationException(errorMessage);
+            var errorMessage = $"At least one of the mapped input values was not assignable to the element type <{elementType.Name}> of parameter <{parameterInfo.Name}> of type <{parameterInfo.ParameterType.FullName}>.";
+            throw new PipelineRunException(errorMessage);
         }
 
         var mappedValuesArray = mappedValues.ToArray();
@@ -218,9 +207,8 @@ public sealed class PipelineStep : IPipelineStep
 
         if (!parameterInfo.ParameterType.IsAssignableFrom(arrayOfCorrectTypeToInject.GetType()))
         {
-            var errorMessage = $"Error in step <{this.Id}>: the generated array of type <{arrayOfCorrectTypeToInject.GetType()}> was not assignable to parameter <{parameterInfo.Name}> of type <{parameterInfo.ParameterType}>.";
-            logger.LogError(errorMessage);
-            throw new InvalidOperationException(errorMessage);
+            var errorMessage = $"The generated array of type <{arrayOfCorrectTypeToInject.GetType()}> was not assignable to parameter <{parameterInfo.Name}> of type <{parameterInfo.ParameterType}>.";
+            throw new PipelineRunException(errorMessage);
         }
 
         return arrayOfCorrectTypeToInject;
@@ -228,24 +216,16 @@ public sealed class PipelineStep : IPipelineStep
 
     private object? GenerateSingleParameter(ParameterInfo parameterInfo, object? mappedValue)
     {
-        if (mappedValue == null)
+        if (mappedValue == null && !IsParameterNullable(parameterInfo))
         {
-            var isNullable = IsParameterNullable(parameterInfo);
-
-            if (!isNullable)
-            {
-                var errorMessage = $"Error in step <{this.Id}>: the parameter <{parameterInfo.Name}> is non-nullable, but the mapped input value was null.";
-                logger.LogError(errorMessage);
-                throw new InvalidOperationException(errorMessage);
-            }
-
-            return null;
+            var errorMessage = $"The parameter <{parameterInfo.Name}> is non-nullable, but the mapped input value was null.";
+            throw new PipelineRunException(errorMessage);
         }
 
-        if (!parameterInfo.ParameterType.IsAssignableFrom(mappedValue.GetType()))
+        if (mappedValue != null && !parameterInfo.ParameterType.IsAssignableFrom(mappedValue.GetType()))
         {
-            var errorMessage = $"Error in step <{this.Id}>: the mapped input value of type <{mappedValue.GetType()}> was not assignable to parameter <{parameterInfo.Name}> of type <{parameterInfo.ParameterType}>.";
-            throw new InvalidOperationException(errorMessage);
+            var errorMessage = $"The mapped input value of type <{mappedValue.GetType()}> was not assignable to parameter <{parameterInfo.Name}> of type <{parameterInfo.ParameterType}>.";
+            throw new PipelineRunException(errorMessage);
         }
 
         return mappedValue;
@@ -267,9 +247,9 @@ public sealed class PipelineStep : IPipelineStep
             }
             else
             {
-                var errMsg = $"Error in step <{this.Id}>: output config is missing 'take' or 'as', or output data not found in process data. this error should not occur. please consolidate the pipeline validation logic.";
-                logger.LogError(errMsg);
-                throw new InvalidOperationException(errMsg);
+                var errorMessage = $"Output config is missing 'take' or 'as', or the process output (referenced by 'take') was not found in the output of the process. This error should not occur. Please consolidate the pipeline validation logic.";
+                logger.LogError(errorMessage);
+                throw new PipelineRunException(errorMessage);
             }
         }
 

--- a/tests/Geopilot.Api.Test/Pipeline/PipelineStepTest.cs
+++ b/tests/Geopilot.Api.Test/Pipeline/PipelineStepTest.cs
@@ -132,7 +132,7 @@ public class PipelineStepTest
     }
 
     [TestMethod]
-    public void SuccessfullStepRunWithSingleInput()
+    public async Task SuccessfullStepRunWithSingleInput()
     {
         var inputConfigs = new List<InputConfig>
         {
@@ -172,7 +172,7 @@ public class PipelineStepTest
 
         Assert.AreEqual(StepState.Pending, pipelineStep.State);
 
-        var stepResult = Task.Run(() => pipelineStep.Run(pipelineContext, CancellationToken.None)).GetAwaiter().GetResult();
+        var stepResult = await pipelineStep.Run(pipelineContext, CancellationToken.None).ConfigureAwait(false);
 
         Assert.IsNotNull(stepResult);
 
@@ -188,7 +188,7 @@ public class PipelineStepTest
     }
 
     [TestMethod]
-    public void SuccessfullStepRunWithArrayInput()
+    public async Task SuccessfullStepRunWithArrayInput()
     {
         var inputConfigs = new List<InputConfig>
         {
@@ -228,7 +228,7 @@ public class PipelineStepTest
 
         Assert.AreEqual(StepState.Pending, pipelineStep.State);
 
-        var stepResult = Task.Run(() => pipelineStep.Run(pipelineContext, CancellationToken.None)).GetAwaiter().GetResult();
+        var stepResult = await pipelineStep.Run(pipelineContext, CancellationToken.None).ConfigureAwait(false);
 
         Assert.IsNotNull(stepResult);
 
@@ -244,7 +244,7 @@ public class PipelineStepTest
     }
 
     [TestMethod]
-    public void SuccessfullStepRunWithManyDifferentInputDataInput()
+    public async Task SuccessfullStepRunWithManyDifferentInputDataInput()
     {
         var inputConfigs = new List<InputConfig>
         {
@@ -290,7 +290,7 @@ public class PipelineStepTest
 
         Assert.AreEqual(StepState.Pending, pipelineStep.State);
 
-        var stepResult = Task.Run(() => pipelineStep.Run(pipelineContext, CancellationToken.None)).GetAwaiter().GetResult();
+        var stepResult = await pipelineStep.Run(pipelineContext, CancellationToken.None).ConfigureAwait(false);
 
         Assert.IsNotNull(stepResult);
 
@@ -306,7 +306,7 @@ public class PipelineStepTest
     }
 
     [TestMethod]
-    public void SuccessfullStepRunWithNullableTypesInput()
+    public async Task SuccessfullStepRunWithNullableTypesInput()
     {
         var inputConfigs = new List<InputConfig>
         {
@@ -346,7 +346,7 @@ public class PipelineStepTest
 
         Assert.AreEqual(StepState.Pending, pipelineStep.State);
 
-        var stepResult = Task.Run(() => pipelineStep.Run(pipelineContext, CancellationToken.None)).GetAwaiter().GetResult();
+        var stepResult = await pipelineStep.Run(pipelineContext, CancellationToken.None).ConfigureAwait(false);
 
         Assert.AreEqual(StepState.Success, pipelineStep.State);
         Assert.AreEqual(1, processMock.NumberOfRunInvokations, "Process Run method was not invoked exactly once.");
@@ -365,7 +365,7 @@ public class PipelineStepTest
     [DataRow("nonNullableString")]
     [DataRow("arrayOfNonNullableInts")]
     [DataRow("arrayOfNonNullableStrings")]
-    public void StepRunFailsIfNullValueForNonNullableParameter(string inputToSetNull)
+    public async Task StepRunFailsIfNullValueForNonNullableParameter(string inputToSetNull)
     {
         // Setup input configs with valid values for each parameter
         var inputConfigs = new List<InputConfig>
@@ -411,14 +411,15 @@ public class PipelineStepTest
 
         Assert.AreEqual(StepState.Pending, pipelineStep.State);
 
-        var stepResult = Task.Run(() => pipelineStep.Run(pipelineContext, CancellationToken.None)).GetAwaiter().GetResult();
+        var exception = await Assert.ThrowsAsync<PipelineRunException>(() => pipelineStep.Run(pipelineContext, CancellationToken.None));
 
+        Assert.Contains("non-nullable", exception.Message);
         Assert.AreEqual(StepState.Failed, pipelineStep.State);
         Assert.AreEqual(0, processMock.NumberOfRunInvokations, "Process Run method was invoked.");
     }
 
     [TestMethod]
-    public void StepRunFailsIfInputDataIsOfWrongType()
+    public async Task StepRunFailsIfInputDataIsOfWrongType()
     {
         var inputConfigs = new List<InputConfig>
         {
@@ -448,14 +449,15 @@ public class PipelineStepTest
         using var pipelineStep = new PipelineStep("my_step", [], inputConfigs, [], processMock);
         Assert.AreEqual(StepState.Pending, pipelineStep.State);
 
-        var stepResult = Task.Run(() => pipelineStep.Run(pipelineContext, CancellationToken.None)).GetAwaiter().GetResult();
+        var exception = await Assert.ThrowsAsync<PipelineRunException>(() => pipelineStep.Run(pipelineContext, CancellationToken.None));
 
+        Assert.AreEqual("The mapped input value of type <System.String> was not assignable to parameter <booleanData> of type <System.Boolean>.", exception.Message);
         Assert.AreEqual(StepState.Failed, pipelineStep.State);
         Assert.AreEqual(0, processMock.NumberOfRunInvokations, "Process Run method was invoked.");
     }
 
     [TestMethod]
-    public void StepRunFailsIfInputDataIsOfWrongTypeForArray()
+    public async Task StepRunFailsIfInputDataIsOfWrongTypeForArray()
     {
         var inputConfigs = new List<InputConfig>
         {
@@ -486,14 +488,15 @@ public class PipelineStepTest
         using var pipelineStep = new PipelineStep("my_step", [], inputConfigs, [], processMock);
         Assert.AreEqual(StepState.Pending, pipelineStep.State);
 
-        var stepResult = Task.Run(() => pipelineStep.Run(pipelineContext, CancellationToken.None)).GetAwaiter().GetResult();
+        var exception = await Assert.ThrowsAsync<PipelineRunException>(() => pipelineStep.Run(pipelineContext, CancellationToken.None));
 
+        Assert.AreEqual("At least one of the mapped input values was not assignable to the element type <String> of parameter <stringData> of type <System.String[]>.", exception.Message);
         Assert.AreEqual(StepState.Failed, pipelineStep.State);
         Assert.AreEqual(0, processMock.NumberOfRunInvokations, "Process Run method was invoked.");
     }
 
     [TestMethod]
-    public void ContextHasNoReferencingStepRusult()
+    public async Task ContextHasNoReferencingStepResult()
     {
         var inputConfigs = new List<InputConfig>
         {
@@ -529,17 +532,15 @@ public class PipelineStepTest
 
         Assert.AreEqual(StepState.Pending, pipelineStep.State);
 
-        var stepResult = Task.Run(() => pipelineStep.Run(pipelineContext, CancellationToken.None)).GetAwaiter().GetResult();
+        var exception = await Assert.ThrowsAsync<PipelineRunException>(() => pipelineStep.Run(pipelineContext, CancellationToken.None));
 
-        Assert.IsEmpty(stepResult.Outputs);
-
+        Assert.AreEqual("Could not find matching data for parameter <data> of type <System.String> in process run method.", exception.Message);
         Assert.AreEqual(StepState.Failed, pipelineStep.State);
-
         Assert.AreEqual(0, processMock.NumberOfRunInvoced, "Process Run method was invoked.");
     }
 
     [TestMethod]
-    public void ContextHasNoReferencingStepOutput()
+    public async Task ContextHasNoReferencingStepOutput()
     {
         var inputConfigs = new List<InputConfig>
         {
@@ -575,17 +576,15 @@ public class PipelineStepTest
 
         Assert.AreEqual(StepState.Pending, pipelineStep.State);
 
-        var stepResult = Task.Run(() => pipelineStep.Run(pipelineContext, CancellationToken.None)).GetAwaiter().GetResult();
+        var exception = await Assert.ThrowsAsync<PipelineRunException>(() => pipelineStep.Run(pipelineContext, CancellationToken.None));
 
-        Assert.IsEmpty(stepResult.Outputs);
-
+        Assert.AreEqual("Could not find matching data for parameter <data> of type <System.String> in process run method.", exception.Message);
         Assert.AreEqual(StepState.Failed, pipelineStep.State);
-
         Assert.AreEqual(0, processMock.NumberOfRunInvoced, "Process Run method was not invoked exactly once.");
     }
 
     [TestMethod]
-    public void ExceptionDuringProcessRun()
+    public async Task ExceptionDuringProcessRun()
     {
         var inputConfigs = new List<InputConfig>
         {
@@ -621,17 +620,17 @@ public class PipelineStepTest
 
         Assert.AreEqual(StepState.Pending, pipelineStep.State);
 
-        var stepResult = Task.Run(() => pipelineStep.Run(pipelineContext, CancellationToken.None)).GetAwaiter().GetResult();
+        var exception = await Assert.ThrowsAsync<PipelineRunException>(() => pipelineStep.Run(pipelineContext, CancellationToken.None));
 
-        Assert.IsEmpty(stepResult.Outputs);
-
+        Assert.AreEqual("The process <MockPipelineProcessException> threw an exception.", exception.Message);
+        Assert.AreEqual(typeof(InvalidOperationException), exception.InnerException?.GetType());
+        Assert.AreEqual("Test exception during process run.", exception.InnerException?.Message);
         Assert.AreEqual(StepState.Failed, pipelineStep.State);
-
         Assert.AreEqual(1, processMock.NumberOfRunInvoced, "Process Run method was not invoked exactly once.");
     }
 
     [TestMethod]
-    public void StepResultCouldNotBeCreated()
+    public async Task StepResultCouldNotBeCreated()
     {
         var inputConfigs = new List<InputConfig>
         {
@@ -671,12 +670,10 @@ public class PipelineStepTest
 
         Assert.AreEqual(StepState.Pending, pipelineStep.State);
 
-        var stepResult = Task.Run(() => pipelineStep.Run(pipelineContext, CancellationToken.None)).GetAwaiter().GetResult();
+        var exception = await Assert.ThrowsAsync<PipelineRunException>(() => pipelineStep.Run(pipelineContext, CancellationToken.None));
 
-        Assert.IsEmpty(stepResult.Outputs);
-
+        Assert.AreEqual("Output config is missing 'take' or 'as', or the process output (referenced by 'take') was not found in the output of the process. This error should not occur. Please consolidate the pipeline validation logic.", exception.Message);
         Assert.AreEqual(StepState.Failed, pipelineStep.State);
-
         Assert.AreEqual(1, processMock.NumberOfRunInvoced, "Process Run method was not invoked exactly once.");
     }
 


### PR DESCRIPTION
Vor diesem Change wurden Exceptions bei einem Pipeline-Run geschluckt und Fehlermeldungen wurde lediglich als Log ausgegeben. Das macht es sehr schwierig als Aufrufer, zu erfahren was mit der Pipeline passiert, bzw. passiert ist. Das Zurückgeben eines leeren StepResults, wenn ein Step fehlschlägt trägt ebenfalls zu einer Undurchsichtigkeit bei.
Auch wurde eine `OperationCancelledException` geschluckt, wenn das `CancellationToken` gecancelled wurde.