### PR TITLE
Don't show reset prompt after completing delivery

### DIFF
--- a/src/Geopilot.Frontend/src/pages/delivery/deliveryContent.tsx
+++ b/src/Geopilot.Frontend/src/pages/delivery/deliveryContent.tsx
@@ -1,8 +1,9 @@
-import { FC, PropsWithChildren, ReactNode } from "react";
+import { FC, PropsWithChildren, ReactNode, useContext } from "react";
 import { useTranslation } from "react-i18next";
 import { Box, Stack, Typography } from "@mui/material";
 import { styled } from "@mui/system";
 import { GeopilotBox } from "../../components/styledComponents";
+import { DeliveryContext } from "./deliveryContext.tsx";
 import { DeliveryRestartButton } from "./deliveryRestartButton";
 
 interface DeliveryContentProps {
@@ -71,7 +72,7 @@ export const DeliveryContent: FC<PropsWithChildren<DeliveryContentProps>> = ({
   buttons,
 }) => {
   const { t } = useTranslation();
-
+  const { steps, lastCompletedStep } = useContext(DeliveryContext);
   return (
     <DeliveryContentGrid>
       <DeliveryContentBox>
@@ -83,7 +84,10 @@ export const DeliveryContent: FC<PropsWithChildren<DeliveryContentProps>> = ({
           {children}
         </GeopilotBox>
         <Stack direction="row" sx={{ alignItems: "center", flexWrap: "wrap", justifyContent: "space-between" }}>
-          <DeliveryRestartButton sx={{ display: { xs: "block", md: "none" } }} />
+          <DeliveryRestartButton
+            sx={{ display: { xs: "block", md: "none" } }}
+            immediate={lastCompletedStep === steps.size - 1}
+          />
           <Stack direction="row" sx={{ alignItems: "center", flexWrap: "wrap", flex: 1, justifyContent: "flex-end" }}>
             {buttons}
           </Stack>

--- a/src/Geopilot.Frontend/src/pages/delivery/deliveryRestartButton.tsx
+++ b/src/Geopilot.Frontend/src/pages/delivery/deliveryRestartButton.tsx
@@ -1,25 +1,41 @@
-import { FC, useContext } from "react";
-import { ButtonProps } from "@mui/material/Button";
+import { forwardRef, useContext } from "react";
+import { ButtonProps as MuiButtonProps } from "@mui/material/Button/Button";
 import { Button } from "../../components/buttons";
 import { PromptContext } from "../../components/prompt/promptContext";
 import { PromptAction } from "../../components/prompt/promptInterfaces";
 import { DeliveryContext } from "./deliveryContext";
 
-export const DeliveryRestartButton: FC<Pick<ButtonProps, "sx">> = ({ sx }) => {
-  const { resetDelivery, selectedFiles } = useContext(DeliveryContext);
-  const { showPrompt } = useContext(PromptContext);
+interface DeliveryRestartButtonProps extends MuiButtonProps {
+  immediate?: boolean;
+}
 
-  const promptToRestart = () => {
-    const promptActions: PromptAction[] = [
-      { label: "cancel", action: () => {} },
-      {
-        label: "restart",
-        variant: "contained",
-        action: () => resetDelivery(),
-      },
-    ];
-    showPrompt("restartPrompt", promptActions);
-  };
+export const DeliveryRestartButton = forwardRef<HTMLButtonElement, DeliveryRestartButtonProps>(
+  ({ immediate, ...props }, ref) => {
+    const { resetDelivery, selectedFiles } = useContext(DeliveryContext);
+    const { showPrompt } = useContext(PromptContext);
 
-  return selectedFiles.length > 0 && <Button label="restart" variant="text" onClick={promptToRestart} sx={sx} />;
-};
+    const promptToRestart = () => {
+      const promptActions: PromptAction[] = [
+        { label: "cancel", action: () => {} },
+        {
+          label: "restart",
+          variant: "contained",
+          action: () => resetDelivery(),
+        },
+      ];
+      showPrompt("restartPrompt", promptActions);
+    };
+
+    return (
+      selectedFiles.length > 0 && (
+        <Button
+          ref={ref}
+          label="restart"
+          variant="text"
+          onClick={immediate ? resetDelivery : promptToRestart}
+          {...props}
+        />
+      )
+    );
+  },
+);

--- a/src/Geopilot.Frontend/src/pages/delivery/deliveryStepper.tsx
+++ b/src/Geopilot.Frontend/src/pages/delivery/deliveryStepper.tsx
@@ -121,7 +121,10 @@ export const DeliveryStepper = () => {
             </Stack>
           </DeliveryStepBox>
         ))}
-        <DeliveryRestartButton sx={{ alignSelf: "flex-start", display: { xs: "none", md: "block" } }} />
+        <DeliveryRestartButton
+          sx={{ alignSelf: "flex-start", display: { xs: "none", md: "block" } }}
+          immediate={lastCompletedStep === steps.size - 1}
+        />
       </StepperStack>
     </StepperViewport>
   );


### PR DESCRIPTION
Wenn der Prompt nach erfolgreicher Lieferung noch angezeigt wird, könnte man den Eindruck bekommen, dass die Lieferung doch noch nicht ganz abgeschlossen ist.