### PR TITLE
Add zoom-to-error control to XTF error map

### DIFF
--- a/src/Geopilot.Frontend/public/locale/de/common.json
+++ b/src/Geopilot.Frontend/public/locale/de/common.json
@@ -176,6 +176,7 @@
   "validatorsLoadingError": "Beim Laden der Validatoren ist ein Fehler aufgetreten: {{error}}",
   "version": "Version",
   "visualizationLoadFailed": "Die Visualisierung konnte nicht geladen werden.",
+  "zoomToError": "Auf Fehler zoomen",
   "zoomToExtent": "Auf alle Objekte zoomen",
   "zoomToLayerExtent": "Auf Ebenenausdehnung zoomen"
 }

--- a/src/Geopilot.Frontend/public/locale/en/common.json
+++ b/src/Geopilot.Frontend/public/locale/en/common.json
@@ -176,6 +176,7 @@
   "validatorsLoadingError": "An error occurred while loading the validators: {{error}}",
   "version": "Version",
   "visualizationLoadFailed": "The visualization could not be loaded.",
+  "zoomToError": "Zoom to error",
   "zoomToExtent": "Zoom to all features",
   "zoomToLayerExtent": "Zoom to layer extent"
 }

--- a/src/Geopilot.Frontend/public/locale/fr/common.json
+++ b/src/Geopilot.Frontend/public/locale/fr/common.json
@@ -176,6 +176,7 @@
   "validatorsLoadingError": "Une erreur s'est produite lors du chargement des validateurs: {{error}}",
   "version": "Version",
   "visualizationLoadFailed": "La visualisation n'a pas pu être chargée.",
+  "zoomToError": "Zoomer sur l'erreur",
   "zoomToExtent": "Zoom sur toutes les entités",
   "zoomToLayerExtent": "Zoomer sur l'étendue de la couche"
 }

--- a/src/Geopilot.Frontend/public/locale/it/common.json
+++ b/src/Geopilot.Frontend/public/locale/it/common.json
@@ -176,6 +176,7 @@
   "validatorsLoadingError": "Si è verificato un errore durante il caricamento dei validatori: {{error}}",
   "version": "Versione",
   "visualizationLoadFailed": "Impossibile caricare la visualizzazione.",
+  "zoomToError": "Zoom sull'errore",
   "zoomToExtent": "Zoom su tutti gli elementi",
   "zoomToLayerExtent": "Zoom sull'estensione del livello"
 }

--- a/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/mapVisualization.tsx
+++ b/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/mapVisualization.tsx
@@ -8,7 +8,7 @@ import { Box, ButtonGroup, Stack } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import i18next from "i18next";
 import { defaults as defaultControls } from "ol/control";
-import { containsExtent, createEmpty, extend as extendExtent, getCenter, isEmpty as isExtentEmpty } from "ol/extent";
+import { createEmpty, extend as extendExtent, getCenter, isEmpty as isExtentEmpty } from "ol/extent";
 import Feature from "ol/Feature";
 import WKT from "ol/format/WKT";
 import WMTSCapabilities from "ol/format/WMTSCapabilities";
@@ -41,6 +41,9 @@ const localized = (entries?: Record<string, string>) =>
 const SWISS_PROJECTION = "EPSG:2056";
 // Bounding extent of Switzerland in LV95, used as the WMTS tile grid extent and default map view extent.
 const SWISS_EXTENT: [number, number, number, number] = [2420000, 1030000, 2900000, 1350000];
+
+const ZOOM_TO_NODE_MAX_ZOOM = 13;
+const ZOOM_TO_NODE_DURATION = 400;
 
 let projectionRegistered = false;
 const registerSwissProjection = () => {
@@ -233,16 +236,16 @@ const getFitExtent = (featureLayers: VectorLayer<VectorSource>[]): number[] => {
   return isExtentEmpty(featureExtent) ? SWISS_EXTENT : featureExtent;
 };
 
-const getSelectedExtent = (
+const getExtentForErrorIds = (
   featureLayers: VectorLayer<VectorSource>[],
-  selectedIds: ReadonlySet<string>,
+  errorIds: ReadonlySet<string>,
 ): { extent: number[]; count: number } => {
   const extent = createEmpty();
   let count = 0;
   for (const featureLayer of featureLayers) {
     for (const feature of featureLayer.getSource()?.getFeatures() ?? []) {
       const errorId = feature.get("errorId") as string | undefined;
-      if (errorId !== undefined && selectedIds.has(errorId)) {
+      if (errorId !== undefined && errorIds.has(errorId)) {
         const geometry = feature.getGeometry();
         if (geometry) {
           extendExtent(extent, geometry.getExtent());
@@ -254,6 +257,15 @@ const getSelectedExtent = (
   return { extent, count };
 };
 
+/**
+ * A request to zoom the map to a set of errors (the errors of a tree node's subtree). The token makes each
+ * request distinct, so zooming to the same node again re-triggers the zoom.
+ */
+export interface MapZoomRequest {
+  errorIds: string[];
+  token: number;
+}
+
 interface MapVisualizationProps {
   /** The map visualization config to render. */
   config: MapVisualizationConfig;
@@ -261,6 +273,8 @@ interface MapVisualizationProps {
   visibleErrorIds?: ReadonlySet<string>;
   /** Error ids to highlight (current selection); empty set means none. */
   highlightedErrorIds: ReadonlySet<string>;
+  /** Latest explicit zoom-to-node request, or null. Selection no longer moves the map; this does. */
+  zoomRequest?: MapZoomRequest | null;
   /** Called with the error id when a feature is clicked. */
   onSelectFeature: (errorId: string) => void;
   /** Whether to show the metadata popup when a feature is selected. */
@@ -275,6 +289,7 @@ export const MapVisualization = ({
   config,
   visibleErrorIds,
   highlightedErrorIds,
+  zoomRequest,
   onSelectFeature,
   showMapSelectionPopup,
   reserveSpaceForFilters,
@@ -283,7 +298,7 @@ export const MapVisualization = ({
 }: MapVisualizationProps) => {
   const { t } = useTranslation();
   const theme = useTheme();
-  const { captureLayerState, restoreLayerState, captureViewState, restoreViewState } =
+  const { captureLayerState, restoreLayerState, captureViewState, restoreViewState, lastZoomTokenRef } =
     useContext(MapVisualizationContext);
   const mapContainerRef = useRef<HTMLDivElement>(null);
   // The map instance and feature layers are kept in refs so the reset-viewport button can re-fit the view
@@ -447,29 +462,30 @@ export const MapVisualization = ({
     };
   }, [config, theme, t, fitOptions, restoreLayerState, restoreViewState, captureViewState]);
 
-  // Apply filter (hide non-matching) and selection (highlight + center) without rebuilding the map: update
-  // the refs the style function reads, restyle the existing layers, and center on the current selection.
+  // Apply filter (hide non-matching) and selection (highlight) without rebuilding the map and without moving
+  // the view: update the refs the style function reads and restyle the existing layers. Moving the map is
+  // the job of the explicit zoom request below, not of selection.
   useEffect(() => {
     visibleIdsRef.current = visibleErrorIds;
     highlightedIdsRef.current = highlightedErrorIds;
     if (!map) return;
     featureLayersRef.current.forEach(layer => layer.changed());
+  }, [map, visibleErrorIds, highlightedErrorIds]);
 
-    if (highlightedErrorIds.size === 0) return;
-    const { extent, count } = getSelectedExtent(featureLayersRef.current, highlightedErrorIds);
+  // Zoom to the features of an explicit zoom request (a tree node's errors: one for a leaf, many for a
+  // group). Guarded by the request token, persisted in the shared context so the unmount/remount of a
+  // fullscreen toggle restores the previous view instead of re-running the last zoom.
+  useEffect(() => {
+    if (!map || !zoomRequest || zoomRequest.token === lastZoomTokenRef.current) return;
+    lastZoomTokenRef.current = zoomRequest.token;
+    const { extent } = getExtentForErrorIds(featureLayersRef.current, new Set(zoomRequest.errorIds));
     if (isExtentEmpty(extent)) return;
-    // Only move the map when the selection is not already visible: clicking a feature on the map must not
-    // yank it out from under the cursor, and an already-visible selection should stay put. An off-screen
-    // single error gently centers (keeps zoom); an off-screen group fits to show all its points.
-    const size = map.getSize();
-    const viewExtent = size ? map.getView().calculateExtent(size) : undefined;
-    if (viewExtent && containsExtent(viewExtent, extent)) return;
-    if (count === 1) {
-      map.getView().setCenter(getCenter(extent));
-    } else {
-      map.getView().fit(extent, fitOptions);
-    }
-  }, [map, visibleErrorIds, highlightedErrorIds, fitOptions]);
+    map.getView().fit(extent, {
+      padding: fitOptions.padding,
+      maxZoom: ZOOM_TO_NODE_MAX_ZOOM,
+      duration: ZOOM_TO_NODE_DURATION,
+    });
+  }, [map, zoomRequest, fitOptions, lastZoomTokenRef]);
 
   return (
     <Box

--- a/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/mapVisualization.tsx
+++ b/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/mapVisualization.tsx
@@ -236,16 +236,16 @@ const getFitExtent = (featureLayers: VectorLayer<VectorSource>[]): number[] => {
   return isExtentEmpty(featureExtent) ? SWISS_EXTENT : featureExtent;
 };
 
-const getExtentForErrorIds = (
+const getExtentForFeatureIds = (
   featureLayers: VectorLayer<VectorSource>[],
-  errorIds: ReadonlySet<string>,
+  featureIds: ReadonlySet<string>,
 ): { extent: number[]; count: number } => {
   const extent = createEmpty();
   let count = 0;
   for (const featureLayer of featureLayers) {
     for (const feature of featureLayer.getSource()?.getFeatures() ?? []) {
-      const errorId = feature.get("errorId") as string | undefined;
-      if (errorId !== undefined && errorIds.has(errorId)) {
+      const featureId = feature.get("errorId") as string | undefined;
+      if (featureId !== undefined && featureIds.has(featureId)) {
         const geometry = feature.getGeometry();
         if (geometry) {
           extendExtent(extent, geometry.getExtent());
@@ -258,11 +258,11 @@ const getExtentForErrorIds = (
 };
 
 /**
- * A request to zoom the map to a set of errors (the errors of a tree node's subtree). The token makes each
+ * A request to zoom the map to a set of features (those of a tree node's subtree). The token makes each
  * request distinct, so zooming to the same node again re-triggers the zoom.
  */
 export interface MapZoomRequest {
-  errorIds: string[];
+  featureIds: string[];
   token: number;
 }
 
@@ -472,13 +472,13 @@ export const MapVisualization = ({
     featureLayersRef.current.forEach(layer => layer.changed());
   }, [map, visibleErrorIds, highlightedErrorIds]);
 
-  // Zoom to the features of an explicit zoom request (a tree node's errors: one for a leaf, many for a
+  // Zoom to the features of an explicit zoom request (a tree node's features: one for a leaf, many for a
   // group). Guarded by the request token, persisted in the shared context so the unmount/remount of a
   // fullscreen toggle restores the previous view instead of re-running the last zoom.
   useEffect(() => {
     if (!map || !zoomRequest || zoomRequest.token === lastZoomTokenRef.current) return;
     lastZoomTokenRef.current = zoomRequest.token;
-    const { extent } = getExtentForErrorIds(featureLayersRef.current, new Set(zoomRequest.errorIds));
+    const { extent } = getExtentForFeatureIds(featureLayersRef.current, new Set(zoomRequest.featureIds));
     if (isExtentEmpty(extent)) return;
     map.getView().fit(extent, {
       padding: fitOptions.padding,

--- a/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/mapVisualizationContext.tsx
+++ b/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/mapVisualizationContext.tsx
@@ -15,6 +15,7 @@ export interface MapLayerState {
 export interface MapVisualizationContextInterface {
   viewStateRef: MutableRefObject<MapViewState | undefined>;
   layerStateRef: MutableRefObject<Map<string, MapLayerState>>;
+  lastZoomTokenRef: MutableRefObject<number | undefined>;
   captureLayerState: (map: OlMap) => void;
   restoreLayerState: (map: OlMap) => void;
   captureViewState: (map: OlMap) => void;
@@ -28,6 +29,7 @@ export interface MapVisualizationContextInterface {
 export const MapVisualizationContext = createContext<MapVisualizationContextInterface>({
   viewStateRef: { current: undefined },
   layerStateRef: { current: new Map() },
+  lastZoomTokenRef: { current: undefined },
   captureLayerState: () => {},
   restoreLayerState: () => {},
   captureViewState: () => {},

--- a/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/mapVisualizationProvider.tsx
+++ b/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/mapVisualizationProvider.tsx
@@ -19,6 +19,7 @@ const visitLayers = (layers: BaseLayer[], parentPath: string, visit: (layer: Bas
 export const MapVisualizationProvider: FC<PropsWithChildren> = ({ children }) => {
   const viewStateRef = useRef<MapViewState | undefined>(undefined);
   const layerStateRef = useRef(new Map<string, MapLayerState>());
+  const lastZoomTokenRef = useRef<number | undefined>(undefined);
 
   const captureLayerState = useCallback((map: OlMap) => {
     const layerState = layerStateRef.current;
@@ -62,6 +63,7 @@ export const MapVisualizationProvider: FC<PropsWithChildren> = ({ children }) =>
       value={{
         viewStateRef,
         layerStateRef,
+        lastZoomTokenRef,
         captureLayerState,
         restoreLayerState,
         captureViewState,

--- a/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/renderTreeItems.tsx
+++ b/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/renderTreeItems.tsx
@@ -1,8 +1,10 @@
 import { ComponentType, ReactNode } from "react";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
+import MapOutlinedIcon from "@mui/icons-material/MapOutlined";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import { Box, Stack, SvgIconProps, Typography } from "@mui/material";
 import { TreeItem } from "@mui/x-tree-view";
+import { IconButton } from "../../../../components/buttons";
 import { nodeId, TreeNode } from "./treeNode";
 
 const SEVERITY_ICON: Record<string, ComponentType<SvgIconProps>> = {
@@ -16,7 +18,7 @@ const renderIcon = (node: TreeNode): ReactNode => {
   return <SvgIcon fontSize="small" color={node.color === "warning" ? "warning" : "error"} />;
 };
 
-const renderLabel = (node: TreeNode): ReactNode => (
+const renderLabel = (node: TreeNode, action?: ReactNode): ReactNode => (
   <Stack direction="row" sx={{ alignItems: "flex-start", gap: 0.5, minWidth: 0 }}>
     {renderIcon(node)}
     <Typography variant="body2" sx={{ wordBreak: "break-word", minWidth: 0 }}>
@@ -27,20 +29,43 @@ const renderLabel = (node: TreeNode): ReactNode => (
         ( {node.count} )
       </Typography>
     )}
+    {action}
   </Stack>
 );
 
 interface RenderTreeOptions {
   selectedId?: string | null;
   inlinePanel?: ReactNode;
+  /** Zooms the map to a node's errors; wired only when a map is present. */
+  onZoom?: (nodeId: string) => void;
+  /** Structural ids of zoomable nodes; the zoom control is rendered only for these. */
+  zoomableNodeIds?: ReadonlySet<string>;
 }
 
 export const renderTreeItems = (nodes: TreeNode[], prefix = "n", options?: RenderTreeOptions): ReactNode =>
   nodes.flatMap((node, index) => {
     const id = nodeId(prefix, index);
     const hasChildren = node.values && node.values.length > 0;
+    const onZoom = options?.onZoom;
+    const zoomButton =
+      onZoom && options?.zoomableNodeIds?.has(id) ? (
+        <IconButton
+          className="tree-zoom-button"
+          size="small"
+          color="primary"
+          label="zoomToError"
+          tooltipPlacement="left"
+          icon={<MapOutlinedIcon />}
+          sx={{ ml: "auto", flexShrink: 0 }}
+          onMouseDown={event => event.stopPropagation()}
+          onClick={event => {
+            event.stopPropagation();
+            onZoom(id);
+          }}
+        />
+      ) : null;
     const item = (
-      <TreeItem key={id} itemId={id} label={renderLabel(node)}>
+      <TreeItem key={id} itemId={id} label={renderLabel(node, zoomButton)}>
         {hasChildren ? renderTreeItems(node.values!, id, options) : null}
       </TreeItem>
     );

--- a/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/treeVisualization.tsx
+++ b/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/treeVisualization.tsx
@@ -24,6 +24,10 @@ interface TreeVisualizationProps {
   shownCount: number;
   /** Whether the tree is shown in a fullscreen map or inline. */
   fullscreen?: boolean;
+  /** Called with the structural node id to zoom the map to that node's errors (leaf or group). */
+  onZoom?: (nodeId: string) => void;
+  /** Structural ids of nodes whose subtree has at least one error present on the map (i.e. zoomable). */
+  zoomableNodeIds?: ReadonlySet<string>;
 }
 
 // Once the tree can no longer keep its minimum width next to the detail box, the box is
@@ -68,6 +72,8 @@ export const TreeVisualization = ({
   totalCount,
   shownCount,
   fullscreen,
+  onZoom,
+  zoomableNodeIds,
 }: TreeVisualizationProps) => {
   const { t } = useTranslation();
   const [expandedItems, setExpandedItems] = useState<string[]>([]);
@@ -119,14 +125,16 @@ export const TreeVisualization = ({
   const hasMetadata = !!selectedNode?.metadata && Object.keys(selectedNode.metadata).length > 0;
 
   const items = useMemo(() => {
+    const zoomOptions = { onZoom, zoomableNodeIds };
     if (!sideBySide && hasMetadata) {
       return renderTreeItems(nodes, "n", {
+        ...zoomOptions,
         selectedId,
         inlinePanel: <MetadataPanel node={selectedNode} />,
       });
     }
-    return renderTreeItems(nodes);
-  }, [nodes, sideBySide, hasMetadata, selectedId, selectedNode]);
+    return renderTreeItems(nodes, "n", zoomOptions);
+  }, [nodes, sideBySide, hasMetadata, selectedId, selectedNode, onZoom, zoomableNodeIds]);
 
   // Align the box's top with the selected row, but keep it within the tree so a selection far down does not
   // push the box past the tree and grow the accordion: clamp to the tree's bottom edge. Recompute when
@@ -189,7 +197,15 @@ export const TreeVisualization = ({
               onSelectedItemsChange={(_: SyntheticEvent, itemId: string | null) => onSelect(itemId)}
               expandedItems={expandedItems}
               onExpandedItemsChange={(_: SyntheticEvent, itemIds: string[]) => setExpandedItems(itemIds)}
-              sx={{ "& .MuiTreeItem-content": { pl: 0 } }}>
+              sx={{
+                "& .MuiTreeItem-content": { pl: 0 },
+                "& .tree-zoom-button": { opacity: 0, transition: "opacity 0.1s ease" },
+                "& .MuiTreeItem-content:hover .tree-zoom-button": { opacity: 1 },
+                // Keyboard focus of the button and touch devices (no hover) still reveal it; selection alone
+                // does not, so a selected row shows the control only while hovered.
+                "& .tree-zoom-button:focus-visible": { opacity: 1 },
+                "@media (hover: none)": { "& .tree-zoom-button": { opacity: 1 } },
+              }}>
               {items}
             </SimpleTreeView>
           </Box>

--- a/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/xtfErrorVisualization.tsx
+++ b/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/xtfErrorVisualization.tsx
@@ -97,8 +97,8 @@ export const XtfErrorVisualization: FC<XtfErrorVisualizationProps> = ({ config }
   const handleZoomToNode = useCallback(
     (nodeId: string) => {
       setSelectedNodeId(nodeId);
-      const errorIds = errorIdsByNodeId.get(nodeId) ?? [];
-      setZoomRequest(prev => ({ errorIds, token: (prev?.token ?? 0) + 1 }));
+      const featureIds = errorIdsByNodeId.get(nodeId) ?? [];
+      setZoomRequest(prev => ({ featureIds, token: (prev?.token ?? 0) + 1 }));
     },
     [errorIdsByNodeId],
   );

--- a/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/xtfErrorVisualization.tsx
+++ b/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/xtfErrorVisualization.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo, useState } from "react";
+import { FC, useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import OpenInFullIcon from "@mui/icons-material/OpenInFull";
 import { Box, Modal, Stack, useTheme } from "@mui/material";
@@ -8,7 +8,7 @@ import { GeopilotBox } from "../../../../components/styledComponents";
 import { useLocalized } from "../../../../hooks/useLocalized";
 import { stopStepSwipePropagation } from "../../../../hooks/useStepSwipe";
 import { FilterBar } from "./filterBar";
-import { MapVisualization } from "./mapVisualization";
+import { MapVisualization, MapZoomRequest } from "./mapVisualization";
 import { MapVisualizationProvider } from "./mapVisualizationProvider";
 import { buildErrorIdIndex, buildTree, collectMetadataAttributes, filterItems, MetadataFilters } from "./treeNode";
 import { TreeVisualization } from "./treeVisualization";
@@ -39,6 +39,7 @@ export const XtfErrorVisualization: FC<XtfErrorVisualizationProps> = ({ config }
   const [metadataFilters, setMetadataFilters] = useState<MetadataFilters>({});
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [fullscreen, setFullscreen] = useState(false);
+  const [zoomRequest, setZoomRequest] = useState<MapZoomRequest | null>(null);
 
   const items = useMemo(() => config.tree?.items ?? [], [config.tree]);
   const groupBy = useMemo(() => config.tree?.groupBy ?? [], [config.tree]);
@@ -72,6 +73,20 @@ export const XtfErrorVisualization: FC<XtfErrorVisualizationProps> = ({ config }
     [selectedNodeId, errorIdsByNodeId],
   );
 
+  // Error ids that actually have a feature on the map; a tree node is zoomable only when its subtree holds
+  // at least one of them. Without a map (tree-only visualization) nothing is zoomable.
+  const mappableErrorIds = useMemo(
+    () => new Set((config.map?.layers ?? []).flatMap(layer => layer.features?.map(feature => feature.errorId) ?? [])),
+    [config.map],
+  );
+  const zoomableNodeIds = useMemo(() => {
+    const zoomable = new Set<string>();
+    for (const [id, errorIds] of errorIdsByNodeId) {
+      if (errorIds.some(errorId => mappableErrorIds.has(errorId))) zoomable.add(id);
+    }
+    return zoomable;
+  }, [errorIdsByNodeId, mappableErrorIds]);
+
   const handleMetadataFilterChange = (key: string, selected: string[]) =>
     setMetadataFilters(current => ({ ...current, [key]: selected }));
   const handleClearFilters = () => {
@@ -79,6 +94,14 @@ export const XtfErrorVisualization: FC<XtfErrorVisualizationProps> = ({ config }
     setMetadataFilters({});
   };
   const handleSelectFeature = (errorId: string) => setSelectedNodeId(nodeIdByErrorId.get(errorId) ?? null);
+  const handleZoomToNode = useCallback(
+    (nodeId: string) => {
+      setSelectedNodeId(nodeId);
+      const errorIds = errorIdsByNodeId.get(nodeId) ?? [];
+      setZoomRequest(prev => ({ errorIds, token: (prev?.token ?? 0) + 1 }));
+    },
+    [errorIdsByNodeId],
+  );
 
   const filter = config.tree && (
     <FilterBar
@@ -96,6 +119,7 @@ export const XtfErrorVisualization: FC<XtfErrorVisualizationProps> = ({ config }
       config={config.map}
       visibleErrorIds={visibleErrorIds}
       highlightedErrorIds={highlightedErrorIds}
+      zoomRequest={zoomRequest}
       onSelectFeature={handleSelectFeature}
       showMapSelectionPopup={!config.tree}
       reserveSpaceForFilters={!!config.tree}
@@ -108,6 +132,8 @@ export const XtfErrorVisualization: FC<XtfErrorVisualizationProps> = ({ config }
       nodes={nodes}
       selectedId={selectedNodeId}
       onSelect={setSelectedNodeId}
+      onZoom={handleZoomToNode}
+      zoomableNodeIds={zoomableNodeIds}
       filterActive={hasActiveFilters}
       totalCount={items.length}
       shownCount={filteredItems.length}


### PR DESCRIPTION
Resolves #759 

Selecting an error now only highlights it. Each error-tree row (single errors and parent groups) has a hover zoom control that zooms the map to that error's features.