### PR TITLE
Refactor des publish von PipelineCore

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Set environment variables
         run: |
           echo VERSION=$(grep -oP "(?<=<VersionPrefix>)[^<]+" Directory.Build.props).$GITHUB_RUN_NUMBER >> $GITHUB_ENV
-          echo CORE_VERSION=$(grep -oP "(?<=<VersionPrefix>)[^<]+" src/Geopilot.PipelineCore/Geopilot.PipelineCore.csproj).$GITHUB_RUN_NUMBER >> $GITHUB_ENV
           echo IMAGE_NAME=$REGISTRY/$(echo ${GITHUB_REPOSITORY,,}) >> $GITHUB_ENV
           echo COMMITED_AT=$(git show -s --format=%cI `git rev-parse HEAD`) >> $GITHUB_ENV
           echo REVISION=$(git rev-parse --short HEAD) >> $GITHUB_ENV
@@ -90,17 +89,6 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           sbom-path: 'sbom.cyclonedx.json'
           push-to-registry: true
-
-      - name: Setup dotnet
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: "10.0"
-
-      - name: Pack NuGet package
-        run: dotnet pack src/Geopilot.PipelineCore/Geopilot.PipelineCore.csproj -c Release -p:Version=${{ env.CORE_VERSION }} -o nuget-artifacts
-
-      - name: Push NuGet package to GitHub Packages
-        run: dotnet nuget push "nuget-artifacts/*.nupkg" --source https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
 
       - name: Create GitHub pre-release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
 
     permissions:
       packages: write
-      contents: read
+      contents: write
 
     steps:
       - name: Checkout repository
@@ -78,6 +78,18 @@ jobs:
 
       - name: Push NuGet package to GitHub Packages
         run: dotnet nuget push "nuget-artifacts/*.nupkg" --source https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
+
+      - name: Tag PipelineCore version
+        run: |
+          git fetch --tags
+          CORE_TAG="pipelinecore/v${CORE_VERSION}"
+          if git rev-parse --verify "refs/tags/${CORE_TAG}" >/dev/null 2>&1; then
+            echo "Tag ${CORE_TAG} already exists, skipping."
+          else
+            git tag "${CORE_TAG}" "${TAG_NAME}"
+            git push origin "${CORE_TAG}"
+            echo "Created tag ${CORE_TAG} at ${TAG_NAME}."
+          fi
 
   patch-changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,35 @@ jobs:
           docker push ${{ env.IMAGE_NAME }}:latest
           docker push ${{ env.IMAGE_NAME }}:v${{ env.MAJOR }}
 
+  publish-nuget:
+    runs-on: ubuntu-latest
+    name: Publish Geopilot.PipelineCore NuGet package
+
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.TAG_NAME }}
+
+      - name: Read PipelineCore version from csproj
+        run: |
+          echo CORE_VERSION=$(grep -oP "(?<=<VersionPrefix>)[^<]+" src/Geopilot.PipelineCore/Geopilot.PipelineCore.csproj) >> $GITHUB_ENV
+
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "10.0"
+
+      - name: Pack NuGet package
+        run: dotnet pack src/Geopilot.PipelineCore/Geopilot.PipelineCore.csproj -c Release -p:Version=${{ env.CORE_VERSION }} -o nuget-artifacts
+
+      - name: Push NuGet package to GitHub Packages
+        run: dotnet nuget push "nuget-artifacts/*.nupkg" --source https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
+
   patch-changelog:
     runs-on: ubuntu-latest
     name: Patch CHANGELOG.md and update GitHub release notes


### PR DESCRIPTION
PipelineCore wird neu gemeinsam mit geopilot released statt bei jedem Commit auf main.

- NuGet-Veröffentlichung wandert vom Pre-Release- in den Release-Workflow.
- Die Version stammt direkt aus dem csproj. Keine Running Number mehr. Ein Versionsbump ist damit eine bewusste Entscheidung im PR, kein CI-Nebeneffekt.
- Wenn sich die PipelineCore Version nicht ändert, wird auch kein neues NuGet Package released (`--skip-duplicate`).
- Pro veröffentlichter NuGet-Version wird ein pipelinecore/v<version>-Tag gesetzt, damit der zugehörige Code nachvollziehbar bleibt.

Issue: #624 