### PR TITLE
Offer step downloads while the pipeline runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - File upload and processing are now decoupled: uploading files returns an upload id, and a separate request starts the processing job for that upload.
 - Cloud upload (Azure Blob Storage) is now the single upload mechanism; the previous direct multipart upload and the `CloudStorage:Enabled` configuration switch were removed.
 - `GeoWerkstatt.Geopilot.Pipeline` 2.0.0 (breaking): upload files are now passed to `IPipeline.Run` (and `IPipelineFactory.CreatePipeline` no longer takes them) instead of being held on the pipeline instance.
+- Files produced by a pipeline step are now offered for download as soon as that step finishes, instead of only after the whole pipeline completes. Downloads from completed steps also remain available if a later step fails or the job times out.
 - `Pipeline:Plugins` can now be configured via a single comma-separated value (e.g. `Pipeline__Plugins=a.dll,b.dll`) in addition to the existing JSON array form, making it usable as a flat environment variable.
 - Pipeline process inputs are now isolated per step: a process that modifies a file it received no longer affects the original, so other steps consuming the same file are unaffected. Stream reads stay cheap; requesting a local path materializes a private copy.
 

--- a/src/Geopilot.Api/Processing/ProcessingRunner.cs
+++ b/src/Geopilot.Api/Processing/ProcessingRunner.cs
@@ -8,9 +8,11 @@ namespace Geopilot.Api.Processing;
 
 /// <summary>
 /// Background worker that consumes pipelines from the <see cref="IProcessingJobStore.ProcessingQueue"/>
-/// and runs them. After each run, files produced by the pipeline are extracted to disk and split into
-/// <see cref="IPipelineStep.Downloads"/> (user-downloadable) and <see cref="IPipelineStep.DeliveryFiles"/>
-/// (delivery payload) according to each output's <see cref="OutputAction"/> tags.
+/// and runs them. A step's user-downloadable files (<see cref="OutputAction.Download"/>) are extracted to
+/// disk as soon as that step finishes, via <see cref="IPipeline.OnStepCompleted"/>, so the supplier can
+/// download them while later steps still run. Delivery payload files (<see cref="OutputAction.Delivery"/>)
+/// are extracted once, only when the run finished successfully and delivery is allowed. They populate
+/// <see cref="IPipelineStep.Downloads"/> and <see cref="IPipelineStep.DeliveryFiles"/> respectively.
 /// </summary>
 public class ProcessingRunner : BackgroundService
 {
@@ -45,17 +47,33 @@ public class ProcessingRunner : BackgroundService
             using var timeoutCts = new CancellationTokenSource(processingOptions.JobTimeout);
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
 
+            // Persist each step's downloadable files the moment the step finishes, so the supplier can
+            // download them while later steps run (and so they survive a later step failing or timing out).
+            pipeline.OnStepCompleted = (step, stepResult, stepCancellationToken) =>
+            {
+                ExtractStepDownloads(pipeline.JobId, step, stepResult);
+                return Task.CompletedTask;
+            };
+
             try
             {
                 var pipelineContext = await pipeline.Run(workItem.Files, linkedCts.Token);
-                ExtractPersistentFiles(pipeline, pipelineContext);
+
+                // Stage the delivery payload only when the job is actually deliverable — the same gate the
+                // submission endpoint enforces (DeliveryController.Create). This keeps incomplete or
+                // non-deliverable payloads (a failed/aborted pipeline, or a matched delivery restriction)
+                // out of the asset store.
+                if (pipeline.State == ProcessingState.Success && pipeline.Delivery == PipelineDelivery.Allow)
+                    ExtractDeliveryFiles(pipeline, pipelineContext);
+
                 jobStore.PipelineFinished(pipeline.JobId, pipeline.State);
             }
             catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
             {
-                // Pipeline state is already Cancelled (set by the running step). Pipeline.Run threw
-                // before returning the context, so any partial step results are unreachable for
-                // file extraction here; the pre-timeout files are not persisted.
+                // Pipeline state is already Cancelled (set by the running step). Downloads from steps that
+                // completed before the timeout were already persisted by the per-step callback; only the
+                // in-flight step's files are lost, and no delivery files are persisted (delivery is staged
+                // only for a successful, deliverable run).
                 logger.LogError("Pipeline <{Pipeline}> timed out after {Timeout}.", pipeline.Id, processingOptions.JobTimeout);
                 jobStore.PipelineFinished(pipeline.JobId, ProcessingState.Cancelled);
             }
@@ -79,62 +97,78 @@ public class ProcessingRunner : BackgroundService
         });
     }
 
-    private void ExtractPersistentFiles(IPipeline pipeline, PipelineContext context)
+    /// <summary>
+    /// Persists the user-downloadable files (<see cref="OutputAction.Download"/>) produced by a single step the
+    /// moment it finishes and records them on <see cref="IPipelineStep.Downloads"/>. Called once per step via
+    /// <see cref="IPipeline.OnStepCompleted"/>, so a step's downloads become available before later steps run.
+    /// </summary>
+    internal void ExtractStepDownloads(Guid jobId, IPipelineStep step, StepResult stepResult)
+    {
+        using var scope = serviceScopeFactory.CreateScope();
+        var downloadFileStore = scope.ServiceProvider.GetRequiredService<IDownloadFileStore>();
+
+        // Names are deterministic per step so they're readable on disk; collisions within the same
+        // step (rare — same originalFileName twice) get a numeric suffix to avoid silent overwrites.
+        var stepIdPrefix = step.Id.SanitizeFileName();
+        var usedNames = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var output in stepResult.Outputs.Values)
+        {
+            if (!output.Action.Contains(OutputAction.Download))
+                continue;
+
+            foreach (var transferFile in ResolveFiles(output.Data))
+            {
+                var fileName = MakeUniqueStepFileName(stepIdPrefix, transferFile.OriginalFileName, usedNames);
+                CopyTo(downloadFileStore, jobId, fileName, transferFile);
+                step.AddDownload(new PersistedFile(transferFile.OriginalFileName, fileName));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Persists the delivery payload files (<see cref="OutputAction.Delivery"/>) of every completed step to the
+    /// asset store and records them on <see cref="IPipelineStep.DeliveryFiles"/>. Only called for a successfully
+    /// completed, deliverable run (gated in <see cref="ExecuteAsync"/>). Download and delivery names are assigned
+    /// independently; for a file tagged with both actions they coincide except in the rare case of two outputs
+    /// sharing an original file name within one step, which is harmless because the download endpoint serves only
+    /// from the download store.
+    /// </summary>
+    internal void ExtractDeliveryFiles(IPipeline pipeline, PipelineContext context)
     {
         using var scope = serviceScopeFactory.CreateScope();
         var assetFileStore = scope.ServiceProvider.GetRequiredService<IAssetFileStore>();
-        var downloadFileStore = scope.ServiceProvider.GetRequiredService<IDownloadFileStore>();
 
         foreach (var step in pipeline.Steps)
         {
             if (!context.StepResults.TryGetValue(step.Id, out var stepResult))
                 continue;
 
-            // Names are deterministic per step so they're readable on disk; collisions
-            // within the same step (rare — same originalFileName twice) get a numeric
-            // suffix to avoid silent overwrites.
             var stepIdPrefix = step.Id.SanitizeFileName();
             var usedNames = new HashSet<string>(StringComparer.Ordinal);
 
             foreach (var output in stepResult.Outputs.Values)
             {
-                var isDownload = output.Action.Contains(OutputAction.Download);
-                var isDelivery = output.Action.Contains(OutputAction.Delivery);
-                if (!isDownload && !isDelivery)
+                if (!output.Action.Contains(OutputAction.Delivery))
                     continue;
 
-                IEnumerable<IPipelineFile> files = output.Data switch
-                {
-                    IPipelineFileList fileList => fileList.Files,
-                    IPipelineFile[] fileArray => fileArray,
-                    IPipelineFile singleFile => [singleFile],
-                    _ => [],
-                };
-
-                // Both stores are filled independently so each can be cleaned on its own
-                // retention. A file tagged with both actions is written to both under the
-                // same name — the download endpoint can fall back to the asset copy after
-                // the download retention expires.
-                foreach (var transferFile in files)
+                foreach (var transferFile in ResolveFiles(output.Data))
                 {
                     var fileName = MakeUniqueStepFileName(stepIdPrefix, transferFile.OriginalFileName, usedNames);
-                    var persisted = new PersistedFile(transferFile.OriginalFileName, fileName);
-
-                    if (isDelivery)
-                    {
-                        CopyTo(assetFileStore, pipeline.JobId, fileName, transferFile);
-                        step.DeliveryFiles.Add(persisted);
-                    }
-
-                    if (isDownload)
-                    {
-                        CopyTo(downloadFileStore, pipeline.JobId, fileName, transferFile);
-                        step.Downloads.Add(persisted);
-                    }
+                    CopyTo(assetFileStore, pipeline.JobId, fileName, transferFile);
+                    step.AddDeliveryFile(new PersistedFile(transferFile.OriginalFileName, fileName));
                 }
             }
         }
     }
+
+    private static IEnumerable<IPipelineFile> ResolveFiles(object? data) => data switch
+    {
+        IPipelineFileList fileList => fileList.Files,
+        IPipelineFile[] fileArray => fileArray,
+        IPipelineFile singleFile => [singleFile],
+        _ => [],
+    };
 
     private string MakeUniqueStepFileName(string stepIdPrefix, string originalFileName, HashSet<string> usedNames)
     {

--- a/src/Geopilot.Pipeline/IPipeline.cs
+++ b/src/Geopilot.Pipeline/IPipeline.cs
@@ -45,6 +45,14 @@ public interface IPipeline : IDisposable
     Guid JobId { get; }
 
     /// <summary>
+    /// Optional callback invoked by <see cref="Run"/> after each step has finished, in step order, with the
+    /// just-completed step and its <see cref="StepResult"/>. Awaited before the next step runs, so a handler can
+    /// reliably react to a step (e.g. persist its outputs) before the pipeline progresses. <see langword="null"/>
+    /// (the default) disables the callback.
+    /// </summary>
+    Func<IPipelineStep, StepResult, CancellationToken, Task>? OnStepCompleted { get; set; }
+
+    /// <summary>
     /// Runs the pipeline with the specified input files.
     /// </summary>
     /// <param name="files">The files to be processed by the pipeline.</param>

--- a/src/Geopilot.Pipeline/IPipelineStep.cs
+++ b/src/Geopilot.Pipeline/IPipelineStep.cs
@@ -52,19 +52,34 @@ public interface IPipelineStep : IDisposable
     LocalizedText? StatusMessage { get; }
 
     /// <summary>
-    /// Files produced by the step that are available for the user to download (outputs
-    /// configured with <see cref="OutputAction.Download"/>). Populated by the processing runner
-    /// after the step completes. Order matches the order of the step's output configs.
+    /// Files produced by the step that are available for the user to download (outputs configured
+    /// with <see cref="OutputAction.Download"/>). Populated by the processing runner (via
+    /// <see cref="AddDownload"/>) as soon as the step completes, so they can be offered while later
+    /// steps still run. Order matches the order of the step's output configs. Read-only; append via
+    /// <see cref="AddDownload"/>.
     /// </summary>
-    IList<PersistedFile> Downloads { get; }
+    IReadOnlyList<PersistedFile> Downloads { get; }
 
     /// <summary>
-    /// Files produced by the step that should be included in the delivery (outputs configured
-    /// with <see cref="OutputAction.Delivery"/>). Populated by the processing runner after the
-    /// step completes. A file tagged with both <see cref="OutputAction.Download"/> and
-    /// <see cref="OutputAction.Delivery"/> appears in both lists and is persisted only once.
+    /// Files produced by the step that should be included in the delivery (outputs configured with
+    /// <see cref="OutputAction.Delivery"/>). Populated by the processing runner (via
+    /// <see cref="AddDeliveryFile"/>) only after a successful, deliverable run. A file tagged with both
+    /// <see cref="OutputAction.Download"/> and <see cref="OutputAction.Delivery"/> appears in both lists.
+    /// Read-only; append via <see cref="AddDeliveryFile"/>.
     /// </summary>
-    IList<PersistedFile> DeliveryFiles { get; }
+    IReadOnlyList<PersistedFile> DeliveryFiles { get; }
+
+    /// <summary>
+    /// Appends a file to <see cref="Downloads"/>. Safe to call while another thread reads
+    /// <see cref="Downloads"/>; readers observe a consistent snapshot.
+    /// </summary>
+    void AddDownload(PersistedFile file);
+
+    /// <summary>
+    /// Appends a file to <see cref="DeliveryFiles"/>. Safe to call while another thread reads
+    /// <see cref="DeliveryFiles"/>; readers observe a consistent snapshot.
+    /// </summary>
+    void AddDeliveryFile(PersistedFile file);
 
     /// <summary>
     /// Runs the step with the given context.

--- a/src/Geopilot.Pipeline/Pipeline.cs
+++ b/src/Geopilot.Pipeline/Pipeline.cs
@@ -83,6 +83,9 @@ public sealed class Pipeline : IPipeline
     public Guid JobId { get; }
 
     /// <inheritdoc/>
+    public Func<IPipelineStep, StepResult, CancellationToken, Task>? OnStepCompleted { get; set; }
+
+    /// <inheritdoc/>
     public PipelineDelivery Delivery { get; set; } = PipelineDelivery.Allow;
 
     /// <inheritdoc/>
@@ -140,6 +143,9 @@ public sealed class Pipeline : IPipeline
 
                 var stepResult = await step.Run(context, cancellationToken).ConfigureAwait(false);
                 context.StepResults[step.Id] = stepResult;
+
+                if (this.OnStepCompleted is not null)
+                    await this.OnStepCompleted(step, stepResult, cancellationToken).ConfigureAwait(false);
             }
 
             await this.EvaluateDeliveryCondition(context);

--- a/src/Geopilot.Pipeline/PipelineStep.cs
+++ b/src/Geopilot.Pipeline/PipelineStep.cs
@@ -2,6 +2,7 @@
 using Geopilot.PipelineCore.Pipeline;
 using Geopilot.PipelineCore.Pipeline.Process;
 using Microsoft.Extensions.Logging;
+using System.Collections.Immutable;
 using System.Reflection;
 
 namespace Geopilot.Pipeline;
@@ -49,11 +50,22 @@ public sealed class PipelineStep : IPipelineStep
     /// <inheritdoc/>
     public LocalizedText? StatusMessage { get; private set; }
 
-    /// <inheritdoc/>
-    public IList<PersistedFile> Downloads { get; } = new List<PersistedFile>();
+    private ImmutableList<PersistedFile> downloads = ImmutableList<PersistedFile>.Empty;
+    private ImmutableList<PersistedFile> deliveryFiles = ImmutableList<PersistedFile>.Empty;
 
     /// <inheritdoc/>
-    public IList<PersistedFile> DeliveryFiles { get; } = new List<PersistedFile>();
+    public IReadOnlyList<PersistedFile> Downloads => downloads;
+
+    /// <inheritdoc/>
+    public IReadOnlyList<PersistedFile> DeliveryFiles => deliveryFiles;
+
+    /// <inheritdoc/>
+    public void AddDownload(PersistedFile file) =>
+        ImmutableInterlocked.Update(ref downloads, static (list, f) => list.Add(f), file);
+
+    /// <inheritdoc/>
+    public void AddDeliveryFile(PersistedFile file) =>
+        ImmutableInterlocked.Update(ref deliveryFiles, static (list, f) => list.Add(f), file);
 
     private readonly ConditionEvaluator conditionEvaluator;
 

--- a/tests/Geopilot.Api.Test/Processing/ProcessingRunnerTest.cs
+++ b/tests/Geopilot.Api.Test/Processing/ProcessingRunnerTest.cs
@@ -1,0 +1,456 @@
+﻿using Api;
+using Geopilot.Api.FileAccess;
+using Geopilot.Api.Processing;
+using Geopilot.Pipeline;
+using Geopilot.Pipeline.Config;
+using Geopilot.PipelineCore.Pipeline;
+using Geopilot.PipelineCore.Pipeline.Process;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using System.Threading.Channels;
+
+namespace Geopilot.Api.Test.Processing;
+
+[TestClass]
+public class ProcessingRunnerTest
+{
+    private readonly ILogger pipelineLogger = Mock.Of<ILogger>();
+    private readonly List<Guid> createdJobIds = new();
+    private readonly List<string> tempFiles = new();
+
+    private PhysicalDownloadFileStore downloadStore;
+    private PhysicalAssetFileStore assetStore;
+    private IServiceScopeFactory scopeFactory;
+
+    [TestInitialize]
+    public void Initialize()
+    {
+        downloadStore = new PhysicalDownloadFileStore(AssemblyInitialize.TestDirectoryProvider);
+        assetStore = new PhysicalAssetFileStore(AssemblyInitialize.TestDirectoryProvider);
+
+        var serviceProvider = new Mock<IServiceProvider>();
+        serviceProvider.Setup(p => p.GetService(typeof(IDownloadFileStore))).Returns(downloadStore);
+        serviceProvider.Setup(p => p.GetService(typeof(IAssetFileStore))).Returns(assetStore);
+
+        var scope = new Mock<IServiceScope>();
+        scope.SetupGet(s => s.ServiceProvider).Returns(serviceProvider.Object);
+
+        var scopeFactoryMock = new Mock<IServiceScopeFactory>();
+        scopeFactoryMock.Setup(f => f.CreateScope()).Returns(scope.Object);
+        scopeFactory = scopeFactoryMock.Object;
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        foreach (var jobId in createdJobIds)
+        {
+            downloadStore.DeleteJob(jobId);
+            assetStore.DeleteJob(jobId);
+        }
+
+        foreach (var path in tempFiles.Where(File.Exists))
+            File.Delete(path);
+    }
+
+    private sealed class FileEmittingProcess
+    {
+        private readonly string outputKey;
+        private readonly string filePath;
+        private readonly string originalFileName;
+
+        public FileEmittingProcess(string outputKey, string filePath, string originalFileName)
+        {
+            this.outputKey = outputKey;
+            this.filePath = filePath;
+            this.originalFileName = originalFileName;
+        }
+
+        [PipelineProcessRun]
+        public Task<Dictionary<string, object>> RunAsync(CancellationToken cancellationToken)
+            => Task.FromResult(new Dictionary<string, object> { { outputKey, new PipelineFile(filePath, originalFileName) } });
+    }
+
+    private sealed class BlockingProcess
+    {
+        private readonly Task gate;
+
+        public BlockingProcess(Task gate) => this.gate = gate;
+
+        [PipelineProcessRun]
+        public async Task<Dictionary<string, object>> RunAsync(CancellationToken cancellationToken)
+        {
+            await gate.WaitAsync(cancellationToken);
+            return new Dictionary<string, object>();
+        }
+    }
+
+    private sealed class ThrowingProcess
+    {
+        [PipelineProcessRun]
+        public Task<Dictionary<string, object>> RunAsync(CancellationToken cancellationToken)
+            => Task.FromException<Dictionary<string, object>>(new InvalidOperationException("step failed"));
+    }
+
+    [TestMethod]
+    public void ExtractStepDownloadsWritesDownloadFileToDownloadStoreOnly()
+    {
+        var jobId = NewJob();
+        using var runner = CreateRunner(Mock.Of<IProcessingJobStore>());
+        var step = BuildBareStep("step_1");
+        var stepResult = FileStepResult("log", "result.log", "log-content", OutputAction.Download);
+
+        runner.ExtractStepDownloads(jobId, step, stepResult);
+
+        Assert.HasCount(1, step.Downloads);
+        var persisted = step.Downloads[0];
+        Assert.AreEqual("result.log", persisted.OriginalFileName);
+        Assert.AreEqual("step_1_result.log", persisted.PersistedFileName);
+        Assert.IsTrue(downloadStore.Exists(jobId, persisted.PersistedFileName));
+        Assert.IsFalse(assetStore.Exists(jobId, persisted.PersistedFileName), "Download files must not be written to the asset store.");
+        Assert.AreEqual("log-content", File.ReadAllText(downloadStore.GetPath(jobId, persisted.PersistedFileName)));
+    }
+
+    [TestMethod]
+    public void ExtractDeliveryFilesWritesDeliveryFileToAssetStoreOnly()
+    {
+        var jobId = NewJob();
+        using var runner = CreateRunner(Mock.Of<IProcessingJobStore>());
+        var step = BuildBareStep("step_1");
+        var stepResult = FileStepResult("payload", "data.xtf", "delivery-content", OutputAction.Delivery);
+        using var pipeline = BuildPipeline(jobId, step);
+        var context = ContextWith(step, stepResult);
+
+        runner.ExtractDeliveryFiles(pipeline, context);
+
+        Assert.HasCount(1, step.DeliveryFiles);
+        var persisted = step.DeliveryFiles[0];
+        Assert.AreEqual("data.xtf", persisted.OriginalFileName);
+        Assert.AreEqual("step_1_data.xtf", persisted.PersistedFileName);
+        Assert.IsTrue(assetStore.Exists(jobId, persisted.PersistedFileName));
+        Assert.IsFalse(downloadStore.Exists(jobId, persisted.PersistedFileName), "Delivery files must not be written to the download store.");
+        Assert.IsEmpty(step.Downloads);
+    }
+
+    [TestMethod]
+    public void FileTaggedDownloadAndDeliveryIsWrittenToBothStoresUnderTheSameName()
+    {
+        var jobId = NewJob();
+        using var runner = CreateRunner(Mock.Of<IProcessingJobStore>());
+        var step = BuildBareStep("step_1");
+        var stepResult = FileStepResult("out", "report.pdf", "report-content", OutputAction.Download, OutputAction.Delivery);
+        using var pipeline = BuildPipeline(jobId, step);
+        var context = ContextWith(step, stepResult);
+
+        runner.ExtractStepDownloads(jobId, step, stepResult);
+        runner.ExtractDeliveryFiles(pipeline, context);
+
+        Assert.HasCount(1, step.Downloads);
+        Assert.HasCount(1, step.DeliveryFiles);
+        Assert.AreEqual(
+            step.Downloads[0].PersistedFileName,
+            step.DeliveryFiles[0].PersistedFileName,
+            "A file tagged for both actions should be persisted under the same name in both stores.");
+        Assert.IsTrue(downloadStore.Exists(jobId, step.Downloads[0].PersistedFileName));
+        Assert.IsTrue(assetStore.Exists(jobId, step.DeliveryFiles[0].PersistedFileName));
+    }
+
+    [TestMethod]
+    public async Task DownloadFromCompletedStepIsAvailableWhileLaterStepStillRuns()
+    {
+        var jobId = NewJob();
+        var gate = new TaskCompletionSource();
+
+        var step1 = BuildEmittingStep("step_1", "log", "first.log", "first-content", OutputAction.Download);
+        var step2 = BuildBlockingStep("step_2", gate.Task);
+        using var pipeline = BuildPipeline(jobId, step1, step2);
+        var job = new ProcessingJob(jobId, new List<ProcessingJobFile>(), 1, DateTime.UtcNow) { Pipeline = pipeline };
+
+        var (runner, store) = CreateRunnerWithStore(pipeline);
+
+        await runner.StartAsync(CancellationToken.None);
+        try
+        {
+            await WaitUntilAsync(() => step1.Downloads.Count > 0, TimeSpan.FromSeconds(10));
+
+            // Mid-run: step 1's download exists on disk and is exposed via the API, while step 2 has not finished.
+            Assert.AreEqual(StepState.Success, step1.State);
+            Assert.AreNotEqual(StepState.Success, step2.State, "Step 2 must still be running while step 1's download is offered.");
+            Assert.AreEqual(ProcessingState.Running, pipeline.State);
+            store.Verify(s => s.PipelineFinished(It.IsAny<Guid>(), It.IsAny<ProcessingState>()), Times.Never);
+
+            var persistedName = step1.Downloads[0].PersistedFileName;
+            Assert.IsTrue(downloadStore.Exists(jobId, persistedName), "Step 1's download must be on disk before the pipeline finishes.");
+
+            var response = job.ToResponse((id, file) => new Uri($"https://localhost/api/v2/processing/{id}/files/{file}"));
+            Assert.HasCount(1, response.Steps[0].Downloads);
+            Assert.AreEqual("first.log", response.Steps[0].Downloads[0].OriginalFileName);
+
+            gate.SetResult();
+            await runner.ExecuteTask!.WaitAsync(TimeSpan.FromSeconds(10));
+
+            Assert.AreEqual(ProcessingState.Success, pipeline.State);
+            Assert.IsTrue(downloadStore.Exists(jobId, persistedName));
+            store.Verify(s => s.PipelineFinished(jobId, ProcessingState.Success), Times.Once);
+        }
+        finally
+        {
+            gate.TrySetResult();
+            await runner.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [TestMethod]
+    public async Task DownloadFromCompletedStepSurvivesLaterStepFailure()
+    {
+        var jobId = NewJob();
+        var step1 = BuildEmittingStep("step_1", "log", "first.log", "first-content", OutputAction.Download);
+        var step2 = BuildThrowingStep("step_2");
+        using var pipeline = BuildPipeline(jobId, step1, step2);
+
+        var (runner, store) = CreateRunnerWithStore(pipeline);
+
+        await runner.StartAsync(CancellationToken.None);
+        await runner.ExecuteTask!.WaitAsync(TimeSpan.FromSeconds(10));
+        await runner.StopAsync(CancellationToken.None);
+
+        Assert.HasCount(1, step1.Downloads);
+        Assert.IsTrue(downloadStore.Exists(jobId, step1.Downloads[0].PersistedFileName), "Earlier step's download must survive a later step failure.");
+        store.Verify(s => s.MarkAsFailed(jobId), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task DownloadFromCompletedStepSurvivesJobTimeout()
+    {
+        var jobId = NewJob();
+        var gate = new TaskCompletionSource();
+
+        var step1 = BuildEmittingStep("step_1", "log", "first.log", "first-content", OutputAction.Download);
+        var step2 = BuildBlockingStep("step_2", gate.Task);
+        using var pipeline = BuildPipeline(jobId, step1, step2);
+
+        var (runner, store) = CreateRunnerWithStore(pipeline, TimeSpan.FromSeconds(2));
+
+        await runner.StartAsync(CancellationToken.None);
+        try
+        {
+            await runner.ExecuteTask!.WaitAsync(TimeSpan.FromSeconds(20));
+        }
+        finally
+        {
+            gate.TrySetResult();
+            await runner.StopAsync(CancellationToken.None);
+        }
+
+        Assert.HasCount(1, step1.Downloads);
+        Assert.IsTrue(downloadStore.Exists(jobId, step1.Downloads[0].PersistedFileName), "Pre-timeout step's download must survive the job timeout.");
+        store.Verify(s => s.PipelineFinished(jobId, ProcessingState.Cancelled), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task DeliveryFilesAreStagedWhenPipelineSucceedsAndDeliveryAllowed()
+    {
+        var jobId = NewJob();
+        var step = BuildEmittingStep("step_1", "payload", "data.xtf", "delivery-content", OutputAction.Delivery);
+        using var pipeline = BuildPipeline(jobId, step);
+
+        var (runner, store) = CreateRunnerWithStore(pipeline);
+
+        await runner.StartAsync(CancellationToken.None);
+        await runner.ExecuteTask!.WaitAsync(TimeSpan.FromSeconds(10));
+        await runner.StopAsync(CancellationToken.None);
+
+        Assert.AreEqual(ProcessingState.Success, pipeline.State);
+        Assert.HasCount(1, step.DeliveryFiles);
+        Assert.IsTrue(assetStore.Exists(jobId, "step_1_data.xtf"));
+        store.Verify(s => s.PipelineFinished(jobId, ProcessingState.Success), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task DeliveryFilesAreNotStagedWhenAFailConditionAbortsThePipeline()
+    {
+        var jobId = NewJob();
+        var step1 = BuildEmittingStep("step_1", "payload", "data.xtf", "delivery-content", OutputAction.Delivery);
+        var step2 = BuildFailConditionStep("step_2");
+        using var pipeline = BuildPipeline(jobId, step1, step2);
+
+        var (runner, store) = CreateRunnerWithStore(pipeline);
+
+        await runner.StartAsync(CancellationToken.None);
+        await runner.ExecuteTask!.WaitAsync(TimeSpan.FromSeconds(10));
+        await runner.StopAsync(CancellationToken.None);
+
+        Assert.AreEqual(ProcessingState.Failed, pipeline.State);
+        Assert.IsEmpty(step1.DeliveryFiles, "No delivery files may be staged when the pipeline does not complete successfully.");
+        Assert.IsFalse(assetStore.Exists(jobId, "step_1_data.xtf"), "No partial delivery may be written to the asset store on failure.");
+        store.Verify(s => s.PipelineFinished(jobId, ProcessingState.Failed), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task DeliveryFilesAreNotStagedWhenDeliveryIsPrevented()
+    {
+        var jobId = NewJob();
+        var step = BuildEmittingStep("step_1", "payload", "data.xtf", "delivery-content", OutputAction.Delivery);
+        using var pipeline = BuildRestrictedPipeline(jobId, "1 == 1", step);
+
+        var (runner, store) = CreateRunnerWithStore(pipeline);
+
+        await runner.StartAsync(CancellationToken.None);
+        await runner.ExecuteTask!.WaitAsync(TimeSpan.FromSeconds(10));
+        await runner.StopAsync(CancellationToken.None);
+
+        Assert.AreEqual(ProcessingState.Success, pipeline.State);
+        Assert.AreEqual(PipelineDelivery.Prevent, pipeline.Delivery);
+        Assert.IsEmpty(step.DeliveryFiles, "No delivery files may be staged when delivery is prevented by a restriction.");
+        Assert.IsFalse(assetStore.Exists(jobId, "step_1_data.xtf"), "No delivery may be written to the asset store when delivery is prevented.");
+        store.Verify(s => s.PipelineFinished(jobId, ProcessingState.Success), Times.Once);
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (!condition())
+        {
+            if (DateTime.UtcNow > deadline)
+                Assert.Fail("Condition was not met within the timeout.");
+            await Task.Delay(20);
+        }
+    }
+
+    private static PipelineContext ContextWith(PipelineStep step, StepResult stepResult) =>
+        new PipelineContext
+        {
+            Upload = new PipelineFileList(),
+            StepResults = new Dictionary<string, StepResult> { { step.Id, stepResult } },
+        };
+
+    private Guid NewJob()
+    {
+        var jobId = Guid.NewGuid();
+        createdJobIds.Add(jobId);
+        return jobId;
+    }
+
+    private ProcessingRunner CreateRunner(IProcessingJobStore jobStore, TimeSpan? jobTimeout = null) =>
+        new ProcessingRunner(
+            Mock.Of<ILogger<ProcessingRunner>>(),
+            jobStore,
+            scopeFactory,
+            Options.Create(new ProcessingOptions { JobTimeout = jobTimeout ?? TimeSpan.FromMinutes(5) }));
+
+    private (ProcessingRunner Runner, Mock<IProcessingJobStore> Store) CreateRunnerWithStore(IPipeline pipeline, TimeSpan? jobTimeout = null)
+    {
+        var channel = Channel.CreateUnbounded<ProcessingWorkItem>();
+        channel.Writer.TryWrite(new ProcessingWorkItem(pipeline, Mock.Of<IPipelineFileList>()));
+        channel.Writer.Complete();
+
+        var store = new Mock<IProcessingJobStore>();
+        store.SetupGet(s => s.ProcessingQueue).Returns(channel.Reader);
+
+        return (CreateRunner(store.Object, jobTimeout), store);
+    }
+
+    private string WriteTempFile(string content)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"geopilot-test-{Guid.NewGuid()}.tmp");
+        File.WriteAllText(path, content);
+        tempFiles.Add(path);
+        return path;
+    }
+
+    private StepResult FileStepResult(string outputKey, string originalFileName, string content, params OutputAction[] actions) =>
+        new StepResult
+        {
+            Outputs = new Dictionary<string, StepOutput>
+            {
+                { outputKey, new StepOutput { Action = new HashSet<OutputAction>(actions), Data = new PipelineFile(WriteTempFile(content), originalFileName) } },
+            },
+        };
+
+    private PipelineStep BuildBareStep(string id) =>
+        PipelineStep
+            .Builder()
+            .Id(id)
+            .DisplayName(LocalizedText.Empty)
+            .InputConfig([])
+            .OutputConfig([])
+            .Process(new object())
+            .Logger(pipelineLogger)
+            .Build();
+
+    private PipelineStep BuildEmittingStep(string id, string outputKey, string originalFileName, string content, params OutputAction[] actions) =>
+        PipelineStep
+            .Builder()
+            .Id(id)
+            .DisplayName(LocalizedText.Empty)
+            .InputConfig([])
+            .OutputConfig([new OutputConfig { Take = outputKey, As = outputKey, Action = new HashSet<OutputAction>(actions) }])
+            .Process(new FileEmittingProcess(outputKey, WriteTempFile(content), originalFileName))
+            .Logger(pipelineLogger)
+            .Build();
+
+    private PipelineStep BuildBlockingStep(string id, Task gate) =>
+        PipelineStep
+            .Builder()
+            .Id(id)
+            .DisplayName(LocalizedText.Empty)
+            .InputConfig([])
+            .OutputConfig([])
+            .Process(new BlockingProcess(gate))
+            .Logger(pipelineLogger)
+            .Build();
+
+    private PipelineStep BuildThrowingStep(string id) =>
+        PipelineStep
+            .Builder()
+            .Id(id)
+            .DisplayName(LocalizedText.Empty)
+            .InputConfig([])
+            .OutputConfig([])
+            .Process(new ThrowingProcess())
+            .Logger(pipelineLogger)
+            .Build();
+
+    private PipelineStep BuildFailConditionStep(string id) =>
+        PipelineStep
+            .Builder()
+            .Id(id)
+            .DisplayName(LocalizedText.Empty)
+            .InputConfig([])
+            .OutputConfig([])
+            .StepConditions(new PipelineStepConditionsConfig
+            {
+                Pre = new PipelineStepPreConditionConfig
+                {
+                    FailConditions = new List<ConditionConfig> { new ConditionConfig { Expression = "1 == 1" } },
+                },
+            })
+            .Process(new object())
+            .Logger(pipelineLogger)
+            .Build();
+
+    private Geopilot.Pipeline.Pipeline BuildRestrictedPipeline(Guid jobId, string restrictionExpression, params PipelineStep[] steps) =>
+        Geopilot.Pipeline.Pipeline
+            .Builder()
+            .Id("test_pipeline")
+            .DisplayName(LocalizedText.Empty)
+            .Steps(steps.Cast<IPipelineStep>().ToList())
+            .DeliveryRestrictions(new List<ConditionConfig> { new ConditionConfig { Expression = restrictionExpression } })
+            .Logger(pipelineLogger)
+            .PipelineDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()))
+            .JobId(jobId)
+            .Build();
+
+    private Geopilot.Pipeline.Pipeline BuildPipeline(Guid jobId, params PipelineStep[] steps) =>
+        Geopilot.Pipeline.Pipeline
+            .Builder()
+            .Id("test_pipeline")
+            .DisplayName(LocalizedText.Empty)
+            .Steps(steps.Cast<IPipelineStep>().ToList())
+            .Logger(pipelineLogger)
+            .PipelineDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()))
+            .JobId(jobId)
+            .Build();
+}

--- a/tests/Geopilot.Pipeline.Test/PipelineStepTest.cs
+++ b/tests/Geopilot.Pipeline.Test/PipelineStepTest.cs
@@ -1494,6 +1494,85 @@ public class PipelineStepTest
         Assert.IsNull(processMock.NullableData);
     }
 
+    [TestMethod]
+    public void DownloadsReturnsImmutableSnapshotNotAffectedByLaterAdds()
+    {
+        using var step = BuildBareStep();
+
+        step.AddDownload(new PersistedFile("a.txt", "my_step_a.txt"));
+        var snapshot = step.Downloads;
+        step.AddDownload(new PersistedFile("b.txt", "my_step_b.txt"));
+
+        Assert.HasCount(1, snapshot, "A previously read reference must not observe later additions.");
+        Assert.HasCount(2, step.Downloads, "A fresh read must observe all additions.");
+    }
+
+    [TestMethod]
+    public void DeliveryFilesReturnsImmutableSnapshotNotAffectedByLaterAdds()
+    {
+        using var step = BuildBareStep();
+
+        step.AddDeliveryFile(new PersistedFile("a.txt", "my_step_a.txt"));
+        var snapshot = step.DeliveryFiles;
+        step.AddDeliveryFile(new PersistedFile("b.txt", "my_step_b.txt"));
+
+        Assert.HasCount(1, snapshot, "A previously read reference must not observe later additions.");
+        Assert.HasCount(2, step.DeliveryFiles, "A fresh read must observe all additions.");
+    }
+
+    [TestMethod]
+    public void AddDownloadPreservesInsertionOrder()
+    {
+        using var step = BuildBareStep();
+        var a = new PersistedFile("a.txt", "my_step_a.txt");
+        var b = new PersistedFile("b.txt", "my_step_b.txt");
+        var c = new PersistedFile("c.txt", "my_step_c.txt");
+
+        step.AddDownload(a);
+        step.AddDownload(b);
+        step.AddDownload(c);
+
+        CollectionAssert.AreEqual(new[] { a, b, c }, step.Downloads.ToList());
+    }
+
+    [TestMethod]
+    public async Task AddDownloadIsThreadSafeWhileEnumerating()
+    {
+        using var step = BuildBareStep();
+        const int count = 1000;
+
+        var enumerate = Task.Run(() =>
+        {
+            for (var i = 0; i < count; i++)
+            {
+                // Enumerate concurrently with additions; this must never throw.
+                foreach (var file in step.Downloads)
+                    Assert.IsNotNull(file);
+            }
+        });
+
+        var add = Task.Run(() =>
+        {
+            for (var i = 0; i < count; i++)
+                step.AddDownload(new PersistedFile($"f{i}.txt", $"my_step_f{i}.txt"));
+        });
+
+        await Task.WhenAll(enumerate, add);
+
+        Assert.HasCount(count, step.Downloads);
+    }
+
+    private PipelineStep BuildBareStep() =>
+        PipelineStep
+            .Builder()
+            .Id("my_step")
+            .DisplayName(LocalizedText.Empty)
+            .InputConfig([])
+            .OutputConfig([])
+            .Process(new MockPipelineProcessOptionalSingleInput())
+            .Logger(loggerMock.Object)
+            .Build();
+
     private InputConfig NewInputConfig(string from, string take, string asInput)
     {
         return new InputConfig

--- a/tests/Geopilot.Pipeline.Test/PipelineTest.cs
+++ b/tests/Geopilot.Pipeline.Test/PipelineTest.cs
@@ -8,6 +8,7 @@ namespace Geopilot.Pipeline.Test;
 [TestClass]
 public class PipelineTest
 {
+    private readonly IPipelineFileList uploadFiles = Mock.Of<IPipelineFileList>();
     private Mock<ILoggerFactory> loggerFactory;
     private Mock<ILogger<Geopilot.Pipeline.Pipeline>> loggerMock;
 
@@ -242,4 +243,144 @@ public class PipelineTest
         Assert.AreEqual("Erste Einschränkung, Zweite Einschränkung", context.DeliveryRestrictionMessage["de"]);
         Assert.AreEqual("Deuxième restriction", context.DeliveryRestrictionMessage["fr"]);
     }
+
+    [TestMethod]
+    public async Task RunInvokesOnStepCompletedOncePerStepInOrder()
+    {
+        var result1 = new StepResult();
+        var result2 = new StepResult();
+        var step1 = NewMockStep("step_1", result1);
+        var step2 = NewMockStep("step_2", result2);
+
+        var completed = new List<(string Id, StepResult Result)>();
+
+        using var pipeline = BuildPipeline(step1.Object, step2.Object);
+        pipeline.OnStepCompleted = (step, result, cancellationToken) =>
+        {
+            completed.Add((step.Id, result));
+            return Task.CompletedTask;
+        };
+
+        await pipeline.Run(uploadFiles, CancellationToken.None);
+
+        Assert.HasCount(2, completed, "OnStepCompleted should fire once per step.");
+        Assert.AreEqual("step_1", completed[0].Id);
+        Assert.AreSame(result1, completed[0].Result, "First callback should carry the first step's result.");
+        Assert.AreEqual("step_2", completed[1].Id);
+        Assert.AreSame(result2, completed[1].Result, "Second callback should carry the second step's result.");
+    }
+
+    [TestMethod]
+    public async Task RunAwaitsOnStepCompletedBeforeRunningNextStep()
+    {
+        var events = new List<string>();
+        var step1 = NewMockStep("step_1", new StepResult(), () => events.Add("run:step_1"));
+        var step2 = NewMockStep("step_2", new StepResult(), () => events.Add("run:step_2"));
+
+        using var pipeline = BuildPipeline(step1.Object, step2.Object);
+        pipeline.OnStepCompleted = (step, result, cancellationToken) =>
+        {
+            events.Add($"hook:{step.Id}");
+            return Task.CompletedTask;
+        };
+
+        await pipeline.Run(uploadFiles, CancellationToken.None);
+
+        CollectionAssert.AreEqual(
+            new[] { "run:step_1", "hook:step_1", "run:step_2", "hook:step_2" },
+            events,
+            "Each step's callback must complete before the next step runs.");
+    }
+
+    [TestMethod]
+    public async Task RunInvokesOnStepCompletedOnlyForCompletedStepsWhenLaterStepThrows()
+    {
+        var step1 = NewMockStep("step_1", new StepResult());
+        var step2 = new Mock<IPipelineStep>();
+        step2.SetupGet(s => s.Id).Returns("step_2");
+        step2.SetupProperty(s => s.State, StepState.Pending);
+        step2.Setup(s => s.Run(It.IsAny<PipelineContext>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        var completed = new List<string>();
+        using var pipeline = BuildPipeline(step1.Object, step2.Object);
+        pipeline.OnStepCompleted = (step, result, cancellationToken) =>
+        {
+            completed.Add(step.Id);
+            return Task.CompletedTask;
+        };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => pipeline.Run(uploadFiles, CancellationToken.None));
+
+        Assert.HasCount(1, completed);
+        Assert.AreEqual("step_1", completed[0], "The throwing step must not be reported as completed.");
+    }
+
+    [TestMethod]
+    public async Task RunInvokesOnStepCompletedForCompletedStepsWhenCancelled()
+    {
+        using var cts = new CancellationTokenSource();
+        var step1 = NewMockStep("step_1", new StepResult());
+        var step2 = new Mock<IPipelineStep>();
+        step2.SetupGet(s => s.Id).Returns("step_2");
+        step2.SetupProperty(s => s.State, StepState.Pending);
+        step2.Setup(s => s.Run(It.IsAny<PipelineContext>(), It.IsAny<CancellationToken>()))
+            .Returns(() =>
+            {
+                cts.Cancel();
+                return Task.FromException<StepResult>(new OperationCanceledException(cts.Token));
+            });
+
+        var completed = new List<string>();
+        using var pipeline = BuildPipeline(step1.Object, step2.Object);
+        pipeline.OnStepCompleted = (step, result, cancellationToken) =>
+        {
+            completed.Add(step.Id);
+            return Task.CompletedTask;
+        };
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => pipeline.Run(uploadFiles, cts.Token));
+
+        Assert.HasCount(1, completed);
+        Assert.AreEqual("step_1", completed[0], "The cancelled step must not be reported as completed.");
+    }
+
+    [TestMethod]
+    public async Task RunWithoutOnStepCompletedRunsAllSteps()
+    {
+        var step1 = NewMockStep("step_1", new StepResult());
+        var step2 = NewMockStep("step_2", new StepResult());
+
+        using var pipeline = BuildPipeline(step1.Object, step2.Object);
+
+        await pipeline.Run(uploadFiles, CancellationToken.None);
+
+        step1.Verify(s => s.Run(It.IsAny<PipelineContext>(), It.IsAny<CancellationToken>()), Times.Once);
+        step2.Verify(s => s.Run(It.IsAny<PipelineContext>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static Mock<IPipelineStep> NewMockStep(string id, StepResult result, Action? onRun = null)
+    {
+        var step = new Mock<IPipelineStep>();
+        step.SetupGet(s => s.Id).Returns(id);
+        step.SetupProperty(s => s.State, StepState.Pending);
+        step.Setup(s => s.Run(It.IsAny<PipelineContext>(), It.IsAny<CancellationToken>()))
+            .Returns(() =>
+            {
+                onRun?.Invoke();
+                return Task.FromResult(result);
+            });
+        return step;
+    }
+
+    private Geopilot.Pipeline.Pipeline BuildPipeline(params IPipelineStep[] steps) =>
+        Geopilot.Pipeline.Pipeline
+            .Builder()
+            .Id("test_pipeline")
+            .DisplayName(new Dictionary<string, string> { { "de", "test pipeline" } })
+            .Steps(steps.ToList())
+            .Logger(loggerMock.Object)
+            .PipelineDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()))
+            .JobId(Guid.NewGuid())
+            .Build();
 }


### PR DESCRIPTION
Step outputs flagged for download were copied to the download directory only after the whole pipeline finished, forcing the supplier to wait for all later steps. They are now persisted as soon as the producing step completes and stay available even if a later step fails or the job times out.

Delivery payload files are now staged to the asset store only after a successful run with delivery allowed, matching the submission gate. Previously a failed or delivery-restricted run could leave an incomplete partial delivery in the asset store.

Step download and delivery lists are exposed as read-only snapshots so they can be read safely while the runner appends.