### PR TITLE
Configuration to restrict users from deleting uploaded deliveries 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Admins can activate and deactivate users.
 - Strict Content-Security-Policy with a per-request nonce for the application and STAC Browser.
 - `IPipelineFile.GetLocalPath()` and `IPipelineFileManager.CreateWritableCopy(...)` in the PipelineCore API, letting a process hand a file to external tools by path and obtain an owned, writable copy without copying it by hand.
-- Users can view and delete their own uploaded deliveries when logged in.
+- Users can view and delete their own uploaded deliveries when logged in. The permission to delete deliveries can be configured to be disabled for all users or restricted to a time duration or interval.
 
 ### Changed
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,6 +117,9 @@ services:
       ClamAV__Host: clamav
       ClamAV__Port: 3310
       Pipeline__Definition: /pipelines/pipelines.yaml
+      Delivery__UploaderDeleteEnabled: true
+      Delivery__DeleteDuration: ""
+      Delivery__DeleteRestrictInterval: ""
       PUID: 1000
       PGID: 1000
     volumes:

--- a/src/Geopilot.Api/ContextExtensions.cs
+++ b/src/Geopilot.Api/ContextExtensions.cs
@@ -175,7 +175,8 @@ internal static class ContextExtensions
             .RuleFor(d => d.Partial, f => f.Random.Bool())
             .RuleFor(d => d.PrecursorDelivery, f => f.PickRandom(context.Deliveries.ToList().Append(null)))
             .RuleFor(d => d.Comment, f => f.Rant.Review())
-            .RuleFor(d => d.Deleted, false);
+            .RuleFor(d => d.Deleted, false)
+            .Ignore(d => d.CanDelete);
 
         Delivery SeedDelivery(int seed) => deliveryFaker.UseSeed(seed).Generate();
         for (int i = 0; i < 20; i++)

--- a/src/Geopilot.Api/Controllers/DeliveryController.cs
+++ b/src/Geopilot.Api/Controllers/DeliveryController.cs
@@ -7,6 +7,7 @@ using Geopilot.Pipeline;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.Annotations;
 using System.Globalization;
 
@@ -23,16 +24,18 @@ public class DeliveryController : ControllerBase
     private readonly Context context;
     private readonly IProcessingService processingService;
     private readonly IAssetHandler assetHandler;
+    private readonly IOptions<DeliveryOptions> deliveryOptions;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DeliveryController"/> class.
     /// </summary>
-    public DeliveryController(ILogger<DeliveryController> logger, Context context, IProcessingService processingService, IAssetHandler assetHandler)
+    public DeliveryController(ILogger<DeliveryController> logger, Context context, IProcessingService processingService, IAssetHandler assetHandler, IOptions<DeliveryOptions> deliveryOptions)
     {
         this.logger = logger;
         this.context = context;
         this.processingService = processingService;
         this.assetHandler = assetHandler;
+        this.deliveryOptions = deliveryOptions;
     }
 
     /// <summary>
@@ -226,6 +229,7 @@ public class DeliveryController : ControllerBase
     [Authorize(Policy = GeopilotPolicies.User)]
     [SwaggerResponse(StatusCodes.Status200OK, "The delivery was successfully deleted.")]
     [SwaggerResponse(StatusCodes.Status400BadRequest, "The server cannot process the request due to invalid or malformed request.", typeof(ValidationProblemDetails), "application/json")]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "The user is not allowed to delete the delivery. This can mean delete is disabled for uploaders or the time to delete has expired.")]
     [SwaggerResponse(StatusCodes.Status404NotFound, "The delivery could not be found.")]
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "The server encountered an unexpected condition that prevented it from fulfilling the request. Likely there was an error deleting the assets.", typeof(ProblemDetails), "application/json")]
     public async Task<IActionResult> Delete([FromRoute] int deliveryId)
@@ -246,6 +250,12 @@ public class DeliveryController : ControllerBase
             {
                 logger.LogTrace("No delivery with id <{DeliveryId}> found.", deliveryId);
                 return NotFound($"No delivery with id <{deliveryId}> found.");
+            }
+
+            if (!user.IsAdmin && !IsDeleteAllowedForUploader(delivery, DateTime.UtcNow))
+            {
+                logger.LogTrace("Delete of delivery with id <{DeliveryId}> not allowed for uploader <{UserId}>.", deliveryId, user.AuthIdentifier);
+                return Forbid($"Deleting delivery with id <{deliveryId}> is not allowed.");
             }
 
             delivery.Deleted = true;
@@ -299,5 +309,26 @@ public class DeliveryController : ControllerBase
             logger.LogError(e, "Error while accessing delivery asset with id <{AssetId}>.", assetId);
             return Problem($"Error while accessing delivery asset with id <{assetId}>.");
         }
+    }
+
+    internal bool IsDeleteAllowedForUploader(Delivery delivery, DateTime now)
+    {
+        var options = deliveryOptions.Value;
+        if (!options.UploaderDeleteEnabled)
+        {
+            return false;
+        }
+
+        if (options.DeleteDuration is TimeSpan deleteDuration && deleteDuration <= now - delivery.Date)
+        {
+            return false;
+        }
+
+        if (options.DeleteRestrictIntervalExpression?.GetNextOccurrence(delivery.Date) is DateTime nextOccurrence && nextOccurrence <= now)
+        {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Geopilot.Api/Controllers/DeliveryController.cs
+++ b/src/Geopilot.Api/Controllers/DeliveryController.cs
@@ -218,6 +218,11 @@ public class DeliveryController : ControllerBase
             .Where(d => d.DeclaringUser.Id == user.Id)
             .ToListAsync();
 
+        foreach (var delivery in result)
+        {
+            delivery.CanDelete = IsDeleteAllowedForUploader(delivery, DateTime.UtcNow);
+        }
+
         return Ok(result);
     }
 

--- a/src/Geopilot.Api/Controllers/DeliveryController.cs
+++ b/src/Geopilot.Api/Controllers/DeliveryController.cs
@@ -234,7 +234,7 @@ public class DeliveryController : ControllerBase
     [Authorize(Policy = GeopilotPolicies.User)]
     [SwaggerResponse(StatusCodes.Status200OK, "The delivery was successfully deleted.")]
     [SwaggerResponse(StatusCodes.Status400BadRequest, "The server cannot process the request due to invalid or malformed request.", typeof(ValidationProblemDetails), "application/json")]
-    [SwaggerResponse(StatusCodes.Status403Forbidden, "The user is not allowed to delete the delivery. This can mean delete is disabled for uploaders or the time to delete has expired.")]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "The user is not allowed to delete the delivery. This can mean delete is disabled for uploaders or the time to delete has expired.", typeof(ProblemDetails), "application/json")]
     [SwaggerResponse(StatusCodes.Status404NotFound, "The delivery could not be found.")]
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "The server encountered an unexpected condition that prevented it from fulfilling the request. Likely there was an error deleting the assets.", typeof(ProblemDetails), "application/json")]
     public async Task<IActionResult> Delete([FromRoute] int deliveryId)
@@ -260,7 +260,7 @@ public class DeliveryController : ControllerBase
             if (!user.IsAdmin && !IsDeleteAllowedForUploader(delivery, DateTime.UtcNow))
             {
                 logger.LogTrace("Delete of delivery with id <{DeliveryId}> not allowed for uploader <{UserId}>.", deliveryId, user.AuthIdentifier);
-                return Forbid($"Deleting delivery with id <{deliveryId}> is not allowed.");
+                return Problem($"Deleting delivery with id <{deliveryId}> is not allowed.", statusCode: StatusCodes.Status403Forbidden);
             }
 
             delivery.Deleted = true;

--- a/src/Geopilot.Api/Controllers/DeliveryController.cs
+++ b/src/Geopilot.Api/Controllers/DeliveryController.cs
@@ -220,7 +220,7 @@ public class DeliveryController : ControllerBase
 
         foreach (var delivery in result)
         {
-            delivery.CanDelete = IsDeleteAllowedForUploader(delivery, DateTime.UtcNow);
+            delivery.CanDelete = IsDeleteAllowedForUploader(delivery);
         }
 
         return Ok(result);
@@ -257,7 +257,7 @@ public class DeliveryController : ControllerBase
                 return NotFound($"No delivery with id <{deliveryId}> found.");
             }
 
-            if (!user.IsAdmin && !IsDeleteAllowedForUploader(delivery, DateTime.UtcNow))
+            if (!user.IsAdmin && !IsDeleteAllowedForUploader(delivery))
             {
                 logger.LogTrace("Delete of delivery with id <{DeliveryId}> not allowed for uploader <{UserId}>.", deliveryId, user.AuthIdentifier);
                 return Problem($"Deleting delivery with id <{deliveryId}> is not allowed.", statusCode: StatusCodes.Status403Forbidden);
@@ -316,7 +316,7 @@ public class DeliveryController : ControllerBase
         }
     }
 
-    internal bool IsDeleteAllowedForUploader(Delivery delivery, DateTime now)
+    internal bool IsDeleteAllowedForUploader(Delivery delivery, DateTime? utcNow = null)
     {
         var options = deliveryOptions.Value;
         if (!options.UploaderDeleteEnabled)
@@ -324,12 +324,21 @@ public class DeliveryController : ControllerBase
             return false;
         }
 
-        if (options.DeleteDuration is TimeSpan deleteDuration && deleteDuration <= now - delivery.Date)
+        utcNow ??= DateTime.UtcNow;
+
+        var deliveryDateUtc = delivery.Date.Kind switch
+        {
+            DateTimeKind.Utc => delivery.Date,
+            DateTimeKind.Local => delivery.Date.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(delivery.Date, DateTimeKind.Utc),
+        };
+
+        if (options.DeleteDuration is TimeSpan deleteDuration && deleteDuration <= utcNow - deliveryDateUtc)
         {
             return false;
         }
 
-        if (options.DeleteRestrictIntervalExpression?.GetNextOccurrence(delivery.Date) is DateTime nextOccurrence && nextOccurrence <= now)
+        if (options.DeleteRestrictIntervalExpression?.GetNextOccurrence(deliveryDateUtc) is DateTime nextOccurrence && nextOccurrence <= utcNow)
         {
             return false;
         }

--- a/src/Geopilot.Api/DeliveryOptions.cs
+++ b/src/Geopilot.Api/DeliveryOptions.cs
@@ -25,7 +25,7 @@ public class DeliveryOptions
     public string? DeleteRestrictInterval
     {
         get => DeleteRestrictIntervalExpression?.ToString();
-        set => DeleteRestrictIntervalExpression = value == null ? null : CronExpression.Parse(value);
+        set => DeleteRestrictIntervalExpression = string.IsNullOrEmpty(value) ? null : CronExpression.Parse(value);
     }
 
     /// <summary>

--- a/src/Geopilot.Api/DeliveryOptions.cs
+++ b/src/Geopilot.Api/DeliveryOptions.cs
@@ -1,0 +1,35 @@
+﻿using Cronos;
+
+namespace Geopilot.Api;
+
+/// <summary>
+/// Configuration options for deliveries.
+/// </summary>
+public class DeliveryOptions
+{
+    /// <summary>
+    /// Whether users are allowed to delete their own uploaded deliveries.
+    /// Restrictions can be defined using <see cref="DeleteDuration"/> and <see cref="DeleteRestrictInterval"/>.
+    /// </summary>
+    public bool UploaderDeleteEnabled { get; set; }
+
+    /// <summary>
+    /// The time period during which users are allowed to delete their own uploaded deliveries.
+    /// </summary>
+    public TimeSpan? DeleteDuration { get; set; }
+
+    /// <summary>
+    /// A cron expression for a time interval after which deleting deliveries is restricted,
+    /// e.g. "0 0 * * *" to restrict deletions every day at midnight.
+    /// </summary>
+    public string? DeleteRestrictInterval
+    {
+        get => DeleteRestrictIntervalExpression?.ToString();
+        set => DeleteRestrictIntervalExpression = value == null ? null : CronExpression.Parse(value);
+    }
+
+    /// <summary>
+    /// The parsed cron expression for <see cref="DeleteRestrictInterval"/>.
+    /// </summary>
+    public CronExpression? DeleteRestrictIntervalExpression { get; set; }
+}

--- a/src/Geopilot.Api/Geopilot.Api.csproj
+++ b/src/Geopilot.Api/Geopilot.Api.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageReference Include="Bogus" Version="35.6.5" />
+    <PackageReference Include="Cronos" Version="0.13.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />

--- a/src/Geopilot.Api/Models/Delivery.cs
+++ b/src/Geopilot.Api/Models/Delivery.cs
@@ -1,4 +1,6 @@
-﻿namespace Geopilot.Api.Models;
+﻿using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Geopilot.Api.Models;
 
 /// <summary>
 /// A fullfillment of a <see cref="Mandate"/>. Contains all relevant meta information and assets provided or created by the validation and delivery process.
@@ -54,4 +56,10 @@ public class Delivery
     /// The deletion status of the delivery.
     /// </summary>
     public bool Deleted { get; set; }
+
+    /// <summary>
+    /// Indicates whether the delivery can be deleted by the uploader.
+    /// </summary>
+    [NotMapped]
+    public bool? CanDelete { get; set; }
 }

--- a/src/Geopilot.Api/Program.cs
+++ b/src/Geopilot.Api/Program.cs
@@ -169,6 +169,7 @@ builder.Services.Configure<PipelineOptions>(builder.Configuration.GetSection("Pi
 builder.Services.AddPipelinePluginsScalarOverride(builder.Configuration);
 builder.Services.Configure<CloudStorageOptions>(builder.Configuration.GetSection("CloudStorage"));
 builder.Services.Configure<ClamAvOptions>(builder.Configuration.GetSection("ClamAV"));
+builder.Services.Configure<DeliveryOptions>(builder.Configuration.GetSection("Delivery"));
 builder.Services.AddOptions<FileAccessOptions>()
     .BindConfiguration(FileAccessOptions.SectionName)
     .ValidateDataAnnotations()

--- a/src/Geopilot.Api/appsettings.Development.json
+++ b/src/Geopilot.Api/appsettings.Development.json
@@ -56,5 +56,9 @@
     "Enabled": true,
     "Host": "localhost",
     "Port": 3310
+  },
+  "Delivery": {
+    "UploaderDeleteEnabled": true,
+    "DeleteRestrictInterval": "0 0 * * *" // Every day at midnight
   }
 }

--- a/src/Geopilot.Api/appsettings.json
+++ b/src/Geopilot.Api/appsettings.json
@@ -52,5 +52,8 @@
     "CleanupIntervalMinutes": 15,
     "RateLimitRequests": 10,
     "RateLimitWindowMinutes": 1
+  },
+  "Delivery": {
+    "UploaderDeleteEnabled": false
   }
 }

--- a/src/Geopilot.Frontend/src/api/apiInterfaces.ts
+++ b/src/Geopilot.Frontend/src/api/apiInterfaces.ts
@@ -60,7 +60,9 @@ export interface Delivery {
   declaringUser: User;
   mandate: Mandate;
   comment: string;
+  canDelete?: boolean;
 }
+
 export enum UserState {
   Inactive = "inactive",
   Active = "active",

--- a/src/Geopilot.Frontend/src/components/grids/deliveryGrid.tsx
+++ b/src/Geopilot.Frontend/src/components/grids/deliveryGrid.tsx
@@ -15,11 +15,14 @@ interface DeliveryInfo {
   userName: string;
   mandateName: string;
   comment: string;
+  canDelete?: boolean;
 }
+
+type ColumnName = keyof Omit<DeliveryInfo, "canDelete">;
 
 interface DeliveryGridProps {
   fetchUrl: string;
-  columns: (keyof DeliveryInfo)[];
+  columns: ColumnName[];
 }
 
 export const DeliveryGrid: FC<DeliveryGridProps> = ({ fetchUrl, columns }) => {
@@ -40,6 +43,7 @@ export const DeliveryGrid: FC<DeliveryGridProps> = ({ fetchUrl, columns }) => {
             userName: d.declaringUser.fullName,
             mandateName: d.mandate.name,
             comment: d.comment,
+            canDelete: d.canDelete,
           })),
         );
       })
@@ -73,7 +77,7 @@ export const DeliveryGrid: FC<DeliveryGridProps> = ({ fetchUrl, columns }) => {
     ]);
   };
 
-  const namedColumnDefs: Record<keyof DeliveryInfo, GridColDef> = {
+  const namedColumnDefs: Record<ColumnName, GridColDef> = {
     id: { field: "id", headerName: t("id"), width: 60 },
     date: {
       field: "date",
@@ -97,16 +101,19 @@ export const DeliveryGrid: FC<DeliveryGridProps> = ({ fetchUrl, columns }) => {
     flex: 0,
     resizable: false,
     cellClassName: "actions",
-    getActions: ({ id }) => [
-      <Tooltip title={t("delete")} key={`delete-${id}`}>
-        <GridActionsCellItem
-          icon={<DeleteOutlinedIcon />}
-          label={t("delete")}
-          onClick={() => confirmDelete(id)}
-          color="error"
-        />
-      </Tooltip>,
-    ],
+    getActions: ({ id, row }) =>
+      row.canDelete !== false
+        ? [
+            <Tooltip title={t("delete")} key={`delete-${id}`}>
+              <GridActionsCellItem
+                icon={<DeleteOutlinedIcon />}
+                label={t("delete")}
+                onClick={() => confirmDelete(id)}
+                color="error"
+              />
+            </Tooltip>,
+          ]
+        : [],
   });
 
   return <GeopilotDataGrid name="deliveryOverview" loading={isLoading} rows={deliveries} columns={columnDefs} />;

--- a/tests/Geopilot.Api.Test/Controllers/DeliveryControllerTest.cs
+++ b/tests/Geopilot.Api.Test/Controllers/DeliveryControllerTest.cs
@@ -519,7 +519,8 @@ public class DeliveryControllerTest
         };
         deliveryOptionsMock.Setup(o => o.Value).Returns(options);
 
-        Assert.IsInstanceOfType<ForbidResult>(await deliveryController.Delete(delivery.Id));
+        var result = Assert.IsInstanceOfType<ObjectResult>(await deliveryController.Delete(delivery.Id));
+        Assert.AreEqual(StatusCodes.Status403Forbidden, result.StatusCode);
 
         AssertNotDeleted(delivery);
     }

--- a/tests/Geopilot.Api.Test/Controllers/DeliveryControllerTest.cs
+++ b/tests/Geopilot.Api.Test/Controllers/DeliveryControllerTest.cs
@@ -552,6 +552,37 @@ public class DeliveryControllerTest
     }
 
     [TestMethod]
+    [DataRow(DateTimeKind.Utc)]
+    [DataRow(DateTimeKind.Local)]
+    [DataRow(DateTimeKind.Unspecified)]
+    public async Task IsDeleteAllowedForUploaderConvertsToUtc(DateTimeKind deliveryDateTimeKind)
+    {
+        var restrictedDate = new DateTime(2026, 1, 1, 12, 30, 0, DateTimeKind.Utc);
+        var allowedDate = new DateTime(2026, 1, 1, 11, 45, 0, DateTimeKind.Utc);
+        var deliveryDate = new DateTime(2026, 1, 1, 11, 30, 0, DateTimeKind.Utc);
+        deliveryDate = deliveryDateTimeKind switch
+        {
+            DateTimeKind.Utc => deliveryDate,
+            DateTimeKind.Local => deliveryDate.ToLocalTime(),
+            DateTimeKind.Unspecified => DateTime.SpecifyKind(deliveryDate, DateTimeKind.Unspecified),
+            _ => throw new ArgumentOutOfRangeException(nameof(deliveryDateTimeKind), deliveryDateTimeKind, null),
+        };
+
+        var options = new DeliveryOptions
+        {
+            UploaderDeleteEnabled = true,
+            DeleteDuration = null,
+            DeleteRestrictInterval = "0 * * * *", // every hour at :00
+        };
+        deliveryOptionsMock.Setup(o => o.Value).Returns(options);
+
+        var delivery = new Delivery { Date = deliveryDate };
+        Assert.IsFalse(deliveryController.IsDeleteAllowedForUploader(delivery, restrictedDate));
+        Assert.IsTrue(deliveryController.IsDeleteAllowedForUploader(delivery, allowedDate));
+        Assert.AreEqual(deliveryDateTimeKind, delivery.Date.Kind);
+    }
+
+    [TestMethod]
     public async Task Download()
     {
         assetHandlerMock.Setup(p => p.DownloadAssetAsync(It.IsAny<Guid>(), It.IsAny<string>())).ReturnsAsync((Encoding.UTF8.GetBytes("Test"), "text/xml"));

--- a/tests/Geopilot.Api.Test/Controllers/DeliveryControllerTest.cs
+++ b/tests/Geopilot.Api.Test/Controllers/DeliveryControllerTest.cs
@@ -8,7 +8,9 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
+using System.Globalization;
 using System.Text;
 
 namespace Geopilot.Api.Controllers;
@@ -19,6 +21,7 @@ public class DeliveryControllerTest
     private Mock<IProcessingService> processingServiceMock;
     private Mock<IAssetHandler> assetHandlerMock;
     private Mock<ILogger<DeliveryController>> loggerMock;
+    private Mock<IOptions<DeliveryOptions>> deliveryOptionsMock;
     private DeliveryController deliveryController;
     private Context context;
 
@@ -29,7 +32,9 @@ public class DeliveryControllerTest
         processingServiceMock = new Mock<IProcessingService>(MockBehavior.Strict);
         assetHandlerMock = new Mock<IAssetHandler>(MockBehavior.Strict);
         context = AssemblyInitialize.DbFixture.GetTestContext();
-        deliveryController = new DeliveryController(loggerMock.Object, context, processingServiceMock.Object, assetHandlerMock.Object);
+        deliveryOptionsMock = new Mock<IOptions<DeliveryOptions>>();
+        deliveryOptionsMock.Setup(o => o.Value).Returns(new DeliveryOptions { UploaderDeleteEnabled = true });
+        deliveryController = new DeliveryController(loggerMock.Object, context, processingServiceMock.Object, assetHandlerMock.Object, deliveryOptionsMock.Object);
     }
 
     [TestCleanup]
@@ -487,14 +492,62 @@ public class DeliveryControllerTest
         Assert.IsNotNull(result);
         Assert.AreEqual(StatusCodes.Status404NotFound, result.StatusCode);
 
-        var dbDelivery = context.DeliveriesWithIncludes
-            .IgnoreQueryFilters()
-            .FirstOrDefault(d => d.Id == delivery.Id);
-        Assert.IsNotNull(dbDelivery);
-        Assert.IsFalse(dbDelivery.Deleted);
-        Assert.IsTrue(dbDelivery.Assets.All(a => !a.Deleted));
+        AssertNotDeleted(delivery);
+    }
 
-        assetHandlerMock.Verify(h => h.DeleteJobAssets(It.IsAny<Guid>()), Times.Never());
+    [TestMethod]
+    [DataRow(false, null, null)]
+    [DataRow(true, "10:00:00", null)]
+    [DataRow(true, null, "0 * * * *")] // every hour at :00
+    public async Task DeleteAsUserFailsIfDisabledByOptions(bool enabled, string? duration, string? interval)
+    {
+        var uploader = context.Users.First(u => !u.IsAdmin);
+
+        deliveryController.SetupTestUser(uploader);
+
+        var guid = Guid.NewGuid();
+        var delivery = new Delivery { JobId = guid, Mandate = context.Mandates.First(), DeclaringUser = uploader, Date = DateTime.UtcNow.AddHours(-12) };
+        delivery.Assets.Add(new Asset());
+        context.Deliveries.Add(delivery);
+        context.SaveChanges();
+
+        var options = new DeliveryOptions
+        {
+            UploaderDeleteEnabled = enabled,
+            DeleteDuration = duration == null ? null : TimeSpan.Parse(duration, CultureInfo.InvariantCulture),
+            DeleteRestrictInterval = interval,
+        };
+        deliveryOptionsMock.Setup(o => o.Value).Returns(options);
+
+        Assert.IsInstanceOfType<ForbidResult>(await deliveryController.Delete(delivery.Id));
+
+        AssertNotDeleted(delivery);
+    }
+
+    [TestMethod]
+    [DataRow(true, true, null, null)]
+    [DataRow(true, true, "0:45:00", null)]
+    [DataRow(true, true, null, "0 * * * *")] // every hour at :00
+    [DataRow(true, true, "0:45:00", "0 * * * *")]
+    [DataRow(false, false, null, null)]
+    [DataRow(false, true, "0:15:00", null)]
+    [DataRow(false, true, null, "*/30 * * * *")] // every half an hour at :00 and :30
+    [DataRow(false, true, "0:15:00", "0 * * * *")]
+    public async Task IsDeleteAllowedForUploader(bool expected, bool enabled, string? duration, string? interval)
+    {
+        var deliveryDate = new DateTime(2026, 1, 1, 12, 10, 0, DateTimeKind.Utc);
+        var currentDate = new DateTime(2026, 1, 1, 12, 40, 0, DateTimeKind.Utc);
+
+        var options = new DeliveryOptions
+        {
+            UploaderDeleteEnabled = enabled,
+            DeleteDuration = duration == null ? null : TimeSpan.Parse(duration, CultureInfo.InvariantCulture),
+            DeleteRestrictInterval = interval,
+        };
+        deliveryOptionsMock.Setup(o => o.Value).Returns(options);
+
+        var delivery = new Delivery { Date = deliveryDate };
+        Assert.AreEqual(expected, deliveryController.IsDeleteAllowedForUploader(delivery, currentDate));
     }
 
     [TestMethod]
@@ -631,5 +684,17 @@ public class DeliveryControllerTest
         CollectionAssert.AllItemsAreUnique(deliveries);
         Assert.IsTrue(deliveries.All(d => d.DeclaringUser.Id == user.Id), "All deliveries should belong to the user.");
         Assert.IsTrue(deliveries.All(d => !d.Deleted), "Should not return deleted deliveries.");
+    }
+
+    private void AssertNotDeleted(Delivery delivery)
+    {
+        var dbDelivery = context.DeliveriesWithIncludes
+            .IgnoreQueryFilters()
+            .FirstOrDefault(d => d.Id == delivery.Id);
+        Assert.IsNotNull(dbDelivery);
+        Assert.IsFalse(dbDelivery.Deleted);
+        Assert.IsTrue(dbDelivery.Assets.All(a => !a.Deleted));
+
+        assetHandlerMock.Verify(h => h.DeleteJobAssets(It.IsAny<Guid>()), Times.Never());
     }
 }

--- a/tests/Geopilot.Api.Test/Controllers/MandateControllerTest.cs
+++ b/tests/Geopilot.Api.Test/Controllers/MandateControllerTest.cs
@@ -8,6 +8,7 @@ using Geopilot.Pipeline.Config;
 using Geopilot.PipelineCore.Pipeline;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using NetTopologySuite.Geometries;
 
@@ -308,7 +309,7 @@ namespace Geopilot.Api.Controllers
             Assert.IsNotNull(mandateToUpdate);
 
             var guid = Guid.NewGuid();
-            var validationServiceMock = new Mock<IProcessingService>();
+            var processingServiceMock = new Mock<IProcessingService>();
             var pipelineMock = new Mock<IPipeline>();
             pipelineMock.SetupGet(p => p.State).Returns(ProcessingState.Success);
             pipelineMock.SetupGet(p => p.Delivery).Returns(PipelineDelivery.Allow);
@@ -321,7 +322,7 @@ namespace Geopilot.Api.Controllers
                 Pipeline = pipelineMock.Object,
             };
 
-            validationServiceMock
+            processingServiceMock
                 .Setup(s => s.GetJob(guid))
                 .Returns(processingJob);
             var assetHandlerMock = new Mock<IAssetHandler>();
@@ -329,7 +330,9 @@ namespace Geopilot.Api.Controllers
                 .Setup(p => p.PersistJobAssets(guid))
                 .Returns(new List<Asset> { new Asset(), new Asset() });
 
-            var deliveryController = new DeliveryController(new Mock<ILogger<DeliveryController>>().Object, context, validationServiceMock.Object, assetHandlerMock.Object);
+            var deliveryOptionsMock = new Mock<IOptions<DeliveryOptions>>();
+            deliveryOptionsMock.Setup(o => o.Value).Returns(new DeliveryOptions { UploaderDeleteEnabled = true });
+            var deliveryController = new DeliveryController(new Mock<ILogger<DeliveryController>>().Object, context, processingServiceMock.Object, assetHandlerMock.Object, deliveryOptionsMock.Object);
             deliveryController.SetupTestUser(editUser);
 
             var request = new DeliveryRequest


### PR DESCRIPTION
Fügt neue Optionen zur Konfiguration hinzu:
```json5
"Delivery": {
    "UploaderDeleteEnabled": true,
    "DeleteDuration": "01:00:00", // TimeSpan: wie lange eine Lieferung nach Erstellen gelöscht werden darf
    "DeleteRestrictInterval": "0 0 * * *" // cron expression: Zeitpunkte, nach welchen eine Lieferung nicht mehr gelöscht werden darf
}
```

Resolves #685 