### PR TITLE
Reword start page heading to processing

### DIFF
--- a/src/Geopilot.Frontend/public/locale/de/common.json
+++ b/src/Geopilot.Frontend/public/locale/de/common.json
@@ -44,7 +44,7 @@
   "deliveryOverviewDeleteIdNotExistError": "Die Lieferung mit der ID {{id}} existiert nicht und kann daher nicht gelöscht werden.",
   "deliveryOverviewLoadingError": "Beim Laden der Lieferungen ist ein Fehler aufgetreten: {{error}}",
   "deliveryPossible": "Lieferung möglich",
-  "deliveryTitle": "Online Validierung & Lieferung von Geodaten",
+  "deliveryTitle": "Online Verarbeitung von Geodaten",
   "description": "Beschreibung",
   "development": "Entwicklung",
   "disconnect": "Verbindungen trennen",

--- a/src/Geopilot.Frontend/public/locale/en/common.json
+++ b/src/Geopilot.Frontend/public/locale/en/common.json
@@ -44,7 +44,7 @@
   "deliveryOverviewDeleteIdNotExistError": "The delivery with the ID {{id}} does not exist and therefore cannot be deleted.",
   "deliveryOverviewLoadingError": "An error occurred while loading the deliveries: {{error}}",
   "deliveryPossible": "Delivery possible",
-  "deliveryTitle": "Online validation & delivery of geodata",
+  "deliveryTitle": "Online processing of geodata",
   "description": "Description",
   "development": "Development",
   "disconnect": "Disconnect",

--- a/src/Geopilot.Frontend/public/locale/fr/common.json
+++ b/src/Geopilot.Frontend/public/locale/fr/common.json
@@ -44,7 +44,7 @@
   "deliveryOverviewDeleteIdNotExistError": "La livraison avec l'ID {{id}} n'existe pas et ne peut donc pas être supprimée.",
   "deliveryOverviewLoadingError": "Une erreur s'est produite lors du chargement des livraisons: {{error}}",
   "deliveryPossible": "Livraison possible",
-  "deliveryTitle": "Validation en ligne et livraison de géodonnées",
+  "deliveryTitle": "Traitement en ligne de géodonnées",
   "description": "Description",
   "development": "Développement",
   "disconnect": "Déconnecter",

--- a/src/Geopilot.Frontend/public/locale/it/common.json
+++ b/src/Geopilot.Frontend/public/locale/it/common.json
@@ -44,7 +44,7 @@
   "deliveryOverviewDeleteIdNotExistError": "La consegna con ID {{id}} non esiste e non può essere eliminata.",
   "deliveryOverviewLoadingError": "Si è verificato un errore durante il caricamento delle consegne: {{error}}",
   "deliveryPossible": "Consegna possibile",
-  "deliveryTitle": "Validazione online e consegna di dati geografici",
+  "deliveryTitle": "Elaborazione online di dati geografici",
   "description": "Descrizione",
   "development": "Sviluppo",
   "disconnect": "Disconnessione",


### PR DESCRIPTION
Validation is now one of several processing options and delivery is optional, so the previous "validation & delivery" heading no longer fits (some environments allow no delivery at all).