### PR TITLE
Make CI use azurite in https like dev environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,12 @@ jobs:
         working-directory: ./src/Geopilot.Api
         run: dotnet tool run dotnet-ef migrations has-pending-model-changes
 
+      - name: Setup dev-certs
+        uses: ./.github/actions/setup-dev-certs
+
       - name: Start test environment
-        run: docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d --wait --wait-timeout 120 db azurite clamav
+        run: docker compose up -d --wait --wait-timeout 120 db azurite clamav
 
       - name: Test
         run: dotnet test Geopilot.slnx -c Release --no-build --verbosity normal
-        env:
-          AZURITE_PROTOCOL: http
 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,3 +1,0 @@
-services:
-  azurite:
-    command: "azurite-blob --blobHost 0.0.0.0 --blobPort 10000 --skipApiVersionCheck"

--- a/tests/Geopilot.Api.Test/Services/AzureBlobStorageServiceTest.cs
+++ b/tests/Geopilot.Api.Test/Services/AzureBlobStorageServiceTest.cs
@@ -9,7 +9,10 @@ namespace Geopilot.Api.Test.Services;
 [TestClass]
 public class AzureBlobStorageServiceTest
 {
-    private static readonly string AzuriteConnectionString = BuildAzuriteConnectionString();
+    private const string AzuriteConnectionString =
+        "DefaultEndpointsProtocol=https;AccountName=devstoreaccount1;" +
+        "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;" +
+        "BlobEndpoint=https://localhost:10000/devstoreaccount1;";
 
     private BlobContainerClient containerClient;
     private AzureBlobStorageService service;
@@ -180,13 +183,5 @@ public class AzureBlobStorageServiceTest
         var blobClient = containerClient.GetBlobClient(key);
         using var stream = new MemoryStream(content);
         await blobClient.UploadAsync(stream, overwrite: true);
-    }
-
-    private static string BuildAzuriteConnectionString()
-    {
-        var protocol = Environment.GetEnvironmentVariable("AZURITE_PROTOCOL") ?? "https";
-        return $"DefaultEndpointsProtocol={protocol};AccountName=devstoreaccount1;" +
-            "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;" +
-            $"BlobEndpoint={protocol}://localhost:10000/devstoreaccount1;";
     }
 }

--- a/tests/Geopilot.Api.Test/Services/CloudCleanupServiceIntegrationTest.cs
+++ b/tests/Geopilot.Api.Test/Services/CloudCleanupServiceIntegrationTest.cs
@@ -11,7 +11,10 @@ namespace Geopilot.Api.Test.Services;
 [TestClass]
 public class CloudCleanupServiceIntegrationTest
 {
-    private static readonly string AzuriteConnectionString = BuildAzuriteConnectionString();
+    private const string AzuriteConnectionString =
+        "DefaultEndpointsProtocol=https;AccountName=devstoreaccount1;" +
+        "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;" +
+        "BlobEndpoint=https://localhost:10000/devstoreaccount1;";
 
     private BlobContainerClient containerClient;
     private AzureBlobStorageService storageService;
@@ -129,13 +132,5 @@ public class CloudCleanupServiceIntegrationTest
         var blobClient = containerClient.GetBlobClient(key);
         using var stream = new MemoryStream(content);
         await blobClient.UploadAsync(stream, overwrite: true);
-    }
-
-    private static string BuildAzuriteConnectionString()
-    {
-        var protocol = Environment.GetEnvironmentVariable("AZURITE_PROTOCOL") ?? "https";
-        return $"DefaultEndpointsProtocol={protocol};AccountName=devstoreaccount1;" +
-            "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;" +
-            $"BlobEndpoint={protocol}://localhost:10000/devstoreaccount1;";
     }
 }


### PR DESCRIPTION
- Azurite tests ran in http due to some cert issues in CI. this caused compatibility problems and drift between the dev environment (which runs azurite in https) and CI. Leads to a lot of successful tests locally failing in CI. This branch aims to unify the two again.