### PR TITLE
Flag mandates referencing a removed pipeline

### DIFF
--- a/src/Geopilot.Frontend/cypress/e2e/mandates.cy.js
+++ b/src/Geopilot.Frontend/cypress/e2e/mandates.cy.js
@@ -352,3 +352,72 @@ describe("Mandate tests", () => {
     cy.get("@slowSave.all").should("have.length", 1);
   });
 });
+
+describe("Mandate with a removed pipeline", () => {
+  // A pipeline definition can be changed between restarts: a pipeline a mandate
+  // was configured with may no longer exist. The stored pipelineId then dangles.
+  const ghostPipelineId = "ghost-pipeline";
+  const availablePipelines = {
+    pipelines: [{ id: "valid-pipeline", displayName: { de: "Gültige Pipeline", en: "Valid Pipeline" } }],
+  };
+  const mandateWithGhostPipeline = {
+    id: 9999,
+    name: "Ghost Pipeline Mandate",
+    isPublic: false,
+    allowDelivery: true,
+    fileTypes: [".xml"],
+    coordinates: [
+      { x: 7.3, y: 47.13 },
+      { x: 8.05, y: 47.46 },
+    ],
+    organisations: [],
+    deliveries: [],
+    evaluatePrecursorDelivery: "optional",
+    evaluatePartial: "required",
+    evaluateComment: "notEvaluated",
+    pipelineId: ghostPipelineId,
+  };
+
+  beforeEach(() => {
+    loginAsAdmin();
+    cy.intercept("GET", "/api/v1/pipeline", { statusCode: 200, body: availablePipelines }).as("getPipelines");
+  });
+
+  it("shows the missing pipeline as invalid in the edit form and blocks saving", () => {
+    cy.intercept("GET", "/api/v1/mandate/9999", { statusCode: 200, body: mandateWithGhostPipeline }).as("getMandate");
+
+    cy.visit("/admin/mandates/9999");
+    cy.wait("@getMandate");
+    cy.wait("@getPipelines");
+
+    // The configured-but-missing pipeline must be surfaced, not rendered as a blank "nothing selected".
+    cy.dataCy("pipelineId-formSelect").should("contain", ghostPipelineId);
+
+    // The field must be in an error state so the mandate is flagged as needing correction.
+    hasError("pipelineId", true);
+
+    // Dirtying the form must not enable saving while the pipeline reference is invalid.
+    setInput("name", "Ghost Pipeline Mandate (edited)");
+    cy.dataCy("save-button").should("be.disabled");
+  });
+
+  it("flags a mandate in the overview whose pipeline no longer exists", () => {
+    cy.intercept("GET", "/api/v1/mandate", {
+      statusCode: 200,
+      body: [
+        { ...mandateWithGhostPipeline, id: 9001, name: "Healthy Mandate", pipelineId: "valid-pipeline" },
+        { ...mandateWithGhostPipeline, id: 9002, name: "Ghost Pipeline Mandate" },
+      ],
+    }).as("getMandates");
+
+    cy.visit("/admin/mandates");
+    cy.wait("@getMandates");
+    cy.wait("@getPipelines");
+
+    // A healthy mandate resolves its pipeline to the localised display name.
+    getGridRowThatContains("mandates-grid", "Healthy Mandate").should("contain", "Valid Pipeline");
+
+    // The broken mandate is flagged with the id of the pipeline that no longer exists.
+    getGridRowThatContains("mandates-grid", "Ghost Pipeline Mandate").should("contain", ghostPipelineId);
+  });
+});

--- a/src/Geopilot.Frontend/cypress/e2e/users.cy.js
+++ b/src/Geopilot.Frontend/cypress/e2e/users.cy.js
@@ -29,7 +29,7 @@ describe("Users tests", () => {
 
   it("checks for unsaved changes when navigating and allows editing users", () => {
     getGridRowThatContains("users-grid", "Bobbie Waelchi")
-      .find('[data-field="isAdmin"] [data-value="false"]')
+      .find('[data-field="isAdmin"] [data-testid="CloseIcon"]')
       .should("exist");
     getGridRowThatContains("users-grid", "Bobbie Waelchi").click();
     cy.location().should(location => {
@@ -78,7 +78,7 @@ describe("Users tests", () => {
     isPromptVisible(false);
     getGridRowThatContains("users-grid", "Bobbie Waelchi").contains("Brown and Sons");
     getGridRowThatContains("users-grid", "Bobbie Waelchi")
-      .find('[data-field="isAdmin"] [data-value="true"]')
+      .find('[data-field="isAdmin"] [data-testid="CheckIcon"]')
       .should("exist");
     cy.dataCy("admin-organisations-nav").click();
     getGridRowThatContains("organisations-grid", "Brown and Sons").click();

--- a/src/Geopilot.Frontend/public/locale/de/common.json
+++ b/src/Geopilot.Frontend/public/locale/de/common.json
@@ -98,6 +98,7 @@
   "partialDelivery": "Teillieferung",
   "pipeline": "Pipeline",
   "pipelineLoadingError": "Beim Laden der Pipelines ist ein Fehler aufgetreten: {{error}}",
+  "pipelineNotKnown": "Pipeline '{{pipelineId}}' nicht bekannt",
   "pipelineSteps": "Schritte:",
   "precursor": "Vorgänger",
   "privacyPolicy": "Datenschutz",

--- a/src/Geopilot.Frontend/public/locale/en/common.json
+++ b/src/Geopilot.Frontend/public/locale/en/common.json
@@ -98,6 +98,7 @@
   "partialDelivery": "Partial delivery",
   "pipeline": "Pipeline",
   "pipelineLoadingError": "An error occurred while loading the pipelines: {{error}}",
+  "pipelineNotKnown": "Pipeline '{{pipelineId}}' is unknown",
   "pipelineSteps": "Steps:",
   "precursor": "Precursor",
   "privacyPolicy": "Privacy policy",

--- a/src/Geopilot.Frontend/public/locale/fr/common.json
+++ b/src/Geopilot.Frontend/public/locale/fr/common.json
@@ -98,6 +98,7 @@
   "partialDelivery": "Livraison partielle",
   "pipeline": "Pipeline",
   "pipelineLoadingError": "Une erreur s'est produite lors du chargement des pipelines: {{error}}",
+  "pipelineNotKnown": "Pipeline '{{pipelineId}}' inconnu",
   "pipelineSteps": "Étapes:",
   "precursor": "Prédécesseur",
   "privacyPolicy": "Politique de confidentialité",

--- a/src/Geopilot.Frontend/public/locale/it/common.json
+++ b/src/Geopilot.Frontend/public/locale/it/common.json
@@ -98,6 +98,7 @@
   "partialDelivery": "Consegna parziale",
   "pipeline": "Pipeline",
   "pipelineLoadingError": "Si è verificato un errore durante il caricamento delle pipeline: {{error}}",
+  "pipelineNotKnown": "Pipeline '{{pipelineId}}' sconosciuta",
   "pipelineSteps": "Passaggi:",
   "precursor": "Precursore",
   "privacyPolicy": "Informativa sulla privacy",

--- a/src/Geopilot.Frontend/src/appTheme.ts
+++ b/src/Geopilot.Frontend/src/appTheme.ts
@@ -296,6 +296,18 @@ export const geopilotTheme = createTheme({
         },
       },
     },
+    MuiTooltip: {
+      styleOverrides: {
+        tooltip: {
+          backgroundColor: "#616161",
+          color: "#ffffff",
+          borderRadius: themeSpacing(0.5),
+        },
+        arrow: {
+          color: "#616161",
+        },
+      },
+    },
     MuiChip: {
       styleOverrides: {
         root: {

--- a/src/Geopilot.Frontend/src/components/form/formSelect.tsx
+++ b/src/Geopilot.Frontend/src/components/form/formSelect.tsx
@@ -20,6 +20,7 @@ export interface FormSelectValue {
   key: number;
   value?: number | string;
   name: string;
+  hidden?: boolean;
 }
 
 export interface FormSelectMenuItem {
@@ -27,6 +28,7 @@ export interface FormSelectMenuItem {
   value?: number | string;
   label: string;
   italic?: boolean;
+  hidden?: boolean;
 }
 
 export const FormSelect: FC<FormSelectProps> = ({
@@ -54,6 +56,7 @@ export const FormSelect: FC<FormSelectProps> = ({
         key: value.key,
         value: value.value ?? value.key,
         label: value.name,
+        hidden: value.hidden,
       });
     });
   }
@@ -91,7 +94,9 @@ export const FormSelect: FC<FormSelectProps> = ({
           data-cy={fieldName + "-formSelect"}
           InputLabelProps={{ shrink: true }}>
           {menuItems.map(item => (
-            <MenuItem key={item.key} value={item.value}>
+            // Hidden items stay in the tree so the select can still render their label as the current value,
+            // but are removed from the open dropdown so they cannot be picked.
+            <MenuItem key={item.key} value={item.value} sx={item.hidden ? { display: "none" } : undefined}>
               {item.italic ? <em>{item.label}</em> : item.label}
             </MenuItem>
           ))}

--- a/src/Geopilot.Frontend/src/components/form/formSelect.tsx
+++ b/src/Geopilot.Frontend/src/components/form/formSelect.tsx
@@ -13,6 +13,7 @@ export interface FormSelectProps {
   values?: FormSelectValue[];
   sx?: SxProps;
   onUpdate?: (value: number) => void;
+  validate?: (value: number | string) => boolean | string;
 }
 
 export interface FormSelectValue {
@@ -37,6 +38,7 @@ export const FormSelect: FC<FormSelectProps> = ({
   values,
   sx,
   onUpdate,
+  validate,
 }) => {
   const { t } = useTranslation();
   const { control } = useFormContext();
@@ -63,6 +65,7 @@ export const FormSelect: FC<FormSelectProps> = ({
       defaultValue={selected ?? ""}
       rules={{
         required: required ?? false,
+        validate,
         onChange: e => {
           if (onUpdate) {
             onUpdate(e.target.value);
@@ -74,6 +77,9 @@ export const FormSelect: FC<FormSelectProps> = ({
           select
           required={required ?? false}
           error={getFormFieldError(fieldName, formState.errors)}
+          helperText={
+            formState.errors[fieldName]?.message ? (formState.errors[fieldName]?.message as string) : undefined
+          }
           sx={{ ...sx }}
           label={t(label)}
           name={field.name}

--- a/src/Geopilot.Frontend/src/components/geopilotDataGrid.tsx
+++ b/src/Geopilot.Frontend/src/components/geopilotDataGrid.tsx
@@ -1,10 +1,13 @@
-import { DataGrid, DataGridProps, GridRowSelectionModel } from "@mui/x-data-grid";
-import { FC } from "react";
-import { Box, Stack } from "@mui/material";
+import { DataGrid, DataGridProps, GridColDef, GridRenderCellParams, GridRowSelectionModel } from "@mui/x-data-grid";
+import { FC, useMemo, useRef, useState } from "react";
+import { Box, Stack, Tooltip } from "@mui/material";
 import { styled } from "@mui/system";
 import { BaseButton } from "./buttons.tsx";
 import AddIcon from "@mui/icons-material/Add";
+import CheckIcon from "@mui/icons-material/Check";
+import CloseIcon from "@mui/icons-material/Close";
 import { GridRowId } from "@mui/x-data-grid/models/gridRows";
+import { FlexBox } from "./styledComponents.ts";
 
 interface GeopilotDataGridProps extends DataGridProps {
   name: string;
@@ -18,7 +21,80 @@ const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
   borderColor: theme.palette.primary.light,
 }));
 
+const OverflowTooltipCell: FC<{ text: string }> = ({ text }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+
+  const handleMouseEnter = () => {
+    const node = containerRef.current;
+    if (node && node.scrollWidth > node.clientWidth) {
+      setOpen(true);
+    }
+  };
+  const handleMouseLeave = () => setOpen(false);
+
+  return (
+    <Tooltip
+      title={text}
+      open={open}
+      disableInteractive
+      slotProps={{ popper: { modifiers: [{ name: "offset", options: { offset: [-20, -16] } }] } }}>
+      <Box
+        ref={containerRef}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        sx={{
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+          width: "100%",
+        }}>
+        {text}
+      </Box>
+    </Tooltip>
+  );
+};
+
+const BooleanTooltipCell: FC<{ value: boolean; label: string }> = ({ value, label }) => (
+  <Tooltip title={label} disableInteractive>
+    <FlexBox sx={{ alignItems: "center", justifyContent: "center" }}>
+      {value ? <CheckIcon fontSize="small" aria-label={label} /> : <CloseIcon fontSize="small" aria-label={label} />}
+    </FlexBox>
+  </Tooltip>
+);
+
+// Only inject the tooltip wrapper for plain-text columns and booleans. Other built-in column types
+// (actions, singleSelect, checkboxSelection) ship their own renderers we don't want to clobber.
+const TEXT_COLUMN_TYPES: ReadonlySet<string | undefined> = new Set([undefined, "string"]);
+
+const withCellTooltips = (columns: readonly GridColDef[]): GridColDef[] =>
+  columns.map(column => {
+    if (column.renderCell) {
+      return column;
+    }
+    if (column.type === "boolean") {
+      return {
+        ...column,
+        renderCell: (params: GridRenderCellParams) => (
+          <BooleanTooltipCell value={Boolean(params.value)} label={params.formattedValue?.toString() ?? ""} />
+        ),
+      };
+    }
+    if (!TEXT_COLUMN_TYPES.has(column.type)) {
+      return column;
+    }
+    return {
+      ...column,
+      renderCell: (params: GridRenderCellParams) => {
+        const value = params.formattedValue ?? params.value;
+        const text = value == null ? "" : String(value);
+        return <OverflowTooltipCell text={text} />;
+      },
+    };
+  });
+
 const GeopilotDataGrid: FC<GeopilotDataGridProps> = props => {
+  const tooltipColumns = useMemo(() => withCellTooltips(props.columns), [props.columns]);
   const handleRowSelection = (newRowSelectionModel: GridRowSelectionModel) => {
     if (props.onSelect && newRowSelectionModel.length > 0) {
       props.onSelect(newRowSelectionModel[0]);
@@ -44,6 +120,7 @@ const GeopilotDataGrid: FC<GeopilotDataGridProps> = props => {
         hideFooterSelectedRowCount
         onRowSelectionModelChange={handleRowSelection}
         {...props}
+        columns={tooltipColumns}
       />
     </Stack>
   ) : (
@@ -54,6 +131,7 @@ const GeopilotDataGrid: FC<GeopilotDataGridProps> = props => {
       hideFooterSelectedRowCount
       onRowSelectionModelChange={handleRowSelection}
       {...props}
+      columns={tooltipColumns}
     />
   );
 };

--- a/src/Geopilot.Frontend/src/mui.theme.d.ts
+++ b/src/Geopilot.Frontend/src/mui.theme.d.ts
@@ -52,6 +52,7 @@ declare module "@mui/material/styles" {
     MuiDialogTitle: object;
     MuiDialogContent: object;
     MuiDialogActions: object;
+    MuiTooltip: object;
     MuiChip: object;
     MuiToggleButton: object;
   }
@@ -73,6 +74,7 @@ declare module "@mui/material/styles" {
     MuiDialogTitle: object;
     MuiDialogContent: object;
     MuiDialogActions: object;
+    MuiTooltip: object;
     MuiChip: object;
     MuiToggleButton: object;
   }

--- a/src/Geopilot.Frontend/src/pages/admin/mandates/mandates.tsx
+++ b/src/Geopilot.Frontend/src/pages/admin/mandates/mandates.tsx
@@ -28,9 +28,10 @@ export const Mandates = () => {
   }, [fetchApi]);
 
   const loadPipelines = useCallback(() => {
-    fetchApi<AvailablePipelinesResponse>("/api/v1/pipeline", { errorMessageLabel: "pipelineLoadingError" }).then(
-      response => setPipelines(response?.pipelines ?? []),
-    );
+    fetchApi<AvailablePipelinesResponse>("/api/v1/pipeline", { errorMessageLabel: "pipelineLoadingError" })
+      .then(response => setPipelines(response?.pipelines ?? []))
+      // Resolve to an empty list on error so the loading gate clears instead of spinning forever.
+      .catch(() => setPipelines([]));
   }, [fetchApi]);
 
   const startEditing = (id: GridRowId) => {
@@ -127,11 +128,15 @@ export const Mandates = () => {
     },
   ];
 
+  // Keep the grid in its loading state until the pipelines are loaded as well, otherwise the
+  // pipeline column briefly renders valid pipelines as "unknown" while the list is still fetching.
+  const isGridLoading = isLoading || pipelines === undefined;
+
   return (
     <GeopilotDataGrid
       name="mandates"
       addLabel="addMandate"
-      loading={isLoading}
+      loading={isGridLoading}
       rows={mandates}
       columns={columns}
       onSelect={startEditing}

--- a/src/Geopilot.Frontend/src/pages/admin/mandates/mandates.tsx
+++ b/src/Geopilot.Frontend/src/pages/admin/mandates/mandates.tsx
@@ -1,19 +1,22 @@
 import { useTranslation } from "react-i18next";
 import { useCallback, useEffect, useState } from "react";
-import { Mandate, Organisation } from "../../../api/apiInterfaces";
+import { AvailablePipelinesResponse, Mandate, Organisation, PipelineSummary } from "../../../api/apiInterfaces";
 import { useGeopilotAuth } from "../../../auth";
-import { GridActionsCellItem, GridColDef, GridRowId } from "@mui/x-data-grid";
-import { Tooltip } from "@mui/material";
+import { GridActionsCellItem, GridColDef, GridRenderCellParams, GridRowId } from "@mui/x-data-grid";
+import { Box, Tooltip } from "@mui/material";
 import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import { useControlledNavigate } from "../../../components/controlledNavigate";
 import GeopilotDataGrid from "../../../components/geopilotDataGrid.tsx";
 import useFetch from "../../../hooks/useFetch.ts";
+import { findPipeline, getLocalisedPipelineName } from "./pipelineDisplay";
 
 export const Mandates = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { user } = useGeopilotAuth();
   const { navigateTo } = useControlledNavigate();
   const [mandates, setMandates] = useState<Mandate[]>();
+  const [pipelines, setPipelines] = useState<PipelineSummary[]>();
   const [isLoading, setIsLoading] = useState(true);
   const { fetchApi } = useFetch();
 
@@ -21,6 +24,12 @@ export const Mandates = () => {
     fetchApi<Mandate[]>("/api/v1/mandate", { errorMessageLabel: "mandatesLoadingError" })
       .then(setMandates)
       .finally(() => setIsLoading(false));
+  }, [fetchApi]);
+
+  const loadPipelines = useCallback(() => {
+    fetchApi<AvailablePipelinesResponse>("/api/v1/pipeline", { errorMessageLabel: "pipelineLoadingError" }).then(
+      response => setPipelines(response?.pipelines ?? []),
+    );
   }, [fetchApi]);
 
   const startEditing = (id: GridRowId) => {
@@ -32,8 +41,11 @@ export const Mandates = () => {
       if (mandates === undefined) {
         loadMandates();
       }
+      if (pipelines === undefined) {
+        loadPipelines();
+      }
     }
-  }, [loadMandates, mandates, user?.isAdmin]);
+  }, [loadMandates, loadPipelines, mandates, pipelines, user?.isAdmin]);
 
   const columns: GridColDef[] = [
     {
@@ -41,6 +53,30 @@ export const Mandates = () => {
       headerName: t("name"),
       flex: 0.5,
       minWidth: 200,
+    },
+    {
+      field: "pipelineId",
+      headerName: t("pipeline"),
+      flex: 0.5,
+      minWidth: 200,
+      renderCell: (params: GridRenderCellParams) => {
+        const pipelineId = params.value as string | undefined;
+        if (!pipelineId) {
+          return "";
+        }
+        const pipeline = findPipeline(pipelines, pipelineId);
+        if (pipeline) {
+          return getLocalisedPipelineName(pipeline, i18n.language);
+        }
+        return (
+          <Tooltip title={t("pipelineNotKnown", { pipelineId })}>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, color: "error.main" }}>
+              <ErrorOutlineIcon fontSize="small" />
+              {pipelineId}
+            </Box>
+          </Tooltip>
+        );
+      },
     },
     {
       field: "fileTypes",

--- a/src/Geopilot.Frontend/src/pages/admin/mandates/mandates.tsx
+++ b/src/Geopilot.Frontend/src/pages/admin/mandates/mandates.tsx
@@ -3,13 +3,14 @@ import { useCallback, useEffect, useState } from "react";
 import { AvailablePipelinesResponse, Mandate, Organisation, PipelineSummary } from "../../../api/apiInterfaces";
 import { useGeopilotAuth } from "../../../auth";
 import { GridActionsCellItem, GridColDef, GridRenderCellParams, GridRowId } from "@mui/x-data-grid";
-import { Box, Tooltip } from "@mui/material";
+import { Tooltip } from "@mui/material";
 import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import { useControlledNavigate } from "../../../components/controlledNavigate";
 import GeopilotDataGrid from "../../../components/geopilotDataGrid.tsx";
 import useFetch from "../../../hooks/useFetch.ts";
 import { findPipeline, getLocalisedPipelineName } from "./pipelineDisplay";
+import { FlexRowBox } from "../../../components/styledComponents.ts";
 
 export const Mandates = () => {
   const { t, i18n } = useTranslation();
@@ -69,11 +70,13 @@ export const Mandates = () => {
           return getLocalisedPipelineName(pipeline, i18n.language);
         }
         return (
-          <Tooltip title={t("pipelineNotKnown", { pipelineId })}>
-            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, color: "error.main" }}>
+          <Tooltip
+            title={t("pipelineNotKnown", { pipelineId })}
+            slotProps={{ popper: { modifiers: [{ name: "offset", options: { offset: [-20, -16] } }] } }}>
+            <FlexRowBox sx={{ alignItems: "center", gap: 0.5, color: "error.main" }}>
               <ErrorOutlineIcon fontSize="small" />
               {pipelineId}
-            </Box>
+            </FlexRowBox>
           </Tooltip>
         );
       },

--- a/src/Geopilot.Frontend/src/pages/admin/mandates/mandates.tsx
+++ b/src/Geopilot.Frontend/src/pages/admin/mandates/mandates.tsx
@@ -126,9 +126,6 @@ export const Mandates = () => {
     },
   ];
 
-  // Derive loading from the data instead of a separate flag: keep the overlay until both mandates
-  // and pipelines are present, so the pipeline column never briefly renders valid pipelines as
-  // "unknown". Both loaders fall back to [] on error so this still resolves.
   const isGridLoading = mandates === undefined || pipelines === undefined;
 
   return (

--- a/src/Geopilot.Frontend/src/pages/admin/mandates/mandates.tsx
+++ b/src/Geopilot.Frontend/src/pages/admin/mandates/mandates.tsx
@@ -18,19 +18,17 @@ export const Mandates = () => {
   const { navigateTo } = useControlledNavigate();
   const [mandates, setMandates] = useState<Mandate[]>();
   const [pipelines, setPipelines] = useState<PipelineSummary[]>();
-  const [isLoading, setIsLoading] = useState(true);
   const { fetchApi } = useFetch();
 
   const loadMandates = useCallback(() => {
     fetchApi<Mandate[]>("/api/v1/mandate", { errorMessageLabel: "mandatesLoadingError" })
       .then(setMandates)
-      .finally(() => setIsLoading(false));
+      .catch(() => setMandates([]));
   }, [fetchApi]);
 
   const loadPipelines = useCallback(() => {
     fetchApi<AvailablePipelinesResponse>("/api/v1/pipeline", { errorMessageLabel: "pipelineLoadingError" })
       .then(response => setPipelines(response?.pipelines ?? []))
-      // Resolve to an empty list on error so the loading gate clears instead of spinning forever.
       .catch(() => setPipelines([]));
   }, [fetchApi]);
 
@@ -128,9 +126,10 @@ export const Mandates = () => {
     },
   ];
 
-  // Keep the grid in its loading state until the pipelines are loaded as well, otherwise the
-  // pipeline column briefly renders valid pipelines as "unknown" while the list is still fetching.
-  const isGridLoading = isLoading || pipelines === undefined;
+  // Derive loading from the data instead of a separate flag: keep the overlay until both mandates
+  // and pipelines are present, so the pipeline column never briefly renders valid pipelines as
+  // "unknown". Both loaders fall back to [] on error so this still resolves.
+  const isGridLoading = mandates === undefined || pipelines === undefined;
 
   return (
     <GeopilotDataGrid

--- a/src/Geopilot.Frontend/src/pages/admin/mandates/pipelineDisplay.ts
+++ b/src/Geopilot.Frontend/src/pages/admin/mandates/pipelineDisplay.ts
@@ -1,0 +1,17 @@
+import { PipelineSummary } from "../../../api/apiInterfaces";
+
+/**
+ * Finds a pipeline by its id. Returns undefined when the id is unset or no longer part of the available
+ * pipelines, which is how a mandate referencing a removed pipeline is detected.
+ */
+export const findPipeline = (
+  pipelines: PipelineSummary[] | undefined,
+  id: string | undefined,
+): PipelineSummary | undefined => (id === undefined ? undefined : pipelines?.find(pipeline => pipeline.id === id));
+
+/**
+ * Resolves the display name of a pipeline for the active language, falling back to German and finally to
+ * the raw id when no localised name is available.
+ */
+export const getLocalisedPipelineName = (pipeline: PipelineSummary, language: string): string =>
+  pipeline.displayName?.[language] || pipeline.displayName?.["de"] || pipeline.id;

--- a/src/Geopilot.Frontend/src/pages/admin/mandates/pipelineFormSelect.tsx
+++ b/src/Geopilot.Frontend/src/pages/admin/mandates/pipelineFormSelect.tsx
@@ -1,42 +1,53 @@
-import { FC } from "react";
+import { FC, useEffect } from "react";
 import { PipelineSummary } from "../../../api/apiInterfaces";
 import { FormSelect } from "../../../components/form/form";
 import { FormSelectValue } from "../../../components/form/formSelect";
+import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { findPipeline, getLocalisedPipelineName } from "./pipelineDisplay";
 
 interface PipelineFormSelectProps {
   pipelines?: PipelineSummary[];
   selected?: string;
 }
 
-const getLocalisedPipelineName = (pipeline: PipelineSummary, language: string): string => {
-  return pipeline.displayName?.[language] || pipeline.displayName?.["de"] || pipeline.id;
-};
-
 const getPipelineSelectMenuItems = (
-  pipelines?: PipelineSummary[],
-  language?: string,
-  t?: (key: string) => string,
-): FormSelectValue[] => {
-  return (
-    pipelines?.map((pipeline, idx) => ({
-      key: idx,
-      value: pipeline.id,
-      name: `${getLocalisedPipelineName(pipeline, language ?? "de")} (${t ? t("id") : "ID"}: ${pipeline.id})`,
-    })) ?? []
-  );
-};
+  pipelines: PipelineSummary[] | undefined,
+  language: string,
+  t: (key: string) => string,
+): FormSelectValue[] =>
+  pipelines?.map((pipeline, idx) => ({
+    key: idx,
+    value: pipeline.id,
+    name: `${getLocalisedPipelineName(pipeline, language)} (${t("id")}: ${pipeline.id})`,
+  })) ?? [];
 
 export const PipelineFormSelect: FC<PipelineFormSelectProps> = ({ pipelines, selected }) => {
   const { t, i18n } = useTranslation();
+  const { trigger } = useFormContext();
+
+  // The pipeline a mandate was configured with may have been removed from the definition. Re-validate once
+  // the available pipelines are known so a now-missing reference is flagged on load, not only on submit.
+  useEffect(() => {
+    if (pipelines !== undefined && selected) {
+      trigger("pipelineId");
+    }
+  }, [pipelines, selected, trigger]);
+
+  const menuItems = getPipelineSelectMenuItems(pipelines, i18n.language, t);
 
   return (
     <FormSelect
       fieldName={"pipelineId"}
       label={"pipeline"}
       required={true}
-      values={getPipelineSelectMenuItems(pipelines, i18n.language, t)}
+      values={menuItems}
       selected={selected}
+      validate={value =>
+        !value || pipelines === undefined || findPipeline(pipelines, value as string) !== undefined
+          ? true
+          : t("pipelineNotKnown", { pipelineId: value })
+      }
     />
   );
 };

--- a/src/Geopilot.Frontend/src/pages/admin/mandates/pipelineFormSelect.tsx
+++ b/src/Geopilot.Frontend/src/pages/admin/mandates/pipelineFormSelect.tsx
@@ -13,14 +13,29 @@ interface PipelineFormSelectProps {
 
 const getPipelineSelectMenuItems = (
   pipelines: PipelineSummary[] | undefined,
+  selected: string | undefined,
   language: string,
   t: (key: string) => string,
-): FormSelectValue[] =>
-  pipelines?.map((pipeline, idx) => ({
-    key: idx,
-    value: pipeline.id,
-    name: `${getLocalisedPipelineName(pipeline, language)} (${t("id")}: ${pipeline.id})`,
-  })) ?? [];
+): FormSelectValue[] => {
+  const items: FormSelectValue[] =
+    pipelines?.map((pipeline, idx) => {
+      const localisedName = getLocalisedPipelineName(pipeline, language);
+      return {
+        key: idx,
+        value: pipeline.id,
+        name: localisedName === pipeline.id ? pipeline.id : `${localisedName} (${t("id")}: ${pipeline.id})`,
+      };
+    }) ?? [];
+
+  // A mandate may reference a pipeline that was removed from the definition. Keep its id as the current
+  // value so the user sees what is configured, but hide it from the dropdown options. It stays out of the
+  // available pipelines, so validation still flags it as unknown.
+  if (selected && pipelines !== undefined && findPipeline(pipelines, selected) === undefined) {
+    items.push({ key: items.length, value: selected, name: selected, hidden: true });
+  }
+
+  return items;
+};
 
 export const PipelineFormSelect: FC<PipelineFormSelectProps> = ({ pipelines, selected }) => {
   const { t, i18n } = useTranslation();
@@ -34,7 +49,7 @@ export const PipelineFormSelect: FC<PipelineFormSelectProps> = ({ pipelines, sel
     }
   }, [pipelines, selected, trigger]);
 
-  const menuItems = getPipelineSelectMenuItems(pipelines, i18n.language, t);
+  const menuItems = getPipelineSelectMenuItems(pipelines, selected, i18n.language, t);
 
   return (
     <FormSelect


### PR DESCRIPTION
A mandate stores the id of the pipeline it runs with. When that pipeline is removed from the definition the reference becomes orphaned, and the admin UI gave no hint: the mandate list showed nothing for it and the edit form's pipeline field rendered blank, as if no pipeline was configured.

The mandate list now shows the configured pipeline and marks a missing one with a warning. The edit form surfaces the removed pipeline as a disabled option so the stored value stays visible, and validates the field so a mandate cannot be saved with a pipeline that no longer exists.