### PR TITLE
Add changelog entry for error visualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - The XTF validation error tree groups errors by configurable criteria (by default model, topic and class; the tree-only pipeline groups by INTERLIS class), shows the number of entries per group, and displays the error-category titles in the active language.
 
+### Added
+
+- Validation errors can be explored visually in the delivery view: when a validation step fails, its errors are shown on an interactive map and in an error tree. The two views are cross-linked (selecting an error in one highlights it in the other) and share a filter.
+- `Visualization` output action in the `GeoWerkstatt.Geopilot.Pipeline` runtime: a pipeline step can tag an output as a self-describing visualization config (a `{ type, data }` envelope), which the runtime serves to the frontend to render based on its `type`.
+
 ## v3.0.341 - 2026-06-17
 
 ### Added


### PR DESCRIPTION
The XTF error visualization feature (#728) shipped without a changelog entry. Record it under [Unreleased] as an added feature.

No version bump: the feature only adds the Visualization output action, and the last stable Geopilot.Pipeline release is still 1.0.0, so the addition rides in the upcoming, not-yet-released 2.0.0.