### PR TITLE
Versioning bug

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -61,7 +61,7 @@ jobs:
           context: .
           push: true
           build-args: |
-            VERSION=${{ env.VERSION }}
+            APP_VERSION=${{ env.VERSION }}
             REVISION=${{ env.REVISION }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Build image from Dockerfile
         run: |
-          docker build --build-arg VERSION=$GITHUB_RUN_NUMBER --build-arg REVISION=${{ github.sha }} -t ${{ env.IMAGE_NAME }}:${{ github.sha }} .
+          docker build --build-arg APP_VERSION=$GITHUB_RUN_NUMBER --build-arg REVISION=${{ github.sha }} -t ${{ env.IMAGE_NAME }}:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Optional virus scanning with ClamAV for cloud uploads.
 - Rate limiting and upload capacity limits for the cloud upload endpoint.
 
+### Changed
+
+- `Pipeline:Plugins` can now be configured via a single comma-separated value (e.g. `Pipeline__Plugins=a.dll,b.dll`) in addition to the existing JSON array form, making it usable as a flat environment variable.
+
 ### Fixed
 
 - The application can start without needing the permission to install PostgreSQL extensions if PostGIS is already installed.

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
-ARG VERSION=0.0.1
+ARG APP_VERSION=0.0.1
 ARG REVISION=0000000
 
 # Set default shell
@@ -37,7 +37,7 @@ ENV GENERATE_SOURCEMAP=false
 COPY src/ .
 RUN dotnet publish "Geopilot.Api/Geopilot.Api.csproj" \
   -c Release \
-  -p:VersionPrefix=${VERSION} \
+  -p:VersionPrefix=${APP_VERSION} \
   -p:SourceRevisionId=${REVISION} \
   -p:UseAppHost=false \
   -o ${PUBLISH_DIR}

--- a/src/Geopilot.Api/Pipeline/PipelineConfigurationExtensions.cs
+++ b/src/Geopilot.Api/Pipeline/PipelineConfigurationExtensions.cs
@@ -1,0 +1,30 @@
+﻿namespace Geopilot.Api.Pipeline;
+
+/// <summary>
+/// Configuration helpers for <see cref="PipelineOptions"/>.
+/// </summary>
+public static class PipelineConfigurationExtensions
+{
+    private const string PluginsKey = "Pipeline:Plugins";
+
+    /// <summary>
+    /// Allows <c>Pipeline:Plugins</c> to be supplied as a single comma-separated string (e.g. via env var
+    /// <c>Pipeline__Plugins=a.dll,b.dll</c>). When such a scalar value is present, it fully overrides any list bound
+    /// from the JSON array form in <c>appsettings.json</c>.
+    /// </summary>
+    public static IServiceCollection AddPipelinePluginsScalarOverride(this IServiceCollection services, IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        return services.PostConfigure<PipelineOptions>(options =>
+        {
+            var scalar = configuration[PluginsKey];
+            if (string.IsNullOrWhiteSpace(scalar))
+                return;
+
+            options.Plugins = scalar
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToList();
+        });
+    }
+}

--- a/src/Geopilot.Api/Pipeline/Process/PipelineProcessFactory.cs
+++ b/src/Geopilot.Api/Pipeline/Process/PipelineProcessFactory.cs
@@ -85,7 +85,10 @@ public class PipelineProcessFactory : IPipelineProcessFactory, IDisposable
 
         var loadContextLogger = loggerFactory.CreateLogger<ProcessPluginLoadContext>();
 
-        foreach (var assemblyPath in pipelineOptions.Plugins)
+        var assemblyPaths = pipelineOptions.Plugins
+            .SelectMany(p => p.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+
+        foreach (var assemblyPath in assemblyPaths)
         {
             var assemblyFullPath = Path.IsPathRooted(assemblyPath) ? assemblyPath : Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, assemblyPath));
 

--- a/src/Geopilot.Api/Pipeline/Process/PipelineProcessFactory.cs
+++ b/src/Geopilot.Api/Pipeline/Process/PipelineProcessFactory.cs
@@ -85,10 +85,7 @@ public class PipelineProcessFactory : IPipelineProcessFactory, IDisposable
 
         var loadContextLogger = loggerFactory.CreateLogger<ProcessPluginLoadContext>();
 
-        var assemblyPaths = pipelineOptions.Plugins
-            .SelectMany(p => p.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
-
-        foreach (var assemblyPath in assemblyPaths)
+        foreach (var assemblyPath in pipelineOptions.Plugins)
         {
             var assemblyFullPath = Path.IsPathRooted(assemblyPath) ? assemblyPath : Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, assemblyPath));
 

--- a/src/Geopilot.Api/Program.cs
+++ b/src/Geopilot.Api/Program.cs
@@ -157,6 +157,7 @@ builder.Services.AddTransient<IAuthorizationHandler, GeopilotUserHandler>();
 
 builder.Services.Configure<ProcessingOptions>(builder.Configuration.GetSection("Processing"));
 builder.Services.Configure<PipelineOptions>(builder.Configuration.GetSection("Pipeline"));
+builder.Services.AddPipelinePluginsScalarOverride(builder.Configuration);
 builder.Services.Configure<CloudStorageOptions>(builder.Configuration.GetSection("CloudStorage"));
 builder.Services.Configure<ClamAvOptions>(builder.Configuration.GetSection("ClamAV"));
 builder.Services.AddOptions<FileAccessOptions>()

--- a/src/Geopilot.PipelineCore/Geopilot.PipelineCore.csproj
+++ b/src/Geopilot.PipelineCore/Geopilot.PipelineCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk" TreatAsLocalProperty="VersionPrefix">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>


### PR DESCRIPTION
- Rename variable in Dockerfile that somehow overwrote versions in PipelineCore, even when it's not passed down or used directly.
- Add property to `Geopilot.PipelineCore.csproj` to exclude VersionPrefix from being overwritten by `dotnet publish`
- Added ability for the factory to parse Plugins as JSON Arrays but also as single string, with multiple items seperated by a comma. This will make maintenance and usability of our hosting a bit easier, since we pass the env via docker compose, which has no clean way to pass an array.
- Update workflows