### PR TITLE
Add map highlight colour for selected errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Added
 
-- Validation errors can be explored visually in the delivery view: when a validation step fails, its errors are shown on an interactive map and in an error tree. The two views are cross-linked (selecting an error in one highlights it in the other) and share a filter.
+- Validation errors can be explored visually in the delivery view: when a validation step fails, its errors are shown on an interactive map and in an error tree. The two views are cross-linked (selecting an error in one highlights it in the other, with the selected errors marked on the map in a distinct colour) and share a filter.
 - `Visualization` output action in the `GeoWerkstatt.Geopilot.Pipeline` runtime: a pipeline step can tag an output as a self-describing visualization config (a `{ type, data }` envelope), which the runtime serves to the frontend to render based on its `type`.
 - A pipeline step `input` value can reference a file shipped with the deployment via `${file(path)}` (relative to the configured `Storage:ResourcesDirectory`), injecting a constant resource such as a template or lookup table into a process without a preceding step.
 - A pipeline step `input` value can reference the uploaded delivery files with `${upload()}`, so a pipeline definition can wire the upload to a process parameter explicitly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Added
 
-- Validation errors can be explored visually in the delivery view: when a validation step fails, its errors are shown on an interactive map and in an error tree. The two views are cross-linked (selecting an error in one highlights it in the other, with the selected errors marked on the map in a distinct colour) and share a filter.
+- Validation errors can be explored visually in the delivery view: when a validation step fails, its errors are shown on an interactive map and in an error tree.
 - `Visualization` output action in the `GeoWerkstatt.Geopilot.Pipeline` runtime: a pipeline step can tag an output as a self-describing visualization config (a `{ type, data }` envelope), which the runtime serves to the frontend to render based on its `type`.
 - A pipeline step `input` value can reference a file shipped with the deployment via `${file(path)}` (relative to the configured `Storage:ResourcesDirectory`), injecting a constant resource such as a template or lookup table into a process without a preceding step.
 - A pipeline step `input` value can reference the uploaded delivery files with `${upload()}`, so a pipeline definition can wire the upload to a process parameter explicitly.

--- a/src/Geopilot.Frontend/src/appPalette.ts
+++ b/src/Geopilot.Frontend/src/appPalette.ts
@@ -43,6 +43,7 @@ export const themePalette = {
   map: {
     fill: "#e53835",
     stroke: "#ffffff",
+    highlight: "#980303",
   },
   divider: alpha("#124A4F", 0.2),
 } satisfies PaletteOptions;

--- a/src/Geopilot.Frontend/src/components/visualizations/map/layers.ts
+++ b/src/Geopilot.Frontend/src/components/visualizations/map/layers.ts
@@ -91,11 +91,17 @@ export const buildWmtsLayer = async (
   }
 };
 
+/** Colours used to render error features: the marker fill, its outline, and the fill of a selected marker. */
+interface MapFeatureColors {
+  fill: string;
+  stroke: string;
+  highlight: string;
+}
+
 export const buildFeatureLayer = (
   layer: MapLayer,
-  color: string,
+  colors: MapFeatureColors,
   title: LocalizedText | undefined,
-  highlightColor: string,
   projection: string,
   visibleIdsRef: MutableRefObject<ReadonlySet<string> | undefined>,
   highlightedIdsRef: MutableRefObject<ReadonlySet<string>>,
@@ -118,20 +124,20 @@ export const buildFeatureLayer = (
   const defaultStyle = new Style({
     image: new Circle({
       radius: 6,
-      fill: new Fill({ color }),
-      stroke: new Stroke({ color: highlightColor, width: 2 }),
+      fill: new Fill({ color: colors.fill }),
+      stroke: new Stroke({ color: colors.stroke, width: 2 }),
     }),
-    stroke: new Stroke({ color, width: 2 }),
-    fill: new Fill({ color: alpha(color, 0.2) }),
+    stroke: new Stroke({ color: colors.fill, width: 2 }),
+    fill: new Fill({ color: alpha(colors.fill, 0.2) }),
   });
   const highlightStyle = new Style({
     image: new Circle({
       radius: 9,
-      fill: new Fill({ color }),
-      stroke: new Stroke({ color: highlightColor, width: 3 }),
+      fill: new Fill({ color: colors.highlight }),
+      stroke: new Stroke({ color: colors.stroke, width: 3 }),
     }),
-    stroke: new Stroke({ color: highlightColor, width: 3 }),
-    fill: new Fill({ color: alpha(color, 0.2) }),
+    stroke: new Stroke({ color: colors.highlight, width: 3 }),
+    fill: new Fill({ color: alpha(colors.highlight, 0.2) }),
   });
 
   return new VectorLayer({

--- a/src/Geopilot.Frontend/src/components/visualizations/map/layers.ts
+++ b/src/Geopilot.Frontend/src/components/visualizations/map/layers.ts
@@ -138,6 +138,8 @@ export const buildFeatureLayer = (
     }),
     stroke: new Stroke({ color: colors.highlight, width: 3 }),
     fill: new Fill({ color: alpha(colors.highlight, 0.2) }),
+    // Highlighted features are drawn on top so nearby unselected markers cannot cover them.
+    zIndex: 1,
   });
 
   return new VectorLayer({

--- a/src/Geopilot.Frontend/src/components/visualizations/map/mapVisualizationProvider.tsx
+++ b/src/Geopilot.Frontend/src/components/visualizations/map/mapVisualizationProvider.tsx
@@ -195,15 +195,7 @@ export const MapVisualizationProvider: FC<PropsWithChildren<MapVisualizationProv
       const layers: BaseLayer[] = config.layers
         .filter(layer => layer.features)
         .map(layer =>
-          buildFeatureLayer(
-            layer,
-            theme.palette.map.fill,
-            layer.title,
-            theme.palette.map.stroke,
-            SWISS_PROJECTION,
-            visibleIdsRef,
-            highlightedIdsRef,
-          ),
+          buildFeatureLayer(layer, theme.palette.map, layer.title, SWISS_PROJECTION, visibleIdsRef, highlightedIdsRef),
         );
 
       const wmtsLayerConfig = config.layers.find(layer => layer.wmts);

--- a/src/Geopilot.Frontend/src/mui.theme.d.ts
+++ b/src/Geopilot.Frontend/src/mui.theme.d.ts
@@ -22,6 +22,7 @@ declare module "@mui/material/styles" {
   interface PaletteMap {
     fill: string;
     stroke: string;
+    highlight: string;
   }
 
   interface PaletteColor {


### PR DESCRIPTION
Selected error features were emphasised only by a larger radius and a thicker outline, which was hard to spot on a map with many errors. They now also get their own fill colour.

The feature colours are passed as a single object so that the outline colour is no longer named highlightColor, which it never was.

Resolves #789 