### PR TITLE
Fix development profile for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Für die Formattierung wird ESLint verwendet. Dazu im Visual Studio unter `Optio
 - Damit die Applikation mit HTTPS funktioniert, muss ein lokales dev-cert erstellt werden. Dieses wird durch das npm Script `predev` vor dem Start automatisch erstellt. Sollte dies nicht funktionieren, kann mit folgendem Befehl ein Zertifikat manuell erstellt und vertraut werden: `dotnet dev-certs https --trust`. HTTPS muss verwendet werden, damit die STAC-Urls korrekt funktionieren und so der STAC-Browser wie in einer produktiven Umgebung verwendet werden kann.
 
 - Das Projekt kann mit dem Launch Profile "Development" gestartet werden.
+  
+  ℹ️ Beim Start hält Visual Studio im Frontend wegen Fetch-Errors, während die API selbst noch am starten ist. Das kann in Visual Studio über `Debug → Windows → Exception Settings → JavaScript Exceptions → Uncaught Exceptions` deaktiviert werden.
 
 ### Starten der Applikation (Docker Compose) 🐳
 

--- a/src/Geopilot.Frontend/.vscode/launch.json
+++ b/src/Geopilot.Frontend/.vscode/launch.json
@@ -6,14 +6,18 @@
       "request": "launch",
       "name": "localhost (Edge)",
       "url": "https://localhost:5173",
-      "webRoot": "${workspaceFolder}"
+      "webRoot": "${workspaceFolder}",
+      "resolveSourceMapLocations": ["${workspaceFolder}/src/**", "!**/node_modules/**"],
+      "skipFiles": ["${workspaceFolder}/node_modules/**"]
     },
     {
       "type": "chrome",
       "request": "launch",
       "name": "localhost (Chrome)",
       "url": "https://localhost:5173",
-      "webRoot": "${workspaceFolder}"
+      "webRoot": "${workspaceFolder}",
+      "resolveSourceMapLocations": ["${workspaceFolder}/src/**", "!**/node_modules/**"],
+      "skipFiles": ["${workspaceFolder}/node_modules/**"]
     }
   ]
 }


### PR DESCRIPTION
The profile "Development" to run the application locally from Visual Studio caused the debugger to create a source map for every single JavaScript of every Node dependency. This resulted in a very slow startup and an extremely laggy Visual Studio while debugging. This change tells the debugger to not create a source map for the node_modules, fixing the issue.

The "Development" profile should now be the usable again and it should start the entire app, including all necessary Docker containers, the API and the frontend.