### PR TITLE
Fix missing downloads after pipeline run

### DIFF
--- a/src/Geopilot.Api/DtoMapperExtensions.cs
+++ b/src/Geopilot.Api/DtoMapperExtensions.cs
@@ -22,10 +22,6 @@ internal static class DtoMapperExtensions
     /// </param>
     public static ProcessingJobResponse ToResponse(this ProcessingJob job, Func<Guid, string, Uri> buildDownloadUrl, PipelineConfig? pipelineConfig = null)
     {
-        var state = job.IsFailed
-            ? ProcessingState.Failed
-            : job.Pipeline?.State ?? ProcessingState.Pending;
-
         var pipelineName = job.Pipeline?.DisplayName
             ?? pipelineConfig?.DisplayName
             ?? new Dictionary<string, string>();
@@ -45,7 +41,7 @@ internal static class DtoMapperExtensions
 
         return new ProcessingJobResponse(
             job.Id,
-            state,
+            job.State,
             job.MandateId,
             pipelineName,
             steps,

--- a/src/Geopilot.Api/Processing/IProcessingJobStore.cs
+++ b/src/Geopilot.Api/Processing/IProcessingJobStore.cs
@@ -46,7 +46,22 @@ public interface IProcessingJobStore
     /// <summary>
     /// Marks the specified job as failed (e.g. cloud preflight failure before a pipeline could be created).
     /// </summary>
+    /// <exception cref="ArgumentException">If no job with the <paramref name="jobId"/> was found.</exception>
+    /// <exception cref="InvalidOperationException">If the job is already in a terminal state.</exception>
     ProcessingJob MarkAsFailed(Guid jobId);
+
+    /// <summary>
+    /// Transitions the job to its terminal state based on the state the pipeline finished in.
+    /// </summary>
+    /// <param name="jobId">The job whose pipeline has finished.</param>
+    /// <param name="pipelineState">
+    /// The terminal state the pipeline ended in. Must be one of <see cref="ProcessingState.Success"/>,
+    /// <see cref="ProcessingState.Failed"/>, or <see cref="ProcessingState.Cancelled"/>.
+    /// </param>
+    /// <exception cref="ArgumentException">If no job with the <paramref name="jobId"/> was found.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">If <paramref name="pipelineState"/> is not a terminal state.</exception>
+    /// <exception cref="InvalidOperationException">If the job is not in <see cref="ProcessingState.Running"/>.</exception>
+    ProcessingJob PipelineFinished(Guid jobId, ProcessingState pipelineState);
 
     /// <summary>
     /// Records the pipeline id the job will run with, so consumers can render step display info before the

--- a/src/Geopilot.Api/Processing/ProcessingJob.cs
+++ b/src/Geopilot.Api/Processing/ProcessingJob.cs
@@ -7,12 +7,6 @@ namespace Geopilot.Api.Processing;
 /// <summary>
 /// Represents a processing job — a pipeline run scoped to one set of uploaded files and an optional mandate.
 /// </summary>
-/// <remarks>
-/// The job's <see cref="ProcessingState"/> is computed from the underlying <see cref="Pipeline"/> if one has
-/// been associated; otherwise it is <see cref="ProcessingState.Pending"/>, or
-/// <see cref="ProcessingState.Failed"/> when <see cref="IsFailed"/> is set (e.g. cloud preflight failure
-/// before a pipeline could be created).
-/// </remarks>
 public record class ProcessingJob(
     Guid Id,
     List<ProcessingJobFile> Files,
@@ -34,7 +28,7 @@ public record class ProcessingJob(
     public string? PipelineId { get; init; }
 
     /// <summary>
-    /// Indicates that the job failed before a pipeline could complete (e.g. cloud preflight failure, security scan).
+    /// The lifecycle state of the job.
     /// </summary>
-    public bool IsFailed { get; init; }
+    public ProcessingState State { get; init; } = ProcessingState.Pending;
 }

--- a/src/Geopilot.Api/Processing/ProcessingJobStore.cs
+++ b/src/Geopilot.Api/Processing/ProcessingJobStore.cs
@@ -69,7 +69,42 @@ public class ProcessingJobStore : IProcessingJobStore
         return jobs.AddOrUpdate(
             jobId,
             id => throw new ArgumentException($"Job with id <{id}> not found.", nameof(jobId)),
-            (id, currentJob) => currentJob with { IsFailed = true });
+            (id, currentJob) =>
+            {
+                if (currentJob.State is not (ProcessingState.Pending or ProcessingState.Running))
+                {
+                    throw new InvalidOperationException(
+                        $"Cannot transition job <{id}> from <{currentJob.State}> to <{ProcessingState.Failed}>.");
+                }
+
+                return currentJob with { State = ProcessingState.Failed };
+            });
+    }
+
+    /// <inheritdoc/>
+    public ProcessingJob PipelineFinished(Guid jobId, ProcessingState pipelineState)
+    {
+        if (pipelineState is not (ProcessingState.Success or ProcessingState.Failed or ProcessingState.Cancelled))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(pipelineState),
+                pipelineState,
+                "Pipeline must have finished in a terminal state.");
+        }
+
+        return jobs.AddOrUpdate(
+            jobId,
+            id => throw new ArgumentException($"Job with id <{id}> not found.", nameof(jobId)),
+            (id, currentJob) =>
+            {
+                if (currentJob.State != ProcessingState.Running)
+                {
+                    throw new InvalidOperationException(
+                        $"Cannot transition job <{id}> from <{currentJob.State}> to <{pipelineState}>.");
+                }
+
+                return currentJob with { State = pipelineState };
+            });
     }
 
     /// <inheritdoc/>
@@ -94,7 +129,13 @@ public class ProcessingJobStore : IProcessingJobStore
             (id, job) =>
             {
                 EnsureJobIsPrePipeline(id, job, "start");
-                return job with { MandateId = mandateId, Pipeline = pipeline, PipelineId = pipeline.Id };
+                return job with
+                {
+                    MandateId = mandateId,
+                    Pipeline = pipeline,
+                    PipelineId = pipeline.Id,
+                    State = ProcessingState.Running,
+                };
             });
 
         pipelineQueue.Writer.TryWrite(pipeline);
@@ -119,7 +160,7 @@ public class ProcessingJobStore : IProcessingJobStore
     {
         if (job.Pipeline != null)
             throw new InvalidOperationException($"Cannot {operation} for job <{jobId}> because a pipeline has already been associated.");
-        if (job.IsFailed)
+        if (job.State == ProcessingState.Failed)
             throw new InvalidOperationException($"Cannot {operation} for job <{jobId}> because the job has been marked as failed.");
     }
 }

--- a/src/Geopilot.Api/Processing/ProcessingRunner.cs
+++ b/src/Geopilot.Api/Processing/ProcessingRunner.cs
@@ -48,6 +48,7 @@ public class ProcessingRunner : BackgroundService
             {
                 var pipelineContext = await pipeline.Run(linkedCts.Token);
                 ExtractPersistentFiles(pipeline, pipelineContext);
+                jobStore.PipelineFinished(pipeline.JobId, pipeline.State);
             }
             catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
             {
@@ -55,6 +56,7 @@ public class ProcessingRunner : BackgroundService
                 // before returning the context, so any partial step results are unreachable for
                 // file extraction here; the pre-timeout files are not persisted.
                 logger.LogError("Pipeline <{Pipeline}> timed out after {Timeout}.", pipeline.Id, processingOptions.JobTimeout);
+                jobStore.PipelineFinished(pipeline.JobId, ProcessingState.Cancelled);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {

--- a/src/Geopilot.Api/Services/PreflightBackgroundService.cs
+++ b/src/Geopilot.Api/Services/PreflightBackgroundService.cs
@@ -58,7 +58,7 @@ public class PreflightBackgroundService : BackgroundService
         var context = scope.ServiceProvider.GetRequiredService<Context>();
 
         var job = jobStore.GetJob(request.JobId);
-        if (job == null || job.Pipeline != null || job.IsFailed)
+        if (job == null || job.Pipeline != null || job.State == ProcessingState.Failed)
         {
             logger.LogWarning("Skipping preflight for job <{JobId}>: job is null, already started, or already failed.", request.JobId);
             return;

--- a/tests/Geopilot.Api.Test/Processing/CloudUploadPollingTest.cs
+++ b/tests/Geopilot.Api.Test/Processing/CloudUploadPollingTest.cs
@@ -84,7 +84,7 @@ public class CloudUploadPollingTest
         var polledJob = processingService.GetJob(jobId);
 
         Assert.IsNotNull(polledJob);
-        Assert.IsFalse(polledJob.IsFailed);
+        Assert.AreNotEqual(ProcessingState.Failed, polledJob.State);
     }
 
     [TestMethod]
@@ -100,7 +100,7 @@ public class CloudUploadPollingTest
         var polledJob = processingService.GetJob(jobId);
 
         Assert.IsNotNull(polledJob);
-        Assert.IsFalse(polledJob.IsFailed);
+        Assert.AreNotEqual(ProcessingState.Failed, polledJob.State);
         Assert.AreEqual(mandate.Id, polledJob.MandateId);
     }
 
@@ -125,7 +125,7 @@ public class CloudUploadPollingTest
         var polledJob = processingService.GetJob(jobId);
 
         Assert.IsNotNull(polledJob);
-        Assert.IsTrue(polledJob.IsFailed);
+        Assert.AreEqual(ProcessingState.Failed, polledJob.State);
     }
 
     [TestMethod]
@@ -146,7 +146,7 @@ public class CloudUploadPollingTest
         var polledJob = processingService.GetJob(jobId);
 
         Assert.IsNotNull(polledJob);
-        Assert.IsTrue(polledJob.IsFailed);
+        Assert.AreEqual(ProcessingState.Failed, polledJob.State);
     }
 
     [TestMethod]
@@ -167,7 +167,7 @@ public class CloudUploadPollingTest
         var polledJob = processingService.GetJob(jobId);
 
         Assert.IsNotNull(polledJob);
-        Assert.IsTrue(polledJob.IsFailed);
+        Assert.AreEqual(ProcessingState.Failed, polledJob.State);
     }
 
     private async Task<(Guid JobId, Mandate Mandate, User User)> CreateAndStartCloudJobAsync()

--- a/tests/Geopilot.Api.Test/Processing/ProcessingJobStoreTest.cs
+++ b/tests/Geopilot.Api.Test/Processing/ProcessingJobStoreTest.cs
@@ -25,7 +25,7 @@ public class ProcessingJobStoreTest
         Assert.HasCount(0, job.Files);
         Assert.AreNotEqual(Guid.Empty, job.Id);
         Assert.IsNull(job.Pipeline);
-        Assert.IsFalse(job.IsFailed);
+        Assert.AreEqual(ProcessingState.Pending, job.State);
     }
 
     [TestMethod]
@@ -116,12 +116,63 @@ public class ProcessingJobStoreTest
     }
 
     [TestMethod]
-    public void MarkAsFailedSetsFlag()
+    public void StartJobSetsStateToRunning()
+    {
+        var job = store.CreateJob();
+        var updated = store.StartJob(job.Id, new Mock<IPipeline>().Object, 1);
+
+        Assert.AreEqual(ProcessingState.Running, updated.State);
+    }
+
+    [TestMethod]
+    [DataRow(ProcessingState.Success)]
+    [DataRow(ProcessingState.Failed)]
+    [DataRow(ProcessingState.Cancelled)]
+    public void PipelineFinishedTransitionsFromRunning(ProcessingState pipelineState)
+    {
+        var job = store.CreateJob();
+        store.StartJob(job.Id, new Mock<IPipeline>().Object, 1);
+        var updated = store.PipelineFinished(job.Id, pipelineState);
+
+        Assert.AreEqual(pipelineState, updated.State);
+    }
+
+    [TestMethod]
+    public void PipelineFinishedThrowsIfNotRunning()
+    {
+        var job = store.CreateJob();
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => store.PipelineFinished(job.Id, ProcessingState.Success));
+    }
+
+    [TestMethod]
+    [DataRow(ProcessingState.Pending)]
+    [DataRow(ProcessingState.Running)]
+    public void PipelineFinishedThrowsIfPipelineStateIsNotTerminal(ProcessingState pipelineState)
+    {
+        var job = store.CreateJob();
+        store.StartJob(job.Id, new Mock<IPipeline>().Object, 1);
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => store.PipelineFinished(job.Id, pipelineState));
+    }
+
+    [TestMethod]
+    public void MarkAsFailedSetsState()
     {
         var job = store.CreateJob();
         var updated = store.MarkAsFailed(job.Id);
 
-        Assert.IsTrue(updated.IsFailed);
+        Assert.AreEqual(ProcessingState.Failed, updated.State);
+    }
+
+    [TestMethod]
+    public void MarkAsFailedThrowsIfAlreadyTerminal()
+    {
+        var job = store.CreateJob();
+        store.StartJob(job.Id, new Mock<IPipeline>().Object, 1);
+        store.PipelineFinished(job.Id, ProcessingState.Success);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => store.MarkAsFailed(job.Id));
     }
 
     [TestMethod]

--- a/tests/Geopilot.Api.Test/Services/PreflightBackgroundServiceTest.cs
+++ b/tests/Geopilot.Api.Test/Services/PreflightBackgroundServiceTest.cs
@@ -140,7 +140,7 @@ public class PreflightBackgroundServiceTest
         cloudOrchestrationServiceMock.Setup(x => x.RunPreflightChecksAsync(jobId))
             .ThrowsAsync(new CloudUploadPreflightException(PreflightFailureReason.IncompleteUpload, "File missing."));
         cloudStorageServiceMock.Setup(x => x.DeletePrefixAsync($"uploads/{jobId}/")).Returns(Task.CompletedTask);
-        jobStoreMock.Setup(x => x.MarkAsFailed(jobId)).Returns(cloudJob with { IsFailed = true });
+        jobStoreMock.Setup(x => x.MarkAsFailed(jobId)).Returns(cloudJob with { State = ProcessingState.Failed });
 
         await service.ProcessRequestAsync(new PreflightRequest(jobId, 1, null));
 
@@ -158,7 +158,7 @@ public class PreflightBackgroundServiceTest
         cloudOrchestrationServiceMock.Setup(x => x.RunPreflightChecksAsync(jobId))
             .ThrowsAsync(new InvalidOperationException("Network timeout"));
         cloudStorageServiceMock.Setup(x => x.DeletePrefixAsync($"uploads/{jobId}/")).Returns(Task.CompletedTask);
-        jobStoreMock.Setup(x => x.MarkAsFailed(jobId)).Returns(cloudJob with { IsFailed = true });
+        jobStoreMock.Setup(x => x.MarkAsFailed(jobId)).Returns(cloudJob with { State = ProcessingState.Failed });
 
         await service.ProcessRequestAsync(new PreflightRequest(jobId, 1, null));
 
@@ -177,7 +177,7 @@ public class PreflightBackgroundServiceTest
             .ThrowsAsync(new CloudUploadPreflightException(PreflightFailureReason.IncompleteUpload, "File missing."));
         cloudStorageServiceMock.Setup(x => x.DeletePrefixAsync($"uploads/{jobId}/"))
             .ThrowsAsync(new InvalidOperationException("Storage unavailable."));
-        jobStoreMock.Setup(x => x.MarkAsFailed(jobId)).Returns(cloudJob with { IsFailed = true });
+        jobStoreMock.Setup(x => x.MarkAsFailed(jobId)).Returns(cloudJob with { State = ProcessingState.Failed });
 
         await service.ProcessRequestAsync(new PreflightRequest(jobId, 1, null));
 
@@ -206,7 +206,7 @@ public class PreflightBackgroundServiceTest
         cloudOrchestrationServiceMock.Setup(x => x.StageFilesLocallyAsync(jobId)).ReturnsAsync(stagedJob);
         mandateServiceMock.Setup(x => x.GetMandateForUser(mandateId, It.Is<User>(u => u.AuthIdentifier == userAuthId))).ReturnsAsync(mandate);
         cloudStorageServiceMock.Setup(x => x.DeletePrefixAsync($"uploads/{jobId}/")).Returns(Task.CompletedTask);
-        jobStoreMock.Setup(x => x.MarkAsFailed(jobId)).Returns(cloudJob with { IsFailed = true });
+        jobStoreMock.Setup(x => x.MarkAsFailed(jobId)).Returns(cloudJob with { State = ProcessingState.Failed });
 
         await service.ProcessRequestAsync(new PreflightRequest(jobId, mandateId, userAuthId));
 


### PR DESCRIPTION
The job state being defined through the pipeline step caused the extraction of pipeline files (i.e. the download files) to happen AFTER the job's state becomes "Success". As soon as every step of the pipeline finishes, the pipeline has the state "Success" and thus the job too. The frontend is polling until the job state is "Success", causing downloads not to show up, because the frontend polled before the files were fully extracted.

This change fixes the problem by giving a ProcessingJob its own state, decoupling it from the pipeline. This state the of the job is set to "Success" by the runner, after the files have been extracted. The frontend then polls that status.

Issue: #687