### PR TITLE
Show base map copyright on XTF error map

### DIFF
--- a/src/Geopilot.Frontend/public/locale/de/common.json
+++ b/src/Geopilot.Frontend/public/locale/de/common.json
@@ -94,6 +94,7 @@
   "mandateSaveError": "Beim Speichern des Mandats ist ein Fehler aufgetreten: {{error}}",
   "mandates": "Mandate",
   "mandatesLoadingError": "Beim Laden der Mandate ist ein Fehler aufgetreten: {{error}}",
+  "mapCopyrightPrefix": "© Daten:",
   "mapVisualizationFeatureLayer": "Objekte",
   "mapZoomIn": "Vergrössern",
   "mapZoomOut": "Verkleinern",

--- a/src/Geopilot.Frontend/public/locale/en/common.json
+++ b/src/Geopilot.Frontend/public/locale/en/common.json
@@ -94,6 +94,7 @@
   "mandateSaveError": "An error occurred while saving the mandate: {{error}}",
   "mandates": "Mandates",
   "mandatesLoadingError": "An error occurred while loading the mandates: {{error}}",
+  "mapCopyrightPrefix": "© Data:",
   "mapVisualizationFeatureLayer": "Features",
   "mapZoomIn": "Zoom in",
   "mapZoomOut": "Zoom out",

--- a/src/Geopilot.Frontend/public/locale/fr/common.json
+++ b/src/Geopilot.Frontend/public/locale/fr/common.json
@@ -94,6 +94,7 @@
   "mandateSaveError": "Une erreur s'est produite lors de l'enregistrement du mandat: {{error}}",
   "mandates": "Mandats",
   "mandatesLoadingError": "Une erreur s'est produite lors du chargement des mandats: {{error}}",
+  "mapCopyrightPrefix": "© Données:",
   "mapVisualizationFeatureLayer": "Entités",
   "mapZoomIn": "Zoom avant",
   "mapZoomOut": "Zoom arrière",

--- a/src/Geopilot.Frontend/public/locale/it/common.json
+++ b/src/Geopilot.Frontend/public/locale/it/common.json
@@ -94,6 +94,7 @@
   "mandateSaveError": "Si è verificato un errore durante il salvataggio del mandato: {{error}}",
   "mandates": "Mandati",
   "mandatesLoadingError": "Si è verificato un errore durante il caricamento dei mandati: {{error}}",
+  "mapCopyrightPrefix": "© Dati:",
   "mapVisualizationFeatureLayer": "Elementi",
   "mapZoomIn": "Ingrandisci",
   "mapZoomOut": "Riduci",

--- a/src/Geopilot.Frontend/src/api/apiInterfaces.ts
+++ b/src/Geopilot.Frontend/src/api/apiInterfaces.ts
@@ -136,6 +136,10 @@ export interface MapLayer {
    * transparent variant, the fill color for polygons. Only meaningful for feature layers.
    */
   color?: string;
+  /** Attribution / data-owner credit for the layer (e.g. "swisstopo"); shown as a copyright credit, the client prepends a localized "©" label. */
+  attribution?: string;
+  /** Optional URL the attribution links to; when set, the credit is rendered as a link. */
+  attributionUrl?: string;
   /** Features rendered directly from the config. Set for feature layers. */
   features?: MapFeature[];
 }

--- a/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/mapVisualization.tsx
+++ b/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/mapVisualization.tsx
@@ -1,4 +1,4 @@
-import { MutableRefObject, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, MutableRefObject, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import AddIcon from "@mui/icons-material/Add";
 import CloseIcon from "@mui/icons-material/Close";
@@ -539,38 +539,38 @@ export const MapVisualization = ({
         </>
       )}
       {attributions.length > 0 && (
-        <Stack
-          direction="row"
+        <Typography
+          variant="caption"
           sx={{
             position: "absolute",
             bottom: 0,
             left: 0,
             px: 0.75,
             py: 0.25,
-            gap: 1,
             maxWidth: "100%",
-            backgroundColor: alpha(theme.palette.background.paper, 0.8),
+            backgroundColor: alpha(theme.palette.background.paper, 0.7),
             borderTopRightRadius: theme.spacing(0.5),
+            lineHeight: 1.2,
           }}>
-          {attributions.map(attribution => (
-            <Typography key={attribution.text} variant="caption" color="text.secondary">
-              {t("mapCopyrightPrefix")}{" "}
+          {t("mapCopyrightPrefix")}{" "}
+          {attributions.map((attribution, index) => (
+            <Fragment key={attribution.text}>
+              {index > 0 && ", "}
               {attribution.url ? (
                 <Link
                   href={attribution.url}
                   target="_blank"
                   rel="noopener noreferrer"
                   variant="inherit"
-                  color="inherit"
-                  underline="always">
+                  color="inherit">
                   {attribution.text}
                 </Link>
               ) : (
                 attribution.text
               )}
-            </Typography>
+            </Fragment>
           ))}
-        </Stack>
+        </Typography>
       )}
     </Box>
   );

--- a/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/mapVisualization.tsx
+++ b/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/mapVisualization.tsx
@@ -405,8 +405,6 @@ export const MapVisualization = ({
           target: mapContainerRef.current,
           layers,
           overlays: [overlay],
-          // Attribution control disabled: the copyright is rendered as a themed React overlay instead
-          // (OpenLayers' control renders attributions via innerHTML, which the app's Trusted Types CSP blocks).
           controls: defaultControls({ zoom: false, attribution: false }),
           view: new View({ projection: SWISS_PROJECTION, extent: SWISS_EXTENT }),
         });

--- a/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/mapVisualization.tsx
+++ b/src/Geopilot.Frontend/src/pages/delivery/processing/visualizations/mapVisualization.tsx
@@ -4,8 +4,8 @@ import AddIcon from "@mui/icons-material/Add";
 import CloseIcon from "@mui/icons-material/Close";
 import RemoveIcon from "@mui/icons-material/Remove";
 import ZoomOutMapIcon from "@mui/icons-material/ZoomOutMap";
-import { Box, ButtonGroup, Stack } from "@mui/material";
-import { useTheme } from "@mui/material/styles";
+import { Box, ButtonGroup, Link, Stack, Typography } from "@mui/material";
+import { alpha, useTheme } from "@mui/material/styles";
 import i18next from "i18next";
 import { defaults as defaultControls } from "ol/control";
 import { containsExtent, createEmpty, extend as extendExtent, getCenter, isEmpty as isExtentEmpty } from "ol/extent";
@@ -390,7 +390,9 @@ export const MapVisualization = ({
           target: mapContainerRef.current,
           layers,
           overlays: [overlay],
-          controls: defaultControls({ zoom: false }),
+          // Attribution control disabled: the copyright is rendered as a themed React overlay instead
+          // (OpenLayers' control renders attributions via innerHTML, which the app's Trusted Types CSP blocks).
+          controls: defaultControls({ zoom: false, attribution: false }),
           view: new View({ projection: SWISS_PROJECTION, extent: SWISS_EXTENT }),
         });
         mapRef.current = map;
@@ -471,6 +473,12 @@ export const MapVisualization = ({
     }
   }, [map, visibleErrorIds, highlightedErrorIds, fitOptions]);
 
+  // Copyright/attribution credits declared by the config's layers (typically the base map). Shown as an
+  // overlay in the bottom-right corner; rendered as a link when the layer provides a URL.
+  const attributions = config.layers.flatMap(layer =>
+    layer.attribution ? [{ text: layer.attribution, url: layer.attributionUrl }] : [],
+  );
+
   return (
     <Box
       {...stopStepSwipePropagation}
@@ -529,6 +537,40 @@ export const MapVisualization = ({
           </Stack>
           <LayerSwitcher map={map} onLayerChange={() => captureLayerState(map)} />
         </>
+      )}
+      {attributions.length > 0 && (
+        <Stack
+          direction="row"
+          sx={{
+            position: "absolute",
+            bottom: 0,
+            left: 0,
+            px: 0.75,
+            py: 0.25,
+            gap: 1,
+            maxWidth: "100%",
+            backgroundColor: alpha(theme.palette.background.paper, 0.8),
+            borderTopRightRadius: theme.spacing(0.5),
+          }}>
+          {attributions.map(attribution => (
+            <Typography key={attribution.text} variant="caption" color="text.secondary">
+              {t("mapCopyrightPrefix")}{" "}
+              {attribution.url ? (
+                <Link
+                  href={attribution.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  variant="inherit"
+                  color="inherit"
+                  underline="always">
+                  {attribution.text}
+                </Link>
+              ) : (
+                attribution.text
+              )}
+            </Typography>
+          ))}
+        </Stack>
       )}
     </Box>
   );

--- a/src/Geopilot.Pipeline/Processes/XtfErrorVisualization/MapVisualizationBuilder.cs
+++ b/src/Geopilot.Pipeline/Processes/XtfErrorVisualization/MapVisualizationBuilder.cs
@@ -18,6 +18,17 @@ internal static class MapVisualizationBuilder
     public const string DefaultBaseMapWmtsCapabilitiesUrl = "https://wmts.geo.admin.ch/EPSG/2056/1.0.0/WMTSCapabilities.xml";
 
     /// <summary>
+    /// Default data-owner credit shown for the swisstopo base map.
+    /// </summary>
+    public const string DefaultBaseMapAttribution = "swisstopo";
+
+    /// <summary>
+    /// Default target the base map attribution links to: the swisstopo terms of use for free geodata and
+    /// geoservices.
+    /// </summary>
+    public const string DefaultBaseMapAttributionUrl = "https://www.swisstopo.admin.ch/de/nutzungsbedingungen-kostenlose-geodaten-und-geodienste";
+
+    /// <summary>
     /// Identifier of the swisstopo colored national map: the default base map. Without it the client would
     /// add every layer the WMTS service advertises.
     /// </summary>
@@ -58,8 +69,10 @@ internal static class MapVisualizationBuilder
     /// </summary>
     /// <param name="errors">The parsed validator errors.</param>
     /// <param name="baseMapWmtsCapabilitiesUrl">The base map WMTS capabilities URL to use.</param>
+    /// <param name="baseMapAttribution">The base map copyright/attribution text.</param>
+    /// <param name="baseMapAttributionUrl">The URL the base map attribution links to.</param>
     /// <returns>The map visualization config.</returns>
-    public static MapVisualizationConfig Build(IReadOnlyList<IndexedError> errors, string baseMapWmtsCapabilitiesUrl)
+    public static MapVisualizationConfig Build(IReadOnlyList<IndexedError> errors, string baseMapWmtsCapabilitiesUrl, string baseMapAttribution, string baseMapAttributionUrl)
     {
         var errorFeatures = errors
             .Where(error => error.Error.Geometry?.Coord != null)
@@ -80,6 +93,8 @@ internal static class MapVisualizationBuilder
                     Title = BaseMapLayerTitle,
                     Wmts = baseMapWmtsCapabilitiesUrl,
                     LayerIds = [GrayBaseMapLayerId, DefaultBaseMapLayerId],
+                    Attribution = baseMapAttribution,
+                    AttributionUrl = baseMapAttributionUrl,
                 },
                 new MapLayer { Title = ErrorLayerTitle, Color = ErrorLayerColor, Features = errorFeatures },
             ],

--- a/src/Geopilot.Pipeline/Processes/XtfErrorVisualization/XtfErrorVisualizationProcess.cs
+++ b/src/Geopilot.Pipeline/Processes/XtfErrorVisualization/XtfErrorVisualizationProcess.cs
@@ -27,6 +27,8 @@ internal class XtfErrorVisualizationProcess
     private readonly bool includeMap;
     private readonly bool includeTree;
     private readonly string baseMapWmtsCapabilitiesUrl;
+    private readonly string baseMapAttribution;
+    private readonly string baseMapAttributionUrl;
     private readonly IReadOnlyList<string> groupBy;
     private readonly IReadOnlyList<string> filterBy;
 
@@ -37,7 +39,9 @@ internal class XtfErrorVisualizationProcess
     /// <param name="baseMapWmtsCapabilitiesUrl">Optional override for the base map WMTS capabilities URL.</param>
     /// <param name="groupBy">Metadata keys the frontend groups the tree items by. Null means no grouping (a flat list).</param>
     /// <param name="filterBy">Metadata keys the frontend offers as filters, in display order. Null means no filters are offered.</param>
-    public XtfErrorVisualizationProcess(HashSet<string>? include = null, string? baseMapWmtsCapabilitiesUrl = null, IReadOnlyList<string>? groupBy = null, IReadOnlyList<string>? filterBy = null)
+    /// <param name="baseMapAttribution">Optional override for the base map copyright/attribution text.</param>
+    /// <param name="baseMapAttributionUrl">Optional override for the URL the base map attribution links to.</param>
+    public XtfErrorVisualizationProcess(HashSet<string>? include = null, string? baseMapWmtsCapabilitiesUrl = null, IReadOnlyList<string>? groupBy = null, IReadOnlyList<string>? filterBy = null, string? baseMapAttribution = null, string? baseMapAttributionUrl = null)
     {
         var selected = include is { Count: > 0 }
             ? new HashSet<string>(include, StringComparer.OrdinalIgnoreCase)
@@ -47,6 +51,12 @@ internal class XtfErrorVisualizationProcess
         this.baseMapWmtsCapabilitiesUrl = string.IsNullOrWhiteSpace(baseMapWmtsCapabilitiesUrl)
             ? MapVisualizationBuilder.DefaultBaseMapWmtsCapabilitiesUrl
             : baseMapWmtsCapabilitiesUrl;
+        this.baseMapAttribution = string.IsNullOrWhiteSpace(baseMapAttribution)
+            ? MapVisualizationBuilder.DefaultBaseMapAttribution
+            : baseMapAttribution;
+        this.baseMapAttributionUrl = string.IsNullOrWhiteSpace(baseMapAttributionUrl)
+            ? MapVisualizationBuilder.DefaultBaseMapAttributionUrl
+            : baseMapAttributionUrl;
         this.groupBy = groupBy ?? [];
         this.filterBy = filterBy ?? [];
     }
@@ -65,7 +75,7 @@ internal class XtfErrorVisualizationProcess
 
         var config = new XtfErrorVisualizationConfig
         {
-            Map = includeMap ? MapVisualizationBuilder.Build(errors, baseMapWmtsCapabilitiesUrl) : null,
+            Map = includeMap ? MapVisualizationBuilder.Build(errors, baseMapWmtsCapabilitiesUrl, baseMapAttribution, baseMapAttributionUrl) : null,
             Tree = includeTree
                 ? new TreeVisualizationConfig { Items = LogErrorToTreeItemMapper.Map(errors), GroupBy = groupBy }
                 : null,

--- a/src/Geopilot.Pipeline/Visualization/MapVisualizationConfig.cs
+++ b/src/Geopilot.Pipeline/Visualization/MapVisualizationConfig.cs
@@ -56,6 +56,23 @@ internal class MapLayer
     public string? Color { get; set; }
 
     /// <summary>
+    /// Attribution / data-owner credit for the layer (for example <c>swisstopo</c>), shown as a copyright
+    /// credit on the map; the client adds a localized "©" prefix. Typically set on the base map layer.
+    /// Optional.
+    /// </summary>
+    [JsonPropertyName("attribution")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Attribution { get; set; }
+
+    /// <summary>
+    /// Optional URL the attribution links to (for example the map owner's terms of use). When set, the
+    /// client renders <see cref="Attribution"/> as a link.
+    /// </summary>
+    [JsonPropertyName("attributionUrl")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AttributionUrl { get; set; }
+
+    /// <summary>
     /// Features rendered directly from the JSON. Set for feature layers; otherwise <see langword="null"/>.
     /// </summary>
     [JsonPropertyName("features")]

--- a/src/Geopilot.Pipeline/Visualization/MapVisualizationConfig.cs
+++ b/src/Geopilot.Pipeline/Visualization/MapVisualizationConfig.cs
@@ -1,6 +1,4 @@
-﻿using System.Text.Json.Serialization;
-
-namespace Geopilot.Pipeline.Visualization;
+﻿namespace Geopilot.Pipeline.Visualization;
 
 /// <summary>
 /// Describes what is displayed in the map visualization on the client. Serializes to the custom
@@ -12,7 +10,6 @@ internal class MapVisualizationConfig
     /// <summary>
     /// The layers displayed in the map, drawn in order. A layer is either a WMTS layer or a feature layer.
     /// </summary>
-    [JsonPropertyName("layers")]
     public required IList<MapLayer> Layers { get; set; }
 }
 
@@ -26,13 +23,11 @@ internal class MapLayer
     /// Localized display title of the layer, keyed by language ("de", "en", ...). Shown in the client's
     /// layer switcher. Optional; the client falls back to a generic title.
     /// </summary>
-    [JsonPropertyName("title")]
     public IDictionary<string, string>? Title { get; set; }
 
     /// <summary>
     /// The capabilities URL of a WMTS map service. Set for WMTS layers; otherwise <see langword="null"/>.
     /// </summary>
-    [JsonPropertyName("wmts")]
     public string? Wmts { get; set; }
 
     /// <summary>
@@ -40,7 +35,6 @@ internal class MapLayer
     /// <see langword="null"/> or empty, the client displays all layers the service advertises (wrapped in a
     /// group layer if there is more than one). Only meaningful for WMTS layers.
     /// </summary>
-    [JsonPropertyName("layerIds")]
     public IList<string>? LayerIds { get; set; }
 
     /// <summary>
@@ -48,7 +42,6 @@ internal class MapLayer
     /// stroke color and a transparent variant of it as the fill color for polygons. Only meaningful for
     /// feature layers. Optional; the client falls back to its theme color.
     /// </summary>
-    [JsonPropertyName("color")]
     public string? Color { get; set; }
 
     /// <summary>
@@ -56,20 +49,17 @@ internal class MapLayer
     /// credit on the map; the client adds a localized "©" prefix. Typically set on the base map layer.
     /// Optional.
     /// </summary>
-    [JsonPropertyName("attribution")]
     public string? Attribution { get; set; }
 
     /// <summary>
     /// Optional URL the attribution links to (for example the map owner's terms of use). When set, the
     /// client renders <see cref="Attribution"/> as a link.
     /// </summary>
-    [JsonPropertyName("attributionUrl")]
     public string? AttributionUrl { get; set; }
 
     /// <summary>
     /// Features rendered directly from the JSON. Set for feature layers; otherwise <see langword="null"/>.
     /// </summary>
-    [JsonPropertyName("features")]
     public IList<MapFeature>? Features { get; set; }
 }
 
@@ -82,18 +72,15 @@ internal class MapFeature
     /// Stable id of the validation error this feature represents, shared with the error's tree node so the
     /// frontend can cross-select map and tree.
     /// </summary>
-    [JsonPropertyName("errorId")]
     public required string ErrorId { get; set; }
 
     /// <summary>
     /// The feature geometry as Well-Known Text (WKT), for example <c>POINT(2600000 1200000)</c>.
     /// </summary>
-    [JsonPropertyName("geom")]
     public required string Geom { get; set; }
 
     /// <summary>
     /// The informational text shown for the feature.
     /// </summary>
-    [JsonPropertyName("info")]
     public required string Info { get; set; }
 }

--- a/src/Geopilot.Pipeline/Visualization/MapVisualizationConfig.cs
+++ b/src/Geopilot.Pipeline/Visualization/MapVisualizationConfig.cs
@@ -27,14 +27,12 @@ internal class MapLayer
     /// layer switcher. Optional; the client falls back to a generic title.
     /// </summary>
     [JsonPropertyName("title")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public IDictionary<string, string>? Title { get; set; }
 
     /// <summary>
     /// The capabilities URL of a WMTS map service. Set for WMTS layers; otherwise <see langword="null"/>.
     /// </summary>
     [JsonPropertyName("wmts")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Wmts { get; set; }
 
     /// <summary>
@@ -43,7 +41,6 @@ internal class MapLayer
     /// group layer if there is more than one). Only meaningful for WMTS layers.
     /// </summary>
     [JsonPropertyName("layerIds")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public IList<string>? LayerIds { get; set; }
 
     /// <summary>
@@ -52,7 +49,6 @@ internal class MapLayer
     /// feature layers. Optional; the client falls back to its theme color.
     /// </summary>
     [JsonPropertyName("color")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Color { get; set; }
 
     /// <summary>
@@ -61,7 +57,6 @@ internal class MapLayer
     /// Optional.
     /// </summary>
     [JsonPropertyName("attribution")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Attribution { get; set; }
 
     /// <summary>
@@ -69,14 +64,12 @@ internal class MapLayer
     /// client renders <see cref="Attribution"/> as a link.
     /// </summary>
     [JsonPropertyName("attributionUrl")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? AttributionUrl { get; set; }
 
     /// <summary>
     /// Features rendered directly from the JSON. Set for feature layers; otherwise <see langword="null"/>.
     /// </summary>
     [JsonPropertyName("features")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public IList<MapFeature>? Features { get; set; }
 }
 

--- a/src/Geopilot.Pipeline/Visualization/TreeItem.cs
+++ b/src/Geopilot.Pipeline/Visualization/TreeItem.cs
@@ -1,6 +1,4 @@
-﻿using System.Text.Json.Serialization;
-
-namespace Geopilot.Pipeline.Visualization;
+﻿namespace Geopilot.Pipeline.Visualization;
 
 /// <summary>
 /// A flat item of the error-tree visualization. The frontend builds the displayed hierarchy by grouping items
@@ -13,20 +11,16 @@ internal sealed class TreeItem
     /// Gets the stable id correlating this item with its map feature so the frontend can cross-select map and tree.
     /// <see langword="null"/> when the item has no correlated feature.
     /// </summary>
-    [JsonPropertyName("id")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Id { get; init; }
 
     /// <summary>
     /// Gets the text shown for this item's leaf node.
     /// </summary>
-    [JsonPropertyName("label")]
     public required string Label { get; init; }
 
     /// <summary>
     /// Gets the item's severity (<c>error</c> or <c>warning</c>); the frontend derives the leaf's icon and colour from it.
     /// </summary>
-    [JsonPropertyName("severity")]
     public required string Severity { get; init; }
 
     /// <summary>
@@ -34,6 +28,5 @@ internal sealed class TreeItem
     /// <c>LocalizedText</c> (a label we generate, e.g. the error category) which serializes to a per-language object.
     /// The keys named in <see cref="TreeVisualizationConfig.GroupBy"/> reference entries of this dictionary.
     /// </summary>
-    [JsonPropertyName("metadata")]
     public required IReadOnlyDictionary<string, object> Metadata { get; init; }
 }

--- a/src/Geopilot.Pipeline/Visualization/TreeVisualizationConfig.cs
+++ b/src/Geopilot.Pipeline/Visualization/TreeVisualizationConfig.cs
@@ -1,6 +1,4 @@
-﻿using System.Text.Json.Serialization;
-
-namespace Geopilot.Pipeline.Visualization;
+﻿namespace Geopilot.Pipeline.Visualization;
 
 /// <summary>
 /// The config for the built-in tree visualization: a flat list of <see cref="Items"/> plus the metadata keys
@@ -13,12 +11,10 @@ internal sealed class TreeVisualizationConfig
     /// <summary>
     /// The flat items. The frontend derives the tree by grouping them on <see cref="GroupBy"/>.
     /// </summary>
-    [JsonPropertyName("items")]
     public required IReadOnlyList<TreeItem> Items { get; init; }
 
     /// <summary>
     /// The metadata keys to group the items by, outermost first (e.g. <c>["Model", "Topic", "Class"]</c>).
     /// </summary>
-    [JsonPropertyName("groupBy")]
     public required IReadOnlyList<string> GroupBy { get; init; }
 }

--- a/src/Geopilot.Pipeline/Visualization/XtfErrorVisualizationConfig.cs
+++ b/src/Geopilot.Pipeline/Visualization/XtfErrorVisualizationConfig.cs
@@ -1,6 +1,4 @@
-﻿using System.Text.Json.Serialization;
-
-namespace Geopilot.Pipeline.Visualization;
+﻿namespace Geopilot.Pipeline.Visualization;
 
 /// <summary>
 /// Composite payload of the built-in XTF error visualization: an optional <see cref="Map"/> and an
@@ -10,13 +8,9 @@ namespace Geopilot.Pipeline.Visualization;
 internal sealed record XtfErrorVisualizationConfig
 {
     /// <summary>Gets the map view, or <see langword="null"/> when the map is not included.</summary>
-    [JsonPropertyName("map")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public MapVisualizationConfig? Map { get; init; }
 
     /// <summary>Gets the error-tree view, or <see langword="null"/> when the tree is not included.</summary>
-    [JsonPropertyName("tree")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public TreeVisualizationConfig? Tree { get; init; }
 
     /// <summary>
@@ -24,7 +18,5 @@ internal sealed record XtfErrorVisualizationConfig
     /// "Class", "Error type"]</c>), or <see langword="null"/> when there is no tree. The filter applies to both
     /// the map and the tree, so it lives on the composite root. Empty means no filters.
     /// </summary>
-    [JsonPropertyName("filterBy")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public IReadOnlyList<string>? FilterBy { get; init; }
 }

--- a/tests/Geopilot.Pipeline.Test/Processes/XtfErrorVisualizationProcessTest.cs
+++ b/tests/Geopilot.Pipeline.Test/Processes/XtfErrorVisualizationProcessTest.cs
@@ -34,6 +34,10 @@ public class XtfErrorVisualizationProcessTest
         Assert.HasCount(2, config.Map.Layers);
         var baseMapLayer = config.Map.Layers[0];
         Assert.AreEqual(SwisstopoBaseMapWmtsCapabilitiesUrl, baseMapLayer.Wmts);
+        Assert.AreEqual("swisstopo", baseMapLayer.Attribution);
+        Assert.AreEqual(
+            "https://www.swisstopo.admin.ch/de/nutzungsbedingungen-kostenlose-geodaten-und-geodienste",
+            baseMapLayer.AttributionUrl);
         Assert.IsNull(baseMapLayer.Features);
         Assert.IsNotNull(baseMapLayer.LayerIds);
         Assert.HasCount(2, baseMapLayer.LayerIds);


### PR DESCRIPTION
Resolves #761 

The WMTS base map layer carries a configurable data-owner credit and link, symmetric to the base layer config. The map renders it in the bottom-left corner as a localized "© Data:" label plus the owner as a link, defaulting to swisstopo linking to the swisstopo terms of use.