### PR TITLE
Fix plugin loading

### DIFF
--- a/src/Geopilot.Api/Geopilot.Api.csproj
+++ b/src/Geopilot.Api/Geopilot.Api.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.0" />
     <PackageReference Include="Humanizer.Core" Version="3.0.1" />
     <PackageReference Include="DotNetStac.Api" Version="1.0.0-beta.5" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="10.0.7" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <PackageReference Include="Yarp.ReverseProxy" Version="2.3.0" />
   </ItemGroup>

--- a/src/Geopilot.Api/Pipeline/Process/PipelineProcessFactory.cs
+++ b/src/Geopilot.Api/Pipeline/Process/PipelineProcessFactory.cs
@@ -83,19 +83,15 @@ public class PipelineProcessFactory : IPipelineProcessFactory, IDisposable
             return;
         }
 
+        var loadContextLogger = loggerFactory.CreateLogger<ProcessPluginLoadContext>();
+
         foreach (var assemblyPath in pipelineOptions.Plugins)
         {
             var assemblyFullPath = Path.IsPathRooted(assemblyPath) ? assemblyPath : Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, assemblyPath));
 
-            var assemblyContext = new ProcessPluginLoadContext(assemblyFullPath, loggerFactory.CreateLogger<ProcessPluginLoadContext>());
-
-            // Validate compatibility against the plugin's metadata before loading it for
-            // execution. LoadFromAssemblyPath would make the plugin's code runnable
-            // (module initializers, type cctors triggered by subsequent reflection), so
-            // incompatible or untrusted assemblies must be rejected first.
-            if (!assemblyContext.ValidateCompatibility())
+            var assemblyContext = ProcessPluginLoadContext.Create(assemblyFullPath, loadContextLogger);
+            if (assemblyContext == null)
             {
-                assemblyContext.Unload();
                 continue;
             }
 

--- a/src/Geopilot.Api/Pipeline/Process/PipelineProcessFactory.cs
+++ b/src/Geopilot.Api/Pipeline/Process/PipelineProcessFactory.cs
@@ -70,32 +70,41 @@ public class PipelineProcessFactory : IPipelineProcessFactory, IDisposable
 
         this.loggerFactory = loggerFactory;
         this.pipelineOptions = pipelinePluginOptions.Value;
-        var processorPlugins = pipelineOptions.Plugins;
         this.logger = loggerFactory.CreateLogger<PipelineProcessFactory>();
 
-        if (processorPlugins != null)
+        LoadPlugins();
+    }
+
+    private void LoadPlugins()
+    {
+        if (pipelineOptions.Plugins == null)
         {
-            foreach (var assemblyPath in processorPlugins)
+            logger.LogInformation("No processor plugins configured. Not loading any plugins.");
+            return;
+        }
+
+        foreach (var assemblyPath in pipelineOptions.Plugins)
+        {
+            var assemblyFullPath = Path.IsPathRooted(assemblyPath) ? assemblyPath : Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, assemblyPath));
+
+            var assemblyContext = new ProcessPluginLoadContext(assemblyFullPath, loggerFactory.CreateLogger<ProcessPluginLoadContext>());
+
+            // Validate compatibility against the plugin's metadata before loading it for
+            // execution. LoadFromAssemblyPath would make the plugin's code runnable
+            // (module initializers, type cctors triggered by subsequent reflection), so
+            // incompatible or untrusted assemblies must be rejected first.
+            if (!assemblyContext.ValidateCompatibility())
             {
-                var assemblyFullPath = Path.IsPathRooted(assemblyPath) ? assemblyPath : Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, assemblyPath));
-
-                var assemblyContext = new ProcessPluginLoadContext(assemblyFullPath, loggerFactory.CreateLogger<ProcessPluginLoadContext>());
-
-                // Validate compatibility against the plugin's metadata before loading it for
-                // execution. LoadFromAssemblyPath would make the plugin's code runnable
-                // (module initializers, type cctors triggered by subsequent reflection), so
-                // incompatible or untrusted assemblies must be rejected first.
-                if (!assemblyContext.ValidateCompatibility())
-                {
-                    assemblyContext.Unload();
-                    continue;
-                }
-
-                var plugin = assemblyContext.LoadFromAssemblyPath(assemblyFullPath);
-
-                processorPluginAssemblies.Add(plugin);
-                processorPluginLoadContexts.Add(assemblyContext);
+                assemblyContext.Unload();
+                continue;
             }
+
+            var plugin = assemblyContext.LoadFromAssemblyPath(assemblyFullPath);
+
+            processorPluginAssemblies.Add(plugin);
+            processorPluginLoadContexts.Add(assemblyContext);
+
+            logger.LogInformation($"Plugin loaded: {assemblyPath}");
         }
     }
 

--- a/src/Geopilot.Api/Pipeline/Process/PipelineProcessFactory.cs
+++ b/src/Geopilot.Api/Pipeline/Process/PipelineProcessFactory.cs
@@ -90,7 +90,7 @@ public class PipelineProcessFactory : IPipelineProcessFactory, IDisposable
                     continue;
                 }
 
-                var assemblyContext = new AssemblyLoadContext(assemblyFullPath, isCollectible: true);
+                var assemblyContext = new ProcessPluginLoadContext(assemblyFullPath);
                 var plugin = assemblyContext.LoadFromAssemblyPath(assemblyFullPath);
 
                 processorPluginAssemblies.Add(plugin);

--- a/src/Geopilot.Api/Pipeline/Process/PipelineProcessFactory.cs
+++ b/src/Geopilot.Api/Pipeline/Process/PipelineProcessFactory.cs
@@ -2,8 +2,6 @@
 using Geopilot.PipelineCore.Pipeline;
 using Microsoft.Extensions.Options;
 using System.Reflection;
-using System.Reflection.Metadata;
-using System.Reflection.PortableExecutable;
 using System.Runtime.Loader;
 
 namespace Geopilot.Api.Pipeline.Process;
@@ -81,100 +79,24 @@ public class PipelineProcessFactory : IPipelineProcessFactory, IDisposable
             {
                 var assemblyFullPath = Path.IsPathRooted(assemblyPath) ? assemblyPath : Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, assemblyPath));
 
+                var assemblyContext = new ProcessPluginLoadContext(assemblyFullPath, loggerFactory.CreateLogger<ProcessPluginLoadContext>());
+
                 // Validate compatibility against the plugin's metadata before loading it for
                 // execution. LoadFromAssemblyPath would make the plugin's code runnable
                 // (module initializers, type cctors triggered by subsequent reflection), so
                 // incompatible or untrusted assemblies must be rejected first.
-                if (!ValidatePluginCoreCompatibility(assemblyFullPath))
+                if (!assemblyContext.ValidateCompatibility())
                 {
+                    assemblyContext.Unload();
                     continue;
                 }
 
-                var assemblyContext = new ProcessPluginLoadContext(assemblyFullPath);
                 var plugin = assemblyContext.LoadFromAssemblyPath(assemblyFullPath);
 
                 processorPluginAssemblies.Add(plugin);
                 processorPluginLoadContexts.Add(assemblyContext);
             }
         }
-    }
-
-    /// <summary>
-    /// Verifies that a plugin assembly references a compatible version of Geopilot.PipelineCore.
-    /// The check reads the assembly's manifest via <see cref="PEReader"/> and
-    /// <see cref="MetadataReader"/> — no code from the plugin is executed. This matters because
-    /// <see cref="AssemblyLoadContext.LoadFromAssemblyPath(string)"/> would make module
-    /// initializers and (on first type access) type constructors runnable before the host could
-    /// decide whether to reject the assembly. The check rejects plugins whose referenced major
-    /// version differs from the host's loaded major version, and warns when the plugin was built
-    /// against an older minor/patch.
-    /// </summary>
-    /// <param name="assemblyPath">Absolute path to the plugin assembly file.</param>
-    /// <returns>True if the plugin is compatible with the host's PipelineCore; false otherwise.</returns>
-    private bool ValidatePluginCoreCompatibility(string assemblyPath)
-    {
-        const string coreAssemblyName = "Geopilot.PipelineCore";
-        var coreVersionUsedByHost = typeof(IPipelineFile).Assembly.GetName().Version;
-
-        string pluginDisplayName = Path.GetFileNameWithoutExtension(assemblyPath);
-        Version? coreVersionUsedByPlugin = null;
-        bool coreReferenceFound = false;
-
-        var resolver = new AssemblyDependencyResolver(assemblyPath);
-        var path = resolver.ResolveAssemblyToPath(new AssemblyName(coreAssemblyName));
-        if (path != null)
-        {
-            coreReferenceFound = true;
-            var name = AssemblyName.GetAssemblyName(path);
-            coreVersionUsedByPlugin = AssemblyName.GetAssemblyName(path).Version;
-        }
-        else
-        {
-            return false;
-        }
-
-        if (!coreReferenceFound)
-        {
-            logger.LogError(
-                "Plugin '{Plugin}' does not reference {Core}; rejecting.",
-                pluginDisplayName,
-                coreAssemblyName);
-            return false;
-        }
-
-        if (coreVersionUsedByPlugin == null || coreVersionUsedByHost == null)
-        {
-            logger.LogError(
-                "Unable to determine {Core} version for plugin '{Plugin}' (plugin={PluginVersion}, host={HostVersion}); rejecting.",
-                coreAssemblyName,
-                pluginDisplayName,
-                coreVersionUsedByPlugin,
-                coreVersionUsedByHost);
-            return false;
-        }
-
-        if (coreVersionUsedByPlugin.Major != coreVersionUsedByHost.Major)
-        {
-            logger.LogError(
-                "Plugin '{Plugin}' was built against {Core} {PluginVersion} but host runs {HostVersion}; major versions differ, plugin will not be loaded.",
-                pluginDisplayName,
-                coreAssemblyName,
-                coreVersionUsedByPlugin,
-                coreVersionUsedByHost);
-            return false;
-        }
-
-        if (coreVersionUsedByPlugin < coreVersionUsedByHost)
-        {
-            logger.LogWarning(
-                "Plugin '{Plugin}' was built against older {Core} {PluginVersion} (host runs {HostVersion}); consider rebuilding the plugin.",
-                pluginDisplayName,
-                coreAssemblyName,
-                coreVersionUsedByPlugin,
-                coreVersionUsedByHost);
-        }
-
-        return true;
     }
 
     /// <inheritdoc />

--- a/src/Geopilot.Api/Pipeline/Process/ProcessPluginLoadContext.cs
+++ b/src/Geopilot.Api/Pipeline/Process/ProcessPluginLoadContext.cs
@@ -98,6 +98,17 @@ internal sealed class ProcessPluginLoadContext : AssemblyLoadContext
             return false;
         }
 
+        if (coreVersionUsedByPlugin.Minor > coreVersionUsedByHost.Minor)
+        {
+            logger.LogError(
+                "Plugin '{Plugin}' was built against {Core} {PluginVersion} but host runs {HostVersion}; minor version of plugin is higher than minor version of host, plugin will not be loaded.",
+                pluginDisplayName,
+                PipelineCoreAssemblyName,
+                coreVersionUsedByPlugin,
+                coreVersionUsedByHost);
+            return false;
+        }
+
         if (coreVersionUsedByPlugin < coreVersionUsedByHost)
         {
             logger.LogWarning(

--- a/src/Geopilot.Api/Pipeline/Process/ProcessPluginLoadContext.cs
+++ b/src/Geopilot.Api/Pipeline/Process/ProcessPluginLoadContext.cs
@@ -1,5 +1,6 @@
 ﻿using Geopilot.PipelineCore.Pipeline;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 
 namespace Geopilot.Api.Pipeline.Process;
@@ -47,23 +48,24 @@ internal sealed class ProcessPluginLoadContext : AssemblyLoadContext
     public bool ValidateCompatibility()
     {
         var coreVersionUsedByHost = typeof(IPipelineFile).Assembly.GetName().Version;
-
         string pluginDisplayName = Path.GetFileNameWithoutExtension(pluginPath);
-        Version? coreVersionUsedByPlugin = null;
-        bool coreReferenceFound = false;
 
-        var path = resolver.ResolveAssemblyToPath(new AssemblyName(PipelineCoreAssemblyName));
-        if (path != null)
+        // MetadataLoadContext needs a corelib in its resolver paths to anchor the type system,
+        // so we feed it every assembly from the shared framework directory plus the plugin
+        // itself. GetReferencedAssemblies() then reads the plugin's manifest table directly —
+        // no plugin code is executed, and PipelineCore does not need to be physically resolvable
+        // next to the plugin (the recorded AssemblyRef carries the version we want).
+        var resolverPaths = new List<string>(Directory.GetFiles(RuntimeEnvironment.GetRuntimeDirectory(), "*.dll"))
         {
-            coreReferenceFound = true;
-            coreVersionUsedByPlugin = AssemblyName.GetAssemblyName(path).Version;
-        }
-        else
-        {
-            return false;
-        }
+            pluginPath,
+        };
+        using var metadataContext = new MetadataLoadContext(new PathAssemblyResolver(resolverPaths));
+        var pluginAssembly = metadataContext.LoadFromAssemblyPath(pluginPath);
 
-        if (!coreReferenceFound)
+        var coreReference = pluginAssembly.GetReferencedAssemblies()
+            .FirstOrDefault(r => r.Name == PipelineCoreAssemblyName);
+
+        if (coreReference == null)
         {
             logger.LogError(
                 "Plugin '{Plugin}' does not reference {Core}; rejecting.",
@@ -71,6 +73,8 @@ internal sealed class ProcessPluginLoadContext : AssemblyLoadContext
                 PipelineCoreAssemblyName);
             return false;
         }
+
+        var coreVersionUsedByPlugin = coreReference.Version;
 
         if (coreVersionUsedByPlugin == null || coreVersionUsedByHost == null)
         {

--- a/src/Geopilot.Api/Pipeline/Process/ProcessPluginLoadContext.cs
+++ b/src/Geopilot.Api/Pipeline/Process/ProcessPluginLoadContext.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using Geopilot.PipelineCore.Pipeline;
+using System.Reflection;
 using System.Runtime.Loader;
 
 namespace Geopilot.Api.Pipeline.Process;
@@ -22,12 +23,88 @@ internal sealed class ProcessPluginLoadContext : AssemblyLoadContext
 
     private readonly AssemblyDependencyResolver resolver;
     private readonly Assembly hostPiplineCoreAssembly;
+    private readonly string pluginPath;
+    private readonly ILogger<ProcessPluginLoadContext> logger;
 
-    public ProcessPluginLoadContext(string pluginPath)
+    public ProcessPluginLoadContext(string pluginPath, ILogger<ProcessPluginLoadContext> logger)
         : base(name: pluginPath, isCollectible: true)
     {
+        this.pluginPath = pluginPath;
+        this.logger = logger;
         resolver = new AssemblyDependencyResolver(pluginPath);
         hostPiplineCoreAssembly = Default.Assemblies.First(a => a.GetName().Name == PipelineCoreAssemblyName);
+    }
+
+    /// <summary>
+    /// Verifies that the plugin assembly references a compatible version of Geopilot.PipelineCore.
+    /// The check inspects the plugin's manifest without executing any plugin code, so incompatible
+    /// or untrusted assemblies can be rejected before <see cref="AssemblyLoadContext.LoadFromAssemblyPath(string)"/>
+    /// makes module initializers and type constructors runnable. Plugins whose referenced major
+    /// version differs from the host's loaded major version are rejected; plugins built against an
+    /// older minor/patch are accepted with a warning.
+    /// </summary>
+    /// <returns>True if the plugin is compatible with the host's PipelineCore; false otherwise.</returns>
+    public bool ValidateCompatibility()
+    {
+        var coreVersionUsedByHost = typeof(IPipelineFile).Assembly.GetName().Version;
+
+        string pluginDisplayName = Path.GetFileNameWithoutExtension(pluginPath);
+        Version? coreVersionUsedByPlugin = null;
+        bool coreReferenceFound = false;
+
+        var path = resolver.ResolveAssemblyToPath(new AssemblyName(PipelineCoreAssemblyName));
+        if (path != null)
+        {
+            coreReferenceFound = true;
+            coreVersionUsedByPlugin = AssemblyName.GetAssemblyName(path).Version;
+        }
+        else
+        {
+            return false;
+        }
+
+        if (!coreReferenceFound)
+        {
+            logger.LogError(
+                "Plugin '{Plugin}' does not reference {Core}; rejecting.",
+                pluginDisplayName,
+                PipelineCoreAssemblyName);
+            return false;
+        }
+
+        if (coreVersionUsedByPlugin == null || coreVersionUsedByHost == null)
+        {
+            logger.LogError(
+                "Unable to determine {Core} version for plugin '{Plugin}' (plugin={PluginVersion}, host={HostVersion}); rejecting.",
+                PipelineCoreAssemblyName,
+                pluginDisplayName,
+                coreVersionUsedByPlugin,
+                coreVersionUsedByHost);
+            return false;
+        }
+
+        if (coreVersionUsedByPlugin.Major != coreVersionUsedByHost.Major)
+        {
+            logger.LogError(
+                "Plugin '{Plugin}' was built against {Core} {PluginVersion} but host runs {HostVersion}; major versions differ, plugin will not be loaded.",
+                pluginDisplayName,
+                PipelineCoreAssemblyName,
+                coreVersionUsedByPlugin,
+                coreVersionUsedByHost);
+            return false;
+        }
+
+        if (coreVersionUsedByPlugin < coreVersionUsedByHost)
+        {
+            logger.LogWarning(
+                "Plugin '{Plugin}' was built against older {Core} {PluginVersion} (host runs {HostVersion}); consider rebuilding the plugin.",
+                pluginDisplayName,
+                PipelineCoreAssemblyName,
+                coreVersionUsedByPlugin,
+                coreVersionUsedByHost);
+        }
+
+        return true;
     }
 
     protected override Assembly? Load(AssemblyName assemblyName)

--- a/src/Geopilot.Api/Pipeline/Process/ProcessPluginLoadContext.cs
+++ b/src/Geopilot.Api/Pipeline/Process/ProcessPluginLoadContext.cs
@@ -1,0 +1,59 @@
+﻿using System.Reflection;
+using System.Runtime.Loader;
+
+namespace Geopilot.Api.Pipeline.Process;
+
+/// <summary>
+/// Collectible <see cref="AssemblyLoadContext"/> for processor plugins. Follows the
+/// Microsoft plugin pattern: private dependencies are resolved through the plugin's
+/// <c>.deps.json</c> via <see cref="AssemblyDependencyResolver"/>, while assemblies
+/// shared with the host are returned from the default ALC so plugin and host see the
+/// same <see cref="Type"/> identity for contract types like
+/// <see cref="Geopilot.PipelineCore.Pipeline.IPipelineFile"/> and
+/// <see cref="Microsoft.Extensions.Logging.ILogger"/>.
+/// </summary>
+internal sealed class ProcessPluginLoadContext : AssemblyLoadContext
+{
+    private const string PipelineCoreAssemblyName = "Geopilot.PipelineCore";
+    private static readonly HashSet<string> HostSharedAssemblies = new(StringComparer.Ordinal)
+    {
+        "Microsoft.Extensions.Logging.Abstractions",
+    };
+
+    private readonly AssemblyDependencyResolver resolver;
+    private readonly Assembly hostPiplineCoreAssembly;
+
+    public ProcessPluginLoadContext(string pluginPath)
+        : base(name: pluginPath, isCollectible: true)
+    {
+        resolver = new AssemblyDependencyResolver(pluginPath);
+        hostPiplineCoreAssembly = Default.Assemblies.First(a => a.GetName().Name == PipelineCoreAssemblyName);
+    }
+
+    protected override Assembly? Load(AssemblyName assemblyName)
+    {
+        // If the assembly to load is PipelineCore, return the hosts assembly directly.
+        // Returning null here would cause the default ALC to load the assembly.
+        // That would be a problem because the default ALC only resolves a requested assembly,
+        // if the found assembly has a version <= the requested version.
+        // In our case that might be the case, because the default ALC uses the PipelineCore DLL vom the referenced project.
+        // The version in the referenced project does not specify a patch number, but the NuGet package does.
+        // So the NuGet package version, which is the requested version, is higher than the host/default version, because it has the patch number at the end.
+        if (assemblyName.Name != null && assemblyName.Name == PipelineCoreAssemblyName)
+            return hostPiplineCoreAssembly;
+
+        // If the assembly to load is a dependency that is shared with the host, return null.
+        // This resolves the plugins' reference to the same assembly as the hosts'.
+        if (assemblyName.Name != null && HostSharedAssemblies.Contains(assemblyName.Name))
+            return null;
+
+        var path = resolver.ResolveAssemblyToPath(assemblyName);
+        return path != null ? LoadFromAssemblyPath(path) : null;
+    }
+
+    protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
+    {
+        var path = resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+        return path != null ? LoadUnmanagedDllFromPath(path) : IntPtr.Zero;
+    }
+}

--- a/src/Geopilot.Api/Pipeline/Process/ProcessPluginLoadContext.cs
+++ b/src/Geopilot.Api/Pipeline/Process/ProcessPluginLoadContext.cs
@@ -25,27 +25,41 @@ internal sealed class ProcessPluginLoadContext : AssemblyLoadContext
     private readonly AssemblyDependencyResolver resolver;
     private readonly Assembly hostPiplineCoreAssembly;
     private readonly string pluginPath;
-    private readonly ILogger<ProcessPluginLoadContext> logger;
 
-    public ProcessPluginLoadContext(string pluginPath, ILogger<ProcessPluginLoadContext> logger)
+    private ProcessPluginLoadContext(string pluginPath)
         : base(name: pluginPath, isCollectible: true)
     {
         this.pluginPath = pluginPath;
-        this.logger = logger;
         resolver = new AssemblyDependencyResolver(pluginPath);
         hostPiplineCoreAssembly = Default.Assemblies.First(a => a.GetName().Name == PipelineCoreAssemblyName);
     }
 
     /// <summary>
-    /// Verifies that the plugin assembly references a compatible version of Geopilot.PipelineCore.
-    /// The check inspects the plugin's manifest without executing any plugin code, so incompatible
-    /// or untrusted assemblies can be rejected before <see cref="AssemblyLoadContext.LoadFromAssemblyPath(string)"/>
-    /// makes module initializers and type constructors runnable. Plugins whose referenced major
-    /// version differs from the host's loaded major version are rejected; plugins built against an
-    /// older minor/patch are accepted with a warning.
+    /// Creates a <see cref="ProcessPluginLoadContext"/> for the plugin at <paramref name="pluginPath"/>,
+    /// but only if the plugin's referenced <c>Geopilot.PipelineCore</c> is compatible with the host's.
+    /// Returns <see langword="null"/> when the plugin is rejected; the caller should skip the plugin in
+    /// that case. Compatibility is checked by reading the plugin's manifest only — no plugin code is
+    /// executed. This matters because <see cref="AssemblyLoadContext.LoadFromAssemblyPath(string)"/>
+    /// would make module initializers and (on first type access) type constructors runnable before
+    /// the host could decide whether to reject the assembly.
     /// </summary>
-    /// <returns>True if the plugin is compatible with the host's PipelineCore; false otherwise.</returns>
-    public bool ValidateCompatibility()
+    /// <param name="pluginPath">Absolute path to the plugin assembly file.</param>
+    /// <param name="logger">Logger used to report rejection reasons and version warnings.</param>
+    /// <returns>A new context if the plugin is compatible; otherwise <see langword="null"/>.</returns>
+    public static ProcessPluginLoadContext? Create(string pluginPath, ILogger logger)
+    {
+        if (!ValidateCompatibility(pluginPath, logger))
+            return null;
+
+        return new ProcessPluginLoadContext(pluginPath);
+    }
+
+    /// <summary>
+    /// Verifies that the plugin assembly references a compatible version of <c>Geopilot.PipelineCore</c>.
+    /// Rejects plugins whose referenced major version differs from the host's loaded major version or use a higher minor version than the host,
+    /// and warns when the plugin was built against an older minor/patch.
+    /// </summary>
+    private static bool ValidateCompatibility(string pluginPath, ILogger logger)
     {
         var coreVersionUsedByHost = typeof(IPipelineFile).Assembly.GetName().Version;
         string pluginDisplayName = Path.GetFileNameWithoutExtension(pluginPath);


### PR DESCRIPTION
This change makes it possible for plugins to have their own dependencies. Previously, only the plugins DLL was loaded and if it referenced a dependency that the geopilot did not have itself, the plugin would fail to load. With this change, a plugin can have accompanying DLLs that must be placed in the same folder as the plugin DLL. They will be loaded with the plugin. As a consequence, every plugin should be in its own sub-folder, with its own dependencies next to it.