### PR TITLE
XTF-Fehler-Visualisierung: Karten-Vollbild und Control-Fixes (#741)

### DIFF
--- a/src/Geopilot.Frontend/public/locale/de/common.json
+++ b/src/Geopilot.Frontend/public/locale/de/common.json
@@ -92,6 +92,8 @@
   "mandateSaveError": "Beim Speichern des Mandats ist ein Fehler aufgetreten: {{error}}",
   "mandates": "Mandate",
   "mandatesLoadingError": "Beim Laden der Mandate ist ein Fehler aufgetreten: {{error}}",
+  "mapFullscreen": "Vollbild",
+  "mapFullscreenExit": "Vollbild verlassen",
   "mapResetViewport": "Ansicht zurücksetzen, um alle Features anzuzeigen",
   "mapVisualizationFeatureLayer": "Objekte",
   "maxFileCount_one": "eine Datei",

--- a/src/Geopilot.Frontend/public/locale/en/common.json
+++ b/src/Geopilot.Frontend/public/locale/en/common.json
@@ -92,6 +92,8 @@
   "mandateSaveError": "An error occurred while saving the mandate: {{error}}",
   "mandates": "Mandates",
   "mandatesLoadingError": "An error occurred while loading the mandates: {{error}}",
+  "mapFullscreen": "Fullscreen",
+  "mapFullscreenExit": "Exit fullscreen",
   "mapResetViewport": "Reset view to show all features",
   "mapVisualizationFeatureLayer": "Features",
   "maxFileCount_one": "one file",

--- a/src/Geopilot.Frontend/public/locale/fr/common.json
+++ b/src/Geopilot.Frontend/public/locale/fr/common.json
@@ -92,6 +92,8 @@
   "mandateSaveError": "Une erreur s'est produite lors de l'enregistrement du mandat: {{error}}",
   "mandates": "Mandats",
   "mandatesLoadingError": "Une erreur s'est produite lors du chargement des mandats: {{error}}",
+  "mapFullscreen": "Plein écran",
+  "mapFullscreenExit": "Quitter le plein écran",
   "mapResetViewport": "Réinitialiser la vue pour afficher tous les éléments",
   "mapVisualizationFeatureLayer": "Entités",
   "maxFileCount_one": "un fichier",

--- a/src/Geopilot.Frontend/public/locale/it/common.json
+++ b/src/Geopilot.Frontend/public/locale/it/common.json
@@ -92,6 +92,8 @@
   "mandateSaveError": "Si è verificato un errore durante il salvataggio del mandato: {{error}}",
   "mandates": "Mandati",
   "mandatesLoadingError": "Si è verificato un errore durante il caricamento dei mandati: {{error}}",
+  "mapFullscreen": "Schermo intero",
+  "mapFullscreenExit": "Esci da schermo intero",
   "mapResetViewport": "Reimposta la vista per mostrare tutti gli elementi",
   "mapVisualizationFeatureLayer": "Elementi",
   "maxFileCount_one": "un file",

--- a/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/layerSwitcher.tsx
+++ b/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/layerSwitcher.tsx
@@ -451,12 +451,12 @@ export const LayerSwitcher = ({ map, onLayerChange }: LayerSwitcherProps) => {
       ref={containerRef}
       sx={{
         position: "absolute",
-        top: 8,
-        left: 8,
+        bottom: 8,
+        right: 8,
         zIndex: 10,
         display: "flex",
         flexDirection: "column",
-        alignItems: "flex-start",
+        alignItems: "flex-end",
         gap: 0.5,
       }}>
       {!open && (

--- a/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/layerSwitcher.tsx
+++ b/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/layerSwitcher.tsx
@@ -470,6 +470,8 @@ export const LayerSwitcher = ({ map, onLayerChange }: LayerSwitcherProps) => {
               boxShadow: 1,
               borderRadius: "4px",
               "&:hover": { backgroundColor: "background.paper", color: "text.primary" },
+              // Keep the fill on focus/active: the theme globally clears the IconButton background on these states.
+              "&:focus, &:focus-visible, &.Mui-focusVisible, &:active": { backgroundColor: "background.paper" },
             }}>
             <LayersOutlinedIcon />
           </IconButton>

--- a/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/mapVisualization.tsx
+++ b/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/mapVisualization.tsx
@@ -420,9 +420,9 @@ export const MapVisualization = ({
           borderRadius: "4px",
           overflow: "hidden",
           border: theme => `1px solid ${theme.palette.primary.light}`,
-          // Move the default zoom (+/-) control to the top-right; the layer switcher and reset-viewport
-          // buttons occupy the top-left corner.
-          "& .ol-zoom": { top: "8px", left: "auto", right: "8px" },
+          // Controls stack at the top-right (fullscreen, zoom, reset); the top slot is left for the fullscreen
+          // button. The layer switcher sits at the bottom-right.
+          "& .ol-zoom": { top: "56px", left: "auto", right: "8px" },
         }}
       />
       <LayerSwitcher map={map} />
@@ -433,9 +433,9 @@ export const MapVisualization = ({
             onClick={resetViewport}
             sx={{
               position: "absolute",
-              // Below the layer switcher button (40px tall at top 8px) with an 8px gap.
-              top: "56px",
-              left: "8px",
+              // Bottom of the top-right control stack: fullscreen (top), zoom, then reset.
+              top: "116px",
+              right: "8px",
               backgroundColor: "background.paper",
               color: "text.secondary",
               boxShadow: 1,

--- a/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/mapVisualization.tsx
+++ b/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/mapVisualization.tsx
@@ -1,6 +1,8 @@
 import { MutableRefObject, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import CenterFocusStrongIcon from "@mui/icons-material/CenterFocusStrong";
+import FullscreenIcon from "@mui/icons-material/Fullscreen";
+import FullscreenExitIcon from "@mui/icons-material/FullscreenExit";
 import { Box, IconButton, Tooltip } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import i18next from "i18next";
@@ -225,6 +227,10 @@ interface MapVisualizationProps {
   onSelectFeature: (errorId: string) => void;
   /** Whether to show the info popup on feature click. Suppressed when the tree below already shows the details. */
   showPopup: boolean;
+  /** Whether the visualization is in fullscreen; the map fills its container then. */
+  isFullscreen: boolean;
+  /** Toggles the fullscreen mode of the composite (map + tree). */
+  onToggleFullscreen: () => void;
 }
 
 export const MapVisualization = ({
@@ -233,6 +239,8 @@ export const MapVisualization = ({
   highlightedErrorIds,
   onSelectFeature,
   showPopup,
+  isFullscreen,
+  onToggleFullscreen,
 }: MapVisualizationProps) => {
   const { t } = useTranslation();
   const theme = useTheme();
@@ -256,6 +264,15 @@ export const MapVisualization = ({
     const map = mapRef.current;
     if (!map) return;
     map.getView().fit(getFitExtent(featureLayersRef.current), FIT_OPTIONS);
+  }, []);
+
+  // Keep the OpenLayers map sized to its container, e.g. after toggling fullscreen.
+  useEffect(() => {
+    const container = mapContainerRef.current;
+    if (!container) return;
+    const observer = new ResizeObserver(() => mapRef.current?.updateSize());
+    observer.observe(container);
+    return () => observer.disconnect();
   }, []);
 
   useEffect(() => {
@@ -410,7 +427,7 @@ export const MapVisualization = ({
   return (
     // zIndex establishes a stacking context so the layer switcher (zIndex 10) stays contained within the map
     // and is masked by the sticky scroll overlay instead of poking over the container's top border.
-    <Box sx={{ position: "relative", zIndex: 0, width: "100%", height: "400px" }}>
+    <Box sx={{ position: "relative", zIndex: 0, width: "100%", height: isFullscreen ? "100%" : "400px" }}>
       <Box
         ref={mapContainerRef}
         data-cy="map-visualization"
@@ -426,6 +443,24 @@ export const MapVisualization = ({
         }}
       />
       <LayerSwitcher map={map} />
+      <Tooltip title={t(isFullscreen ? "mapFullscreenExit" : "mapFullscreen")}>
+        <IconButton
+          data-cy="map-fullscreen-toggle"
+          onClick={onToggleFullscreen}
+          sx={{
+            position: "absolute",
+            top: "8px",
+            right: "8px",
+            backgroundColor: "background.paper",
+            color: "text.secondary",
+            boxShadow: 1,
+            borderRadius: "4px",
+            "&:hover": { backgroundColor: "background.paper", color: "text.primary" },
+            "&:focus, &:focus-visible, &.Mui-focusVisible, &:active": { backgroundColor: "background.paper" },
+          }}>
+          {isFullscreen ? <FullscreenExitIcon /> : <FullscreenIcon />}
+        </IconButton>
+      </Tooltip>
       {map && (
         <Tooltip title={t("mapResetViewport")}>
           <IconButton

--- a/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/mapVisualization.tsx
+++ b/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/mapVisualization.tsx
@@ -441,6 +441,8 @@ export const MapVisualization = ({
               boxShadow: 1,
               borderRadius: "4px",
               "&:hover": { backgroundColor: "background.paper", color: "text.primary" },
+              // Keep the fill on focus/active: the theme globally clears the IconButton background on these states.
+              "&:focus, &:focus-visible, &.Mui-focusVisible, &:active": { backgroundColor: "background.paper" },
             }}>
             <CenterFocusStrongIcon />
           </IconButton>

--- a/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/xtfErrorVisualization.tsx
+++ b/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/xtfErrorVisualization.tsx
@@ -1,6 +1,6 @@
-import { FC, useMemo, useState } from "react";
+import { FC, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Stack } from "@mui/material";
+import { Box, Stack } from "@mui/material";
 import { MapVisualizationConfig, TreeVisualizationConfig } from "../../../../api/apiInterfaces";
 import { useLocalized } from "../../../../hooks/useLocalized";
 import { FilterBar } from "./filterBar";
@@ -32,6 +32,7 @@ export const XtfErrorVisualization: FC<XtfErrorVisualizationProps> = ({ config }
   const [messageQuery, setMessageQuery] = useState("");
   const [metadataFilters, setMetadataFilters] = useState<MetadataFilters>({});
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
 
   const items = useMemo(() => config.tree?.items ?? [], [config.tree]);
   const groupBy = useMemo(() => config.tree?.groupBy ?? [], [config.tree]);
@@ -72,9 +73,33 @@ export const XtfErrorVisualization: FC<XtfErrorVisualizationProps> = ({ config }
     setMetadataFilters({});
   };
   const handleSelectFeature = (errorId: string) => setSelectedNodeId(nodeIdByErrorId.get(errorId) ?? null);
+  const toggleFullscreen = () => setIsFullscreen(current => !current);
+
+  // Allow Escape to leave the fullscreen overlay.
+  useEffect(() => {
+    if (!isFullscreen) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setIsFullscreen(false);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [isFullscreen]);
 
   return (
-    <Stack sx={{ width: "100%" }}>
+    <Stack
+      sx={{
+        width: "100%",
+        // In fullscreen the whole visualization becomes a fixed overlay filling the viewport; the map grows.
+        ...(isFullscreen && {
+          position: "fixed",
+          inset: 0,
+          zIndex: "modal",
+          height: "100vh",
+          bgcolor: "background.default",
+          p: 2,
+          overflow: "auto",
+        }),
+      }}>
       {config.tree && (
         <FilterBar
           attributes={attributes}
@@ -86,13 +111,17 @@ export const XtfErrorVisualization: FC<XtfErrorVisualizationProps> = ({ config }
         />
       )}
       {config.map && (
-        <MapVisualization
-          config={config.map}
-          visibleErrorIds={visibleErrorIds}
-          highlightedErrorIds={highlightedErrorIds}
-          onSelectFeature={handleSelectFeature}
-          showPopup={!config.tree}
-        />
+        <Box sx={{ ...(isFullscreen && { flex: 1, minHeight: 0 }) }}>
+          <MapVisualization
+            config={config.map}
+            visibleErrorIds={visibleErrorIds}
+            highlightedErrorIds={highlightedErrorIds}
+            onSelectFeature={handleSelectFeature}
+            showPopup={!config.tree}
+            isFullscreen={isFullscreen}
+            onToggleFullscreen={toggleFullscreen}
+          />
+        </Box>
       )}
       {config.tree && (
         <TreeVisualization


### PR DESCRIPTION
## Worum geht's

Verbesserungen an der Karten-Visualisierung gemäss #741, gestaltet nach
Roswitas Design.

Baut auf #740 auf.

## Änderungen

- **Vollbild für Karte + Tree.** Ein Toggle oben rechts auf der Karte schaltet die
  gesamte Visualisierung (Filter, Karte, Tree) in ein Vollbild-Overlay über den
  Viewport und wieder zurück; Escape beendet ebenfalls. Die Karte wächst mit, ein
  ResizeObserver hält OpenLayers passend zur Containergrösse.
- **Transparenter Bedien-Button behoben.** Der Reset-View-Button (und der
  Layer-Switcher-Toggle) wurde nach einem Klick transparent, weil das Theme den
  IconButton-Hintergrund global auf Fokus/Active leert. Die Buttons behalten ihre
  Füllung jetzt auch in diesen Zuständen.
- **Controls neu angeordnet (Roswita).** Layer-Switcher unten rechts (Panel öffnet
  nach oben), Zoom / Reset / Vollbild oben rechts gestapelt. Damit liegen alle
  Controls vollständig innerhalb der Kartenfläche.

## Betroffene Stellen

- `mapVisualization.tsx`, `layerSwitcher.tsx`, `xtfErrorVisualization.tsx`
- Übersetzungen `mapFullscreen` / `mapFullscreenExit` (de/fr/it/en)

## Hinweis

Der Overflow der Controls über den Kartenrand (Umfang-Punkt) wurde bereits in
#740 (Stacking-Context) gelöst; hier kommt die Neu-Anordnung dazu.

## Tests

- Frontend: `ts`, `lint`, `knip`, `build` grün; Locale-JSONs valide.
- Manuell noch zu prüfen: vertikale Abstände der oben-rechts gestapelten Controls
  (Offsets geschätzt) und das Rendering der Karte im Vollbild.

Closes #741