### PR TITLE
Pipeline-, Prozessoren- und Plugin-Doku nach docs/ verschieben (#827)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - A pipeline step `input` value can reference the uploaded delivery files with `${upload()}`, so a pipeline definition can wire the upload to a process parameter explicitly.
 - Pipeline processes can use an `IIli2GpkgClient` from `GeoWerkstatt.Geopilot.PipelineCore` to run ili2gpkg operations using an [ilitools-wrapper](https://github.com/geowerkstatt/ilitools-wrapper) service.
 - Mandates can have a description. The description is shown to the users when they choose a mandate before processing.
+- The documentation of the pipeline definition format, of the processors shipped with geopilot and of the plugin system is now published with the code under [`docs/pipeline/`](docs/pipeline/Pipelines.md).
 - Pipeline steps can end in a `Warning` state through a post `warn_conditions` list: the step ran and reported issues but the pipeline continues, shown with a warning icon in the delivery view. A run whose only non-successful steps are warnings is reported as a warning overall, and a warning does not block delivery on its own (delivery stays governed by the pipeline's `delivery_restrictions`). The built-in XTF validation pipelines mark the validation step as a warning when the validation was not successful.
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 geopilot ist ein benutzerfreundliches Tool für das Liefern und Validieren von Geodaten. Es ermöglicht das Hochladen von Geodaten in verschiedenen Formaten und überprüft sie auf Einhaltung geltender Standards. Anwender können ihre hochgeladenen und validierten Daten deklarieren um diese für die Weiterverarbeitung bereit zu stellen. Mit geopilot wird der Prozess der Geodatenverarbeitung für eine reibungslose und zuverlässige Datenübermittlung optimiert.
 
+Die Dokumentation zu Pipelines, den mitgelieferten Prozessoren und dem Plugin-System liegt unter [`docs/`](./docs/README.md).
+
 ## Einrichten der Entwicklungsumgebung
 
 Folgende Komponenten müssen auf dem Entwicklungsrechner installiert sein:
@@ -45,6 +47,8 @@ docker compose up -d
 ### Pipeline-Konfiguration
 
 geopilot verwendet eine YAML-Konfigurationsdatei, um den Validierungs- und Lieferprozess als Pipeline zu definieren. Diese Datei beschreibt die verfügbaren Prozesse (z.B. INTERLIS-Validierung), deren Konfiguration sowie die Schritte, die bei einer Datenlieferung ausgeführt werden. Ein Beispiel befindet sich unter [`src/Geopilot.Api/PipelineDefinitions/basicPipeline_01.yaml`](./src/Geopilot.Api/PipelineDefinitions/basicPipeline_01.yaml).
+
+Das Format der Definition, die mitgelieferten Prozessoren und das Plugin-System sind in der [Pipeline-Dokumentation](./docs/pipeline/Pipelines.md) beschrieben.
 
 Der Pfad zur Pipeline-Konfiguration kann auf zwei Arten festgelegt werden:
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ volumes:
 
 | URL                    | Project                                       | Reverse Proxy                                                             |
 | ---------------------- | --------------------------------------------- | ------------------------------------------------------------------------- |
-| https://localhost:5173 | Geopilot.Frontend                             | `/api` und `/browser` zu https://localhost:7188                           |
-| https://localhost:7188 | Geopilot.Api                                  | `/browser` zu http://localhost:8080 (der `/browser`-Prefix wird entfernt) |
+| https://localhost:5173 | Geopilot.Frontend                             | `/api` und `/browser` zu https://localhost:7443                           |
+| https://localhost:7443 | Geopilot.Api                                  | `/browser` zu http://localhost:8080 (der `/browser`-Prefix wird entfernt) |
 | https://localhost:5173 | Geopilot.Api (in docker-compose mit Frontend) | `/browser` zu http://localhost:8080 (der `/browser`-Prefix wird entfernt) |
 | http://localhost:8080  | stac-browser (in docker-compose)              | -                                                                         |
 | http://localhost:3001  | PgAdmin (in docker-compose)                   | -                                                                         |
@@ -162,7 +162,7 @@ Diese werden beispielsweise bei den [OIDC Scopes](https://openid.net/specs/openi
 ### Redirect URIs
 
 Als erlaubte Redirect URIs müssen für das Login aus dem Frontend `https://<app-domain>` und aus Swagger UI `https://<app-domain>/swagger/oauth2-redirect.html` angegeben werden.
-_([Entwicklungsumgebung](./config/realms/keycloak-geopilot.json): `https://localhost:5173` und `https://localhost:7188/swagger/oauth2-redirect.html`)_
+_([Entwicklungsumgebung](./config/realms/keycloak-geopilot.json): `https://localhost:5173` und `https://localhost:7443/swagger/oauth2-redirect.html`)_
 
 ### Swagger UI
 
@@ -185,7 +185,7 @@ Folgende Appsettings können definiert werden (Beispiel aus [appsettings.Develop
     "FullScope": "openid profile email geopilot.api" // Full scope a client application needs to send as to configure access and id tokens correctly
 
     // Swagger UI auth options
-    "ApiOrigin": "https://localhost:7188", // Swagger UI origin (required)
+    "ApiOrigin": "https://localhost:7443", // Swagger UI origin (required)
     "AuthorizationUrl": "http://localhost:4011/realms/geopilot/protocol/openid-connect/auth", // OAuth2 login URL
     "TokenUrl": "http://localhost:4011/realms/geopilot/protocol/openid-connect/token", // OAuth2 token URL
     "ApiServerScope": "<custom app scope>"

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,11 @@
+# Dokumentation
+
+Dokumentation zu geopilot für Betreiber, Pipeline-Autoren und Plugin-Entwickler. Die Anleitung zum Einrichten der Entwicklungsumgebung befindet sich im [README](../README.md) im Wurzelverzeichnis.
+
+## Pipeline
+
+- [Pipelines](pipeline/Pipelines.md): Grundlagen und Konzepte. Aufbau einer Pipeline, Format der YAML-Definition, Datenfluss zwischen den Schritten, Status-Modell, Konfiguration der Prozessoren, Conditions und Einschränkungen für die Datenlieferung.
+- [Prozessoren](pipeline/Pipelines.md#prozesse): Referenz zu jedem Prozessor, welcher mit geopilot ausgeliefert wird, je mit Implementierungsname, Konfiguration, Inputs und Outputs.
+- [Plugin System](pipeline/pluginSystem.md): Wie eigene Prozessoren als Plugin entwickelt und in geopilot eingebunden werden. Baut auf [Pipelines](pipeline/Pipelines.md) auf.
+
+Die Beispiel-Definitionen, welche mit geopilot ausgeliefert werden, liegen unter [`src/Geopilot.Api/PipelineDefinitions/`](../src/Geopilot.Api/PipelineDefinitions/).

--- a/docs/pipeline/Pipelines.md
+++ b/docs/pipeline/Pipelines.md
@@ -1,0 +1,438 @@
+# Dokumentation und Konzepte im Zusammenhang mit geopilot und Pipelines
+
+## Was ist eine Pipeline bei geopilot?
+
+Eine Pipeline in geopilot ist eine Abfolge von Verarbeitungsschritten, die auf hochgeladene Daten angewendet werden, um ein bestimmtes Ergebnis zu erzielen.
+Diese Schritte können verschiedene Operationen umfassen, wie z.B. Validierung, Transformation, Analyse oder Visualisierung.
+Pipelines ermöglichen es, komplexe Datenverarbeitungsprozesse zu automatisieren und effizient zu gestalten.
+Dabei können verschiedene Inputs und Outputs der Schritte miteinander verbunden werden, um die gewünschten Ergebnisse zu erzielen.
+
+Die von der Pipeline verarbeiteten Daten können im Anschluss für die Datenlieferung verwendet werden.
+
+## Wie ist eine Pipeline aufgebaut?
+
+Alle Pipeline-Definitionen werden in einer gemeinsamen Pipeline-Konfigurationsdatei definiert. Pro Umgebung gibt es genau eine solche Konfigurationsdatei. Die Konfiguration wird in einer YAML-Datei erstellt. Eine Pipeline seinerseits enthält einen oder mehrere Schritte und beschreibt deren Konfigurationen und Logik. Der Aufbau einer Pipeline-Definition ist folgendermassen strukturiert:
+
+- __Prozesse__: Eine Liste von möglichen Prozessen (processes), die in den Schritten (steps) verwendet werden können. Jeder Prozess hat eine eindeutige Identifikation (ID), über die er in den Schritten referenziert werden kann. Ein Prozess kann dabei in mehreren Schritten verwendet werden. Ein Prozess kann eine Standardkonfiguration haben, welche in den Schritten überschrieben werden kann. Jeder Prozess muss die Klasse, welche die Logik des Prozesses enthält, definieren.
+- __Pipelines__: Eine Liste von Pipelines, welche die Verarbeitungsschritte beschreibt, die sequenziell ausgeführt werden. Jede Pipeline hat eine eindeutige Identifikation (ID) und eine Liste von Schritten.
+  - __Schritte__: Eine Liste von Schritten, die in der Pipeline ausgeführt werden. Jeder Schritt hat eine innerhalb der Pipeline eindeutige Identifikation (ID). Des Weiteren definiert der Schritt, wie er an seine Daten kommt und wie er seine Ergebnisse zur Verfügung stellt. Eine Referenz auf einen Prozess definiert die Logik des Schrittes, welche ausgeführt wird. Die Konfiguration des Schrittes überschreibt die Standardkonfiguration des Prozesses, und definiert somit die spezifische Logik des Schrittes.
+
+## Wer darf eine Pipeline ausführen?
+
+Die Berechtigung zur Ausführung einer Pipeline wird über die Mandate geregelt. Ein solches Mandat kann entweder öffentlich sein oder über die Organisation einem Benutzer zugeordnet werden.
+
+## Wie ist der Ablauf einer Pipeline-Ausführung?
+
+Zu Beginn wählt der Anwender ein Mandat aus welches per ID auf eine Pipeline referenziert. Anhand dieser Referenz wird die Pipeline-Definition geladen. Jede Ausführung besitzt dabei seine eigene Pipeline-Instanz, welche die Informationen über die Ausführung der Pipeline enthält, wie z.B. die aktuellen Schritte und Prozessoren. Die Schritte innerhalb der Pipeline werden sequenziell ausgeführt, d.h. es wird erst mit dem nächsten Schritt begonnen, wenn der vorherige Schritt abgeschlossen ist.
+
+### Status der Pipeline und Schritte
+
+Schlägt ein Schritt fehl, so schlägt die gesamte Pipeline-Ausführung fehl und die darauffolgenden Schritte werden nicht ausgeführt. 
+
+#### Schritte
+
+Die Schritte können dabei verschiedene Stati durchlaufen, welche den aktuellen Stand der Schritt-Ausführung beschreiben. Diese Stati sind:
+
+- `Pending`: Schritt wurde noch nicht gestartet, und befindet sich in der Warteschlange.
+- `Skipped`: Schritt wurde aufgrund einer Condition übersprungen und nicht ausgeführt ([Bedingungen](#conditions-auf-schritten)).
+- `Running`: Schritt ist aktuell in Bearbeitung.
+- `Success`: Schritt wurde erfolgreich abgeschlossen.
+- `Warning`: Schritt wurde ausgeführt, hat aber Probleme gemeldet (eine `warn_conditions`-POST-Condition traf zu). Die Pipeline läuft normal weiter; der Schritt gilt nicht als Fehler.
+- `Error`: Schritt ist durch eigene Verarbeitungslogik fehlgeschlagen.
+- `Cancelled`: Schritt wurde vor Abschluss von aussen abgebrochen (z.B. Job-Timeout oder Shutdown des Hosts). Wird bewusst von `Error` unterschieden, weil der Schritt nicht aufgrund eines Verarbeitungsfehlers, sondern durch eine externe Unterbrechung beendet wurde.
+
+#### Pipeline
+
+Der Status der Pipeline ergibt sich aus den Stati der Schritte.
+
+- `Pending`: Alle Schritte befinden sich im Status `Pending`.
+- `Running`: Ein Schritt befindet sich im Status `Running`, und es gibt keinen Schritt im Status `Error`.
+- `Success`: Alle Schritte haben mit dem Status `Success` oder `Skipped` abgeschlossen.
+- `Warning`: Alle Schritte haben terminal abgeschlossen, mindestens einer im Status `Warning` und die übrigen `Success` oder `Skipped` (kein `Error`, kein `Cancelled`). Ein `Warning`-Status verhindert die Datenlieferung nicht von sich aus; ob geliefert werden darf, entscheiden weiterhin die Delivery-Restrictions.
+- `Failed`: Ein Schritt hat mit dem Status `Error` abgeschlossen (die darauffolgenden Schritte wurden nicht mehr ausgeführt).
+- `Cancelled`: Mindestens ein Schritt befindet sich im Status `Cancelled` und kein Schritt ist im Status `Error`. Tritt auf, wenn die Pipeline während der Ausführung von aussen abgebrochen wurde (z.B. Job-Timeout oder Shutdown des Hosts). Eine `Cancelled`-Pipeline verhindert die Datenlieferung, unabhängig von definierten Delivery-Restrictions.
+
+### Datenfluss in der Pipeline
+
+Ein Schritt und somit auch ein Prozess kann 1-n Inputs und 1-n Outputs haben. Die Inputs eines Schrittes werden von vorherigen Schritten bezogen. Ein Input kann zudem die hochgeladenen Dateien über `${upload()}` beziehen. Ebenso kann ein Input über eine Datei-Referenz `${file(pfad)}` eine Datei aus dem konfigurierten Ressourcen-Verzeichnis beziehen. Die Outputs eines Schrittes sind implizit alle öffentlichen, lesbaren Properties seines Prozess-Ergebnisses; sie stehen den darauffolgenden Schritten unter ihrem Property-Namen (PascalCase) zur Verfügung, ohne einzeln deklariert werden zu müssen.
+
+Die Daten der Schritte werden in einem Pipeline-Context akkumuliert. Die Schritte beziehen ihren Input von diesem Pipeline-Context. Am Ende der Pipeline-Ausführung stehen die Ergebnisse zur Datenlieferung oder zum Download bereit. Welche Behandlung eine Ausgabe erhält, wird über `output_actions` gesteuert: dort wird einer Result-Property über ihren Namen eine oder mehrere Actions zugewiesen. Die folgenden Actions können definiert werden:
+
+- `Download`: Die Daten werden zum Download bereitgestellt, und können von den Anwendern heruntergeladen werden. Der Wert muss ein `IPipelineFile` oder eine Sammlung davon (`IEnumerable<IPipelineFile>`) sein; andernfalls schlägt der Schritt zur Laufzeit fehl.
+- `Delivery`: Die Daten werden in der Lieferung mit abgegeben. Der Wert muss ein `IPipelineFile` oder eine Sammlung davon (`IEnumerable<IPipelineFile>`) sein; ein anderer Wert wird ignoriert und es wird nichts geliefert.
+- `StatusMessage`: Kann für die Bereitstellung von Statusnachrichten verwendet werden, welche in der Benutzeroberfläche angezeigt werden. Der Typ für Daten welche als StatusMessage bereitgestellt werden, ist `LocalizedText` (ab PipelineCore 1.3). Aus Gründen der Abwärtskompatibilität wird weiterhin auch ein `Dictionary<string, string>` akzeptiert. Key ist dabei der Sprachcode (z.B. `de`, `en`, `fr`, `it`), und Value die Nachricht in der entsprechenden Sprache.
+- `Visualization`: Markiert die Ausgabe als Visualisierung. Der zugewiesene Wert muss ein `IVisualization`-Envelope sein (keine Datei); andernfalls schlägt der Schritt zur Laufzeit fehl. Die Runtime serialisiert ihn zu JSON (camelCase, `null`-Felder werden weggelassen), legt ihn im dedizierten Visualisierungs-Store ab und vermerkt eine Referenz auf dem Schritt, ausgeliefert wird er über den Visualisierungs-Endpunkt. Das JSON ist ein selbstbeschreibender Envelope `{ "type": <Diskriminator>, "data": <Nutzlast> }`: `type` wählt die Frontend-Komponente, `data` ist die von ihr gerenderte Nutzlast. Das konkrete `data`-Format ist prozessor-spezifisch und bei der jeweiligen Prozessor-Doku beschrieben.
+
+Der Zugriff auf diese Daten erfolgt über eine Referenz in der Form `${step_output(stepId.PropertyName)}`: `stepId` wählt den vorherigen Schritt, von welchem die Daten bezogen werden, und `PropertyName` ist der Name der Result-Property (PascalCase) des Prozesses dieses Schrittes.
+
+Die Daten können dabei verschiedene Typen haben. Dies können einfache Datentypen wie Strings oder Zahlen sein, aber auch komplexe Datentypen wie Dateien (z.B. `IPipelineFile`) oder Listen. Es ist dabei zu beachten, dass die Daten, welche von einem Schritt bereitgestellt werden, von den darauffolgenden Schritten verarbeitet werden können. Um dies zu gewährleisten muss die Dokumentation des jeweilig verwendeten Prozessors konsultiert werden. Dabei muss sowohl der Typ, als auch der Namen, unter welchem die Daten dem Prozessor bereitgestellt werden, übereinstimmen. Stimmt dies nicht überein, schlägt die Pipeline zu Laufzeit fehl.
+
+Es ist möglich, dass die Daten von einem Schritt von mehreren darauffolgenden Schritten verarbeitet werden können. Ebenso ist es möglich, dass sich mehrere Schritte auf den gleichen Datensatz beziehen. Durch diese Möglichkeiten lassen sich Ausführungsstränge öffnen und wieder zusammenführen.
+
+## Wie ist eine Pipeline-Definition aufgebaut?
+
+```yaml
+processes:
+  - id: xtf_matcher
+    implementation: Geopilot.Pipeline.Processes.Matcher.XtfMatcher.XtfMatcherProcess
+    default_config:
+      fileExtensions:
+        - xtf
+  - id: xtf_validator
+    implementation: Geopilot.Pipeline.Processes.XtfValidation.XtfValidatorProcess
+    default_config:
+      validationProfile: DEFAULT
+      pollInterval: 1000
+pipelines:
+  - id: xtf_validation
+    display_name:
+      en: XTF Validation
+      de: XTF Validierung
+      fr: XTF Validation
+      it: XTF Validazione
+    steps:
+      - id: xtf_matching
+        display_name:
+          en: XTF Matching
+          de: XTF Zuordnung
+          fr: XTF Correspondance
+          it: XTF Corrispondenza
+        process_id: xtf_matcher
+      - id: validation
+        display_name:
+          en: XTF Validation
+          de: XTF Validierung
+          fr: XTF Validation
+          it: XTF Validazione
+        process_id: xtf_validator
+        process_config_overwrites:
+          pollInterval: 500
+          validationProfile: PROFILE-A
+        input:
+          iliFile: "${step_output(xtf_matching.XtfFiles)}"
+        output_actions:
+          - property: ErrorLog
+            actions:
+              - Download
+          - property: XtfLog
+            actions:
+              - Download
+```
+
+- `processes`: Liste von Prozessen, welche in den Schritten verwendet werden können.
+  - `processes[X].id`: Die eindeutige ID des Prozesses, welche in den Schritten referenziert werden kann.
+  - `processes[X].implementation`: Die Implementierung für den aktuellen Prozess.
+  - `processes[X].default_config`: Optionale Standard-Konfiguration für den aktuellen Prozess. Die Konfigurationsmöglichkeiten eines spezifischen Prozesses müssen in der Dokumentation des Prozesses nachgeschlagen werden. Diese Konfiguration kann in den Schritten überschrieben werden, um spezifisches Verhalten zu definieren. In diesem konkreten Beispiel definiert die Standard-Konfiguration des XTF Validators (`processes[1]`) das Profil `DEFAULT` und ein Poll-Intervall von 1000ms. Beim XTF Matcher (`processes[0]`) wird die Dateiendung `xtf` als Filter konfiguriert.
+- `pipelines`: Liste von Pipelines, welche die Verarbeitungsschritte beschreiben.
+  - `pipelines[0].id`: Eindeutige ID der Pipeline, welche zur Ausführung der Pipeline verwendet wird. Diese ID wird als Referenz im Mandat verwendet, um die Berechtigung zur Ausführung der Pipeline zu regeln.
+  - `pipelines[0].display_name`: Anzeigename der Pipeline, der in der Benutzeroberfläche verwendet wird. Wir übersetzen üblicherweise die folgenden Sprachen: Deutsch 'de', Englisch 'en', Französisch 'fr' und Italienisch 'it'.
+  - `pipelines[0].delivery_restrictions`: Optionale Liste von Einschränkungen für die Datenlieferung. Jede Einschränkung ist ein Objekt mit `expression` und optionaler `message`. Trifft eine Einschränkung zu, wird die Datenlieferung verhindert (siehe [Einschränkungen für die Datenlieferung](#einschränkungen-für-die-datenlieferung-delivery-restrictions)).
+  - `pipelines[0].steps`: Liste der Schritte, die in der Pipeline ausgeführt werden. In diesem Beispiel ist der erste Schritt (`steps[0]`) der XTF Matcher, welcher die hochgeladenen Dateien filtert, und der zweite Schritt (`steps[1]`) die XTF Validierung.
+    - `pipelines[0].steps[X].id`: ID des Schrittes. Diese ID muss für jeden Schritt innerhalb einer Pipeline eindeutig sein. In diesem Beispiel ist die ID des Matcher-Schrittes `xtf_matching` und die ID des Validierungsschrittes `validation`.
+    - `pipelines[0].steps[X].display_name`: Anzeigename des Schrittes, der in der Benutzeroberfläche verwendet wird. Wir übersetzen üblicherweise die folgenden Sprachen: Deutsch 'de', Englisch 'en', Französisch 'fr' und Italienisch 'it'.
+    - `pipelines[0].steps[X].process_id`: Referenz auf die ID des Prozesses, welche die Logik des Schrittes definiert. In diesem Beispiel wird im Validierungsschritt (`steps[1]`) der Prozess `xtf_validator` verwendet, welcher in der Liste der Prozesse definiert ist (siehe `processes[1].id`).
+    - `pipelines[0].steps[X].process_config_overwrites`: Überschreibt die Standard-Konfiguration des Prozesses, um spezifisches Verhalten für diesen Schritt zu definieren. In diesem Beispiel wird im Validierungsschritt (`steps[1]`) das `pollInterval` auf 500ms verkürzt und das `validationProfile` auf 'PROFILE-A' geändert.
+    - `pipelines[0].steps[X].input`: Definiert, wie der Schritt an seine Eingabedaten kommt. Der Input ist eine Zuordnung (Map) von Prozessparameter-Namen zu Werten: Der Schlüssel ist der Name des Run-Methoden-Parameters, dem der Wert übergeben wird, der Wert ist die Quelle für diesen Parameter. Es können mehrere Parameter definiert werden, welche alle in der Dokumentation des verwendeten Prozessors beschrieben sein müssen. In diesem Beispiel wird im Validierungsschritt (`steps[1]`) der Parameter `iliFile` gesetzt, welcher den Output `XtfFiles` des Schrittes `xtf_matching` bezieht.
+      - Schlüssel (im Beispiel `iliFile`): der Name des Prozessparameters, dem der Wert übergeben wird. Dieser Name muss der Dokumentation des verwendeten Prozesses entnommen werden und einen Parameter der Run-Methode treffen, sonst schlägt die Validierung beim Laden fehl.
+      - Wert: entweder ein Literal (ein direkt geschriebener Wert wie `PROFILE-A`), oder eine Referenz auf den Output eines vorherigen Schrittes in der Form `${step_output(stepId.PropertyName)}`. Dabei ist `stepId` die ID eines Schrittes, welcher sich in der gleichen Pipeline vor dem aktuellen Schritt befindet, und `PropertyName` der Name der Result-Property (PascalCase) dieses Schrittes. Damit der Prozess den Wert korrekt verarbeiten kann, müssen Name und Typ übereinstimmen.
+      - Mehrere Quellen auf denselben Parameter: Als Wert kann eine YAML-Liste von Einträgen (Referenzen und/oder Literale) angegeben werden, welche zu einem einzigen Parameter zusammengeführt werden. Voraussetzung ist, dass der Prozessparameter dafür ausgelegt ist (z.B. ein Array- bzw. `params`-Parameter).
+      - Datei-Referenz: Als Wert kann eine Datei aus dem konfigurierten Ressourcen-Verzeichnis in der Form `${file(pfad)}` referenziert werden. Der Pfad ist relativ zum Ressourcen-Verzeichnis (Appsettings `Storage:ResourcesDirectory`), muss innerhalb dieses Verzeichnisses liegen (kein absoluter Pfad, keine `..`-Segmente) und wird dem Prozessparameter als `IPipelineFile` übergeben. Damit lässt sich eine konstante Datei (z.B. eine Vorlage oder eine Nachschlagetabelle) direkt injizieren, ohne dass ein vorheriger Schritt sie bereitstellen muss. Das Ressourcen-Verzeichnis wird vom Deployment bereitgestellt (z.B. als Volume gemountet).
+    - `pipelines[0].steps[X].output_actions`: Optional. Weist einzelnen Result-Properties des Prozesses eine oder mehrere Actions zu. Die Outputs selbst müssen nicht deklariert werden: alle öffentlichen Properties des Prozess-Ergebnisses stehen den nachfolgenden Schritten implizit unter ihrem Property-Namen zur Verfügung. `output_actions` wird nur benötigt, wenn eine Property zusätzlich behandelt werden soll (herunterladbar, in der Lieferung, als Statusnachricht oder als Visualisierung). In diesem Beispiel werden vom Validierungsschritt (`steps[1]`) die Properties `ErrorLog` und `XtfLog` je zum Download bereitgestellt.
+      - `pipelines[0].steps[X].output_actions[X].property`: Der Name der Result-Property des Prozesses (PascalCase), auf welche die Actions angewendet werden.
+      - `pipelines[0].steps[X].output_actions[X].actions`: Die Liste der Actions für diese Property. Es kann eine oder mehrere Actions geben (z.B. `Download` und `Delivery` gemeinsam).
+
+## Validierungen
+
+Zum Programmstart wird validiert, ob die Pipeline-Definition korrekt ist. Dabei wird geprüft, ob die Definition den Anforderungen entspricht, und ob alle Referenzen korrekt sind. Es werden folgende Validierungen durchgeführt:
+
+- Es muss mindestens ein Prozess vorhanden sein.
+- Jeder Prozess muss eine eindeutige ID haben.
+- Jeder Prozess muss eine Implementierung haben, welche die Logik des Prozesses enthält. Diese Implementierung muss in der Anwendung vorhanden sein, damit der Prozess verwendet werden kann (entweder als mit geopilot ausgelieferter Prozessor oder als über `Pipeline:Plugins` geladenes Plugin-Assembly).
+- Es muss mindestens eine Pipeline vorhanden sein.
+- Jede Pipeline muss eine eindeutige ID haben.
+- Jeder Schritt muss eine eindeutige ID innerhalb der Pipeline haben.
+- Jeder Schritt muss eine gültige Referenz auf einen Prozess haben, welcher in der Liste der Prozesse definiert ist.
+- Eine Input-Referenz `${step_output(stepId.PropertyName)}` muss syntaktisch korrekt sein und auf einen in der Pipeline definierten Schritt zeigen.
+- Eine Input-Referenz darf nur auf vorgängige Schritte zeigen und nicht auf Schritte, welche nach dem aktuellen Schritt kommen.
+- Ob die referenzierte Property auf dem Ergebnistyp des referenzierten Schrittes tatsächlich existiert, wird nicht beim Laden geprüft, sondern erst zur Laufzeit (die Outputs sind implizit und werden per Reflection aufgelöst). Stimmt der Name mit keiner Property überein, schlägt der Schritt zur Laufzeit fehl.
+- Jeder Input-Schlüssel muss einen Parameter der Run-Methode des Prozesses treffen (der `CancellationToken` wird nicht über den Input verdrahtet). Ein Schlüssel, welcher keinen solchen Parameter trifft, lässt die Validierung fehlschlagen.
+- Ein als Literal geschriebener Input-Wert muss sich in den Typ des Zielparameters konvertieren lassen.
+- Eine Datei-Referenz `${file(pfad)}` muss einen relativen Pfad ohne `..`-Segmente verwenden, so dass sie nicht aus dem Ressourcen-Verzeichnis ausbrechen kann.
+- Der Zielparameter einer Datei-Referenz muss ein `IPipelineFile` (oder eine Liste davon) entgegennehmen, und die referenzierte Datei muss im konfigurierten Ressourcen-Verzeichnis vorhanden sein.
+- Innerhalb der `output_actions` eines Schrittes darf dieselbe `property` nicht mehrfach vorkommen.
+- Ein Schritt darf höchstens eine Property mit der Action `StatusMessage` taggen.
+
+## Konfiguration eines Pipeline-Prozessors
+
+Die Konfiguration eines Pipeline-Prozessors erfolgt über die Appsettings von geopilot und über die Pipeline-Definition. Die Namen der Konfiguration müssen der Dokumentation des jeweiligen Prozessors entnommen werden. Der Name der Konfiguration entsprich dabei immer dem Namen des Konstruktorparameters des Prozessors. Ein Prozessor muss genau einen `public` Konstruktor besitzen.
+
+### Konfigurationsmöglichkeiten
+
+Eine Konfiguration besteht immer aus einem Key-Value-Paar, wobei der Key der Name der Konfiguration ist, und der Value der Wert der Konfiguration ist. Die Konfigurationsparameter aus den unterschiedlichen Quellen (Appsettings, Standard-Konfiguration - auf dem Prozessor, überschriebene Konfiguration - auf dem Schritt) werden zu einer Konfiguration zusammengeführt, aber mit klarer Priorität und Restriktionen.
+
+#### Parameter-Typen
+
+Alle Typen von Konfigurationsparameter sind sowohl als Pflicht, als auch als optionale Parameter möglich. Ist ein Pflicht-Parameter in der Initialisierung eines Prozessors definiert, und kann dieser Parameter nicht aus der Konfiguration bezogen werden, schlägt die Pipeline-Ausführung fehl. Optionale Parameter können in der Initialisierung eines Prozessors weggelassen werden, und müssen somit nicht zwingend aus der Konfiguration bezogen werden. Damit der Parameter korrekt der Initialisierung eines Prozessors zugeordnet werden kann, müssen sowohl der Name als auch der Typ des Parameters übereinstimmen.
+
+Es gibt folgende mögliche Typen von Konfigurationsparametern:
+
+- `string`: Ein String-Parameter, welcher einen beliebigen Text enthalten kann. Beispiel: Basis-URL eines Drittanbieter-Services, Filename eines durch den Prozessor generierten Files, Validierungsprofil, ...
+- `int`: Ein Integer-Parameter, welcher eine Ganzzahl enthält. Beispiel: Poll-Intervall in Millisekunden, Anzahl der zu verarbeitenden Objekte, ...
+- `double`: Ein Double-Parameter, welcher eine Gleitkommazahl enthält. Beispiel: Schwellenwert, ...
+- `bool`: Ein Bool-Parameter, welcher einen Wahrheitswert (true/false) enthält. Beispiel: Aktivierungsstatus, Debugging-Optionen, ...
+
+#### Appsettings
+
+1. **Prozessor-Typ**: Der vollqualifizierte Prozessor für welchen die Konfiguration gilt.
+2. **Prozessor-Parameter**: Key-Value-Paar der Parameter.
+
+Ein Beispiel für die Konfiguration eines Pipeline-Prozessors in den Appsettings könnte wie folgt aussehen:
+
+```json
+{
+  "Pipeline": {
+    "ProcessConfigs": {
+      "Geopilot.Pipeline.Processes.XtfValidation.XtfValidatorProcess": {
+        "checkServiceBaseUrl": "http://localhost:3080/"
+      }
+    }
+  }
+}
+```
+
+#### Pipeline-Definition
+
+- `processes[X].default_config`: Standard-Konfiguration für einen Prozess, welche in den Schritten überschrieben werden kann.
+- `pipelines[X].steps[X].process_config_overwrites`: Überschreibt die Standard-Konfiguration des Prozesses, um spezifisches Verhalten für diesen Schritt zu definieren.
+
+Ein Beispiel für die Konfiguration eines Pipeline-Prozessors in der Pipeline könnte wie folgt aussehen:
+ 
+```yaml
+processes:
+  - id: xtf_validator
+    implementation: Geopilot.Pipeline.Processes.XtfValidation.XtfValidatorProcess
+    default_config:
+      validationProfile: DEFAULT
+      pollInterval: 1000
+pipelines:
+  - id: xtf_validation
+    display_name:
+      en: XTF Validation
+    steps:
+      - id: validation
+        display_name:
+          en: XTF Validation
+        process_id: xtf_validator
+        process_config_overwrites:
+          validationProfile: PROFILE-A
+```
+
+### Regeln für die Konfiguration
+
+Die Übernahme eines Konfigurationsparameters ist hierarchisch und wird folgendermassen priorisiert:
+
+1. **Basis-Konfiguration**: Die Basis-Konfiguration eines Prozessors, welche in den Appsettings definiert ist, bildet die Grundlage für die Konfiguration des Prozessors.
+2. **Standard-Konfiguration**: Die Standard-Konfiguration, welche in der Pipeline-Definition unter `processes[X].default_config` definiert ist
+3. **Schritt-spezifische Konfiguration**: Die Schritt-spezifische Konfiguration, welche in der Pipeline-Definition unter `pipelines[X].steps[X].process_config_overwrites` definiert ist, überschreibt die Standard-Konfiguration für diesen spezifischen Schritt.
+
+Für das Überschreiben von Konfigurationsparametern gelten folgende Einschränkungen:
+
+- Basis-Konfigurationen, welche in den Appsettings definiert sind, können nicht von der Pipeline-Definition überschrieben werden. Ein in der Basis-Konfiguration definierter Wert ist somit fix und unveränderbar. Ein Beispiel für einen solchen Konfigurationsparameter ist die Basis-URL eines Drittanbieter-Services, welcher für die gesamte Umgebung gilt (Development, Acceptance, Prod, ...). Um die gleiche Pipeline auf den verschiedenen Umgebungen mit unterschiedlichen Basis-URLs verwenden zu können, sollte dieser Parameter in den Appsettings definiert werden und nicht in der Pipeline-Definition.
+- Das Überschreiben von Konfigurations-Parameter wird in den Schritten unter `pipelines[X].steps[X].process_config_overwrites` vorgenommen. Um ein Konfigurationsparameter zu überschreiben muss dieser Parameter auf der Standard-Konfiguration des Prozesses definiert sein (`processes[X].default_config`). Es ist somit nicht möglich, neue Konfigurationsparameter in den Schritten zu definieren, welche nicht bereits in der Standard-Konfiguration definiert sind.
+
+### Beispiel einer Instanziierung eines Prozessors mit Konfigurationsparametern
+
+Das folgende Beispiel zeigt die Initialisierung des `XtfValidatorProcess` welcher mit geopilot ausgeliefert wird. Es werden die  Konfigurationsparameter `checkServiceBaseUrl`, `validationProfile` und `pollInterval` übergeben. Dabei handelt es sich bei dem Parameter `checkServiceBaseUrl` um einen Pflichtparameter, welcher die Basis-URL des IliCop-Services definiert. Die Parameter `validationProfile` und `pollInterval` sind optionale Parameter, welche das Profil definieren, anhand dessen die Validierung durchgeführt wird, bzw. das Intervall definieren, in welchem der Prozess den Status der Validierung abfragt.
+
+Der `logger` ist nicht Teil der Konfiguration, sondern wird von geopilot bereitgestellt, um innerhalb des Prozesses wichtige Informationen zu loggen. Es wird empfohlen den Logger von geopilot zu verwenden, anstatt einen eigenen Logger zu erstellen, um die Konsistenz der Logs zu gewährleisten und die Logs korrekt in die Log-Management-Lösung von geopilot zu integrieren.
+
+Der `pipelineFileManager` ist ebenfalls nicht Teil der Konfiguration, sondern wird von geopilot bereitgestellt, um das Erstellen von Dateien innerhalb der Pipeline zu ermöglichen. Dabei wir sichergestellt, dass Dateien, welche mit dem `pipelineFileManager` erstellt wurden, nach dem Terminieren der Pipeline wieder abgeräumt werden.
+
+```csharp
+public XtfValidatorProcess(string checkServiceBaseUrl, string? validationProfile, int? pollInterval, IPipelineFileManager pipelineFileManager, ILogger logger)
+{
+}
+```
+
+## Conditions
+
+Conditions ermöglichen es, die Ausführung von Schritten und somit der Pipeline oder die Bereitstellung von Daten zu steuern. Dabei wird eine Condition definiert, welche bei der Ausführung der Pipeline ausgewertet wird. Eine Condition referenziert dabei auf Resultate von vorherigen Schritten.
+
+Beispiel für Conditions in einer Pipeline-Definition:
+
+```yaml
+processes:
+  - id: xtf_matcher
+    implementation: Geopilot.Pipeline.Processes.Matcher.XtfMatcher.XtfMatcherProcess
+    default_config:
+      fileExtensions:
+        - xtf
+  - id: xtf_validator
+    implementation: Geopilot.Pipeline.Processes.XtfValidation.XtfValidatorProcess
+  - id: zip_package_process
+    implementation: Geopilot.Pipeline.Processes.ZipPackage.ZipPackageProcess
+pipelines:
+  - id: xtf_validation
+    display_name:
+      en: XTF Validation
+    delivery_restrictions:
+      - expression: "!([validation.ValidationSuccessful])"
+        message:
+          de: "Die Validierung war nicht erfolgreich. Datenlieferung nicht möglich."
+          en: "Validation was not successful. Delivery is not possible."
+    steps:
+      - id: xtf_matching
+        display_name:
+          en: XTF Matching
+        process_id: xtf_matcher
+      - id: validation
+        display_name:
+          en: XTF Validation
+        process_id: xtf_validator
+        input:
+          iliFile: "${step_output(xtf_matching.XtfFiles)}"
+      - id: zip_package
+        display_name:
+          en: Zip Package
+        process_id: zip_package_process
+        conditions:
+          pre:
+            skip_conditions:
+              - expression: "[validation.ErrorLog] != null && [validation.XtfLog] != null"
+                message:
+                  de: "Schritt übersprungen, da Logs vorhanden."
+                  en: "Step skipped because logs exist."
+            fail_conditions:
+              - expression: "[validation.ErrorLog] != null && [validation.XtfLog] != null"
+                message:
+                  de: "Schritt fehlgeschlagen, da Logs vorhanden."
+                  en: "Step failed because logs exist."
+          post:
+            fail_conditions:
+              - expression: "[zip_package.ZipPackage] == null"
+                message:
+                  de: "Zip-Paket konnte nicht erstellt werden."
+                  en: "Zip package could not be created."
+        input:
+          input:
+            - "${step_output(validation.ErrorLog)}"
+            - "${step_output(validation.XtfLog)}"
+```
+
+### Syntax der Expressions
+
+Als Basis dient [NCalc](https://ncalc.github.io/ncalc/articles/index.html). Dabei muss beachtet werden, dass die Expression ein Boolscher Ausdruck sein muss, welcher bei der Auswertung entweder zu `true` oder `false` ausgewertet wird. Es können dabei die Resultate von vorherigen Schritten referenziert werden, indem auf die Schritt-ID (`steps.id`) und den Property-Namen des Outputs (`step.PropertyName`) verwiesen wird. Diese referenzierten Parameter können dann in der Expression verwendet werden, um die Condition zu definieren. Parameter werden dabei in eckigen oder geschweiften Klammern referenziert (`[step.result]` oder `{step.result}`).
+
+Folgende Syntax-Elemente können in den Expressions verwendet werden:
+
+- AND- oder OR-Logik: `&&` oder `and` für AND, `||` oder `or` für OR
+- Negieren: `!`, `-` oder `not`
+- Vergleichsoperatoren: `==`, `!=`, `<`, `>`, `<=`, `>=`
+- Klammern zur Gruppierung von Bedingungen: `(...)`
+
+Eine Detaillierte Übersicht über die Syntax-Elemente und deren Verwendung kann in der [NCalc-Dokumentation](https://ncalc.github.io/ncalc/articles/index.html) nachgeschlagen werden.
+
+#### Funktionen
+
+Zusätzlich zu den Standard-NCalc-Funktionen stellt geopilot folgende eigene Funktionen bereit:
+
+- `Length(parameter)`: Gibt die Anzahl Elemente einer Sammlung (Array oder Collection) zurück. Kann verwendet werden, um die Grösse von Resultaten vorheriger Schritte zu prüfen. Wirft einen Fehler, wenn der Parameter `null` ist oder kein Array bzw. keine Collection ist.
+
+#### Beispiele für die Syntax
+
+- Einfache Condition: `[validation.ValidationSuccessful] == true`
+- Mehrere Bedingungen: `[validation.ValidationSuccessful] == true && [validation.ErrorLog] == null`
+- Bedingung mit OR-Logik: `[validation.ValidationSuccessful] == true || [validation.ErrorLog] == null`
+- Bedingung Klammern: `[validation.ValidationSuccessful] == true && ([validation.ErrorLog] == null || [validation.XtfLog] == null)`
+- Anzahl Elemente prüfen: `Length([xtf_matching.XtfFiles]) == 1`
+- Kombination mit Length: `Length([xtf_matching.XtfFiles]) > 0 && [validation.ValidationSuccessful] == true`
+
+### Conditions auf Schritten
+
+Conditions auf Schritten ermöglichen es, die Ausführung eines Schrittes zu steuern. Jede Condition ist ein Objekt mit den folgenden Eigenschaften:
+
+- `expression`: Der boolsche Ausdruck, welcher ausgewertet wird (Pflichtfeld).
+- `message`: Ein optionaler lokalisierter Text (`LocalizedText`, Key = Sprachcode, Value = Nachricht). Diese Nachrichten werden als Statusnachricht des Schrittes bereitgestellt.
+
+Es können pro Bedingungstyp (`skip_conditions`, `fail_conditions`, `warn_conditions`) mehrere Conditions definiert werden. Die Conditions werden mit ODER-Logik ausgewertet: Trifft mindestens eine Condition zu, wird die entsprechende Aktion (Skip, Error oder Warning) ausgelöst. Dabei werden **alle** zutreffenden Conditions gesammelt und deren Nachrichten pro Sprache kommasepariert zusammengeführt.
+
+#### PRE-Condition
+
+In einer PRE-Condition wird vor der Ausführung eines Schrittes ausgewertet und entschieden, ob der Schritt ausgeführt oder mit einem Fehler abgebrochen werden soll. Die `fail_conditions` werden dabei vor den `skip_conditions` ausgewertet. Trifft eine Condition zu, resultiert das in den folgenden möglichen Szenarien:
+
+- **Skipped**: Schritt wird aufgrund einer `skip_conditions`-Condition übersprungen und nicht ausgeführt. In der Pipeline wird ein übersprungener Schritt und ein erfolgreich abgeschlossener Schritt gleich behandelt. Es ist somit möglich, dass ein Schritt übersprungen wird, und die Pipeline trotzdem mit Erfolg abschliesst.
+- **Error**: Schritt wird aufgrund einer `fail_conditions`-Condition mit einem Fehler abgebrochen. Dies führt dazu, dass die gesamte Pipeline mit einem Fehler abschliesst, und die darauffolgenden Schritte nicht mehr ausgeführt werden.
+
+#### POST-Condition
+
+In einer POST-Condition wird nach der Ausführung eines Schrittes ausgewertet, wie der Schritt abgeschlossen wird. Es gibt zwei Bedingungstypen mit fester Priorität:
+
+- `fail_conditions`: Trifft eine zu, wird der Schritt mit `Error` abgebrochen; die Pipeline schlägt fehl und die darauffolgenden Schritte werden nicht mehr ausgeführt.
+- `warn_conditions`: Trifft keine `fail_conditions`, aber mindestens eine `warn_conditions`-Condition zu, schliesst der Schritt mit `Warning` ab. Der Schritt gilt nicht als Fehler, die Pipeline läuft normal weiter. Damit lassen sich Probleme sichtbar machen (z.B. eine nicht erfolgreiche Validierung), ohne die Pipeline abzubrechen. Die Datenlieferung wird dadurch nicht verhindert; das bleibt Sache der Delivery-Restrictions.
+
+Die Precedence ist somit `Error` (fail) vor `Warning` (warn) vor `Success`.
+
+```yaml
+warn_conditions:
+  - expression: "!([validation.ValidationSuccessful])"
+    message:
+      de: "Die Validierung hat Fehler gefunden."
+      en: "Validation found errors."
+      fr: "La validation a détecté des erreurs."
+      it: "La validazione ha rilevato errori."
+```
+
+#### Statusnachrichten aus Conditions
+
+Wenn zutreffende Conditions eine `message`-Eigenschaft besitzen, werden deren Nachrichten als Statusnachricht des Schrittes bereitgestellt. Dies ermöglicht es, den Anwendern in der Benutzeroberfläche lokalisierte Hinweise anzuzeigen, warum ein Schritt übersprungen oder fehlgeschlagen ist. Bei mehreren zutreffenden Conditions werden die Nachrichten pro Sprachcode kommasepariert zusammengeführt.
+
+Beispiel einer Condition mit Nachricht:
+
+```yaml
+fail_conditions:
+  - expression: "Length([xtf_matching.XtfFiles]) != 1"
+    message:
+      de: "Es muss genau eine XTF-Datei hochgeladen werden."
+      en: "Exactly one XTF file must be uploaded."
+      fr: "Exactement un fichier XTF doit être téléchargé."
+      it: "Deve essere caricato esattamente un file XTF."
+```
+
+### Einschränkungen für die Datenlieferung (Delivery Restrictions)
+
+Einschränkungen für die Datenlieferung (`delivery_restrictions`) ermöglichen es, die Bereitstellung von Daten in der Datenlieferung zu steuern. Der Default ist, dass eine Datenlieferung möglich ist. Dies kann mit einer oder mehreren Einschränkungen übersteuert und somit verhindert werden.
+
+Die Einschränkungen verwenden die gleiche Objektstruktur wie Conditions auf Schritten (`expression` und optionale `message`). Die Semantik ist dabei: **Trifft eine Einschränkung zu (`expression` ergibt `true`), wird die Datenlieferung verhindert.**
+
+Es werden alle Einschränkungen ausgewertet und die Nachrichten aller zutreffenden Einschränkungen pro Sprache kommasepariert zusammengeführt. Die resultierende Nachricht wird dem Anwender in der Benutzeroberfläche als Statusnachricht angezeigt.
+
+Beispiel:
+
+```yaml
+pipelines:
+  - id: xtf_validation
+    display_name:
+      en: XTF Validation
+    delivery_restrictions:
+      - expression: "!([validation.ValidationSuccessful])"
+        message:
+          de: "Die Validierung war nicht erfolgreich. Datenlieferung nicht möglich."
+          en: "Validation was not successful. Delivery is not possible."
+          fr: "La validation n'a pas réussi. La livraison n'est pas possible."
+          it: "La validazione non è riuscita. La consegna non è possibile."
+    steps:
+      # ...
+```
+
+> **Hinweis:** Schlägt die Pipeline fehl (Status `Failed`), wird die Datenlieferung unabhängig von den definierten Einschränkungen automatisch verhindert.
+
+## Prozesse
+
+Dokumentation der Funktionsweise der Prozesse, welche mit geopilot ausgeliefert werden, und wie sie in den Pipelines verwendet werden können. Jeder mitgelieferte Prozessor ist in einer eigenen Datei dokumentiert:
+
+- [XTF Matcher](Prozessoren/xtf-matcher.md)
+- [File Matcher](Prozessoren/file-matcher.md)
+- [XTF Validierung](Prozessoren/xtf-validierung.md)
+- [ZIP Paketierung](Prozessoren/zip-paketierung.md)
+- [ZIP Unpacker](Prozessoren/zip-unpacker.md)
+- [XTF Fehlervisualisierung](Prozessoren/xtf-fehlervisualisierung.md)

--- a/docs/pipeline/Prozessoren/file-matcher.md
+++ b/docs/pipeline/Prozessoren/file-matcher.md
@@ -1,0 +1,27 @@
+# File Matcher
+
+Filtert eine Liste von Dateien anhand konfigurierbarer Kriterien (Dateiendungen, Dateinamen-Muster) und gibt die übereinstimmenden Dateien als Ausgabe zurück. Im Gegensatz zum [XTF Matcher](xtf-matcher.md) prüft dieser Prozess keine ILI-Modelle in den Datei-Headern und ist deshalb nicht spezifisch für XTF/ITF, sondern für beliebige Dateien einsetzbar (z.B. `pdf`, `png`, `ili`).
+
+Wie beim XTF Matcher werden alle konfigurierten Filter mit UND-Logik kombiniert (eine Datei muss alle aktiven Filter erfüllen). Werte innerhalb eines einzelnen Filters werden mit ODER-Logik kombiniert. Filter, deren Konfiguration `null` oder leer ist, werden übersprungen und schränken das Ergebnis nicht ein.
+
+## Implementierung
+
+Ein File Matcher Prozess muss unter `processes[X].implementation` den Wert `Geopilot.Pipeline.Processes.Matcher.FileMatcher.FileMatcherProcess` definieren.
+
+## Konfiguration
+
+- `fileExtensions`: Optionaler Parameter vom Typ `HashSet<string>`. Definiert die Dateiendungen, nach denen gefiltert werden soll (z.B. `pdf`, `png`). Der Vergleich erfolgt ohne Berücksichtigung der Gross-/Kleinschreibung. Wenn `null` oder leer, wird nicht nach Dateiendung gefiltert.
+- `fileNamePatterns`: Optionaler Parameter vom Typ `HashSet<string>`. Definiert reguläre Ausdrücke (Regex), welche gegen den originalen Dateinamen geprüft werden. Mehrere Muster werden mit ODER-Logik zu einer Alternation kombiniert (`(p1)|(p2)|...`). Wenn `null` oder leer, wird nicht nach Dateiname gefiltert.
+
+## Input
+
+Der Name des Prozessor-Inputs, welcher als Schlüssel im `input`-Map des Schrittes (`pipelines[X].steps[X].input`) verwendet werden muss.
+
+- `files`: Eine Liste von Dateien vom Typ `IPipelineFile[]`, welche gefiltert wird. Die Quelle wird in der Pipeline-Definition festgelegt; in den ausgelieferten Pipelines ist der Parameter mit `${upload()}` (die hochgeladenen Dateien) verdrahtet.
+
+## Output
+
+Die öffentlichen Result-Properties des Prozesses stehen den nachfolgenden Schritten implizit unter ihrem Property-Namen (PascalCase) zur Verfügung und werden über `${step_output(stepId.PropertyName)}` referenziert. Soll eine Property zusätzlich behandelt werden (Download, Lieferung, Statusnachricht oder Visualisierung), wird sie in `pipelines[X].steps[X].output_actions` getaggt.
+
+- `MatchedFiles`: Ein Array von Dateien vom Typ `IPipelineFile[]`, welche den konfigurierten Filterkriterien entsprechen. Dieses Array kann leer sein, wenn keine Datei den Kriterien entspricht.
+- `StatusMessage`: Eine lokalisierte Status-Nachricht vom Typ `LocalizedText`, welche über die Anzahl der übereinstimmenden Dateien informiert (z.B. `"2 von 5 Datei(en) entsprechen den Filterkriterien."`) oder meldet, dass keine Dateien den Kriterien entsprechen.

--- a/docs/pipeline/Prozessoren/xtf-fehlervisualisierung.md
+++ b/docs/pipeline/Prozessoren/xtf-fehlervisualisierung.md
@@ -1,0 +1,90 @@
+# XTF Fehlervisualisierung
+
+Wandelt das XTF-Log der [XTF Validierung](xtf-validierung.md) in eine zusammengesetzte Fehlervisualisierung um, die eine Kartenansicht und eine Error-Tree-Ansicht derselben Fehler kombiniert. Über `include` wird gewählt, welche Ansichten erzeugt werden (Standard: beide). Beide Ansichten teilen sich eine gemeinsame Hülle (Envelope), damit das Frontend sie zusammen in einer Komponente darstellen und untereinander verknüpfen kann.
+
+## Implementierung
+
+Ein XTF Fehlervisualisierungs-Prozess muss unter `processes[X].implementation` den Wert `Geopilot.Pipeline.Processes.XtfErrorVisualization.XtfErrorVisualizationProcess` definieren.
+
+## Konfiguration
+
+- `include`: Optionaler Parameter vom Typ `HashSet<string>`. Wählt die zu erzeugenden Ansichten: `map` (Kartenansicht) und/oder `tree` (Error Tree). Der Vergleich erfolgt ohne Berücksichtigung der Gross-/Kleinschreibung. Wenn `null` oder leer, werden beide Ansichten erzeugt.
+- `baseMapWmtsCapabilitiesUrl`: Optionaler Parameter vom Typ `string`. Übersteuert die WMTS-Capabilities-URL der Hintergrundkarte für die Kartenansicht. Wenn `null` oder leer, wird die eingebaute Standard-Hintergrundkarte verwendet.
+- `baseMapAttribution`: Optionaler Parameter vom Typ `string`. Übersteuert den Copyright-/Urhebervermerk der Hintergrundkarte (Daten-Owner, z.B. `swisstopo`), symmetrisch zu `baseMapWmtsCapabilitiesUrl`. Wenn `null` oder leer, wird der eingebaute Standardwert verwendet. Das Frontend zeigt den Vermerk mit einem lokalisierten "©"-Präfix in der linken unteren Ecke der Karte an.
+- `baseMapAttributionUrl`: Optionaler Parameter vom Typ `string`. Übersteuert die URL, auf die der Copyright-Vermerk verlinkt (z.B. die Nutzungsbedingungen des Karten-Owners). Wenn `null` oder leer, wird der eingebaute Standardwert verwendet. Da `null` und leer auf den Standardwert zurückfallen, ist immer eine URL wirksam und der Vermerk wird stets als Link dargestellt. Wer `baseMapAttribution` übersteuert, sollte deshalb auch `baseMapAttributionUrl` passend setzen, sonst verlinkt der angepasste Vermerk weiterhin auf den Standardwert (z.B. swisstopo).
+- `groupBy`: Optionaler Parameter vom Typ `IReadOnlyList<string>`. Metadaten-Schlüssel, nach denen das Frontend den Error Tree gruppiert, äusserste Ebene zuerst (z.B. `["Model", "Topic", "Class"]`). Wenn `null` oder leer, wird nicht gruppiert (flache Liste). Ein Schlüssel, der auf einem Fehler nicht vorhanden ist, landet in einer separaten Gruppe "Ohne Zuordnung".
+- `filterBy`: Optionaler Parameter vom Typ `IReadOnlyList<string>`. Metadaten-Schlüssel, die das Frontend als Filter anbietet, in Anzeigereihenfolge (z.B. `["Model", "Topic", "Class", "Error type"]`). Der Filter wirkt auf Karte und Baum gleichzeitig. Wenn `null` oder leer, werden keine Filter angeboten.
+
+## Input
+
+Der Name des Inputs, welcher als Schlüssel im `input`-Map des Schrittes (`pipelines[X].steps[X].input`) verwendet werden muss.
+
+- `xtfLog`: Ein Input-File vom Typ `IPipelineFile`. Auf diesen Namen muss genau ein File gemappt werden, aus dem die Fehler gelesen werden. Es ist das XTF-Log der Validierung (Output `XtfLog` der [XTF Validierung](xtf-validierung.md)).
+
+## Output
+
+Die öffentlichen Result-Properties des Prozesses stehen den nachfolgenden Schritten implizit unter ihrem Property-Namen (PascalCase) zur Verfügung und werden über `${step_output(stepId.PropertyName)}` referenziert. Soll eine Property zusätzlich behandelt werden (Download, Lieferung, Statusnachricht oder Visualisierung), wird sie in `pipelines[X].steps[X].output_actions` getaggt.
+
+- `Visualization`: Die zusammengesetzte Fehlervisualisierung (Kartenansicht und/oder Error Tree) in einem gemeinsamen Envelope. Wird mit der Output-Aktion `Visualization` versehen, damit die Visualisierung im Frontend dargestellt wird.
+- `StatusMessage`: Eine lokalisierte Status-Nachricht vom Typ `LocalizedText`, welche meldet, dass die Fehlervisualisierung erstellt wurde.
+
+## Format des `Visualization`-Outputs
+
+Der `Visualization`-Output ist ein Envelope mit dem Diskriminator `xtfError` und einer Nutzlast aus optionaler Karten- und Baum-Ansicht (je nach `include`). Der Baum wird als **flache Liste** von Fehlern geliefert; das Frontend baut daraus die dargestellte Hierarchie, indem es die Fehler nach den `groupBy`-Schlüsseln gruppiert. Serialisiert wird als camelCase-JSON, `null`-Felder werden weggelassen:
+
+```json
+{
+  "type": "xtfError",
+  "data": {
+    "map": {
+      "layers": [
+        {
+          "title": { "de": "Hintergrundkarte", "en": "Base map", "fr": "Fond de carte", "it": "Mappa di base" },
+          "wmts": "https://example.com/wmts/1.0.0/WMTSCapabilities.xml",
+          "layerIds": ["ch.swisstopo.pixelkarte-farbe"],
+          "attribution": "swisstopo",
+          "attributionUrl": "https://www.swisstopo.admin.ch/de/nutzungsbedingungen-kostenlose-geodaten-und-geodienste"
+        },
+        {
+          "color": "#e53835",
+          "features": [
+            { "errorId": "e0", "geom": "POINT(2600000 1200000)", "info": "Fehlerbeschreibung" }
+          ]
+        }
+      ]
+    },
+    "tree": {
+      "items": [
+        {
+          "id": "e0",
+          "label": "obj123",
+          "severity": "error",
+          "metadata": {
+            "Error type": {
+              "de": "Pflichtattribut fehlt",
+              "en": "Mandatory attribute missing",
+              "fr": "Attribut obligatoire manquant",
+              "it": "Attributo obbligatorio mancante"
+            },
+            "Model": "Schutzbauten_V1_1",
+            "Topic": "Einzelobjekte",
+            "Class": "Gebaeudeeingang",
+            "Message": "Attribute IstExaktDefiniert requires a value",
+            "Line": "42"
+          }
+        }
+      ],
+      "groupBy": ["Model", "Topic", "Class"]
+    },
+    "filterBy": ["Model", "Topic", "Class", "Error type"]
+  }
+}
+```
+
+- `data.map` und `data.tree` erscheinen nur, wenn die jeweilige Ansicht via `include` erzeugt wurde. `data.filterBy` erscheint nur, wenn ein Baum erzeugt wurde.
+- `map.layers` werden in Reihenfolge gezeichnet. Ein Layer ist entweder ein WMTS-Layer (`wmts` = Capabilities-URL, optional `layerIds`) oder ein Feature-Layer (`features`, optional `color` als Hex-Farbe). `title` (lokalisiert) ist optional. Ein Layer kann zudem einen Copyright-Vermerk tragen: `attribution` (Daten-Owner bzw. Anzeigetext) und optional `attributionUrl` (Link-Ziel); das Frontend zeigt ihn mit lokalisiertem "©"-Präfix unten links an.
+- Pro `features`-Eintrag: `geom` als WKT (z.B. `POINT(...)`), `errorId` als stabile Fehler-ID, `info` als Anzeigetext.
+- `tree.items` ist eine flache Liste; jedes Element ist ein Fehler und wird zum Blatt des Baums. Pro Element: `id` (stabile Fehler-ID, optional), `label` (Anzeigetext des Blattes), `severity` (`error` oder `warning`, daraus leitet das Frontend Icon und Farbe ab) und `metadata` (Key/Value). Ein Metadaten-Wert ist entweder ein einfacher String (Daten, z.B. ein Klassenname) oder ein `LocalizedText` (eine generierte Beschriftung wie die Fehlerkategorie, serialisiert als Objekt je Sprache).
+- `tree.groupBy` sind die Metadaten-Schlüssel, nach denen das Frontend die Items zur Hierarchie gruppiert (äusserste Ebene zuerst); eine leere Liste ergibt eine flache Liste. `data.filterBy` sind die im Frontend als Filter angebotenen Schlüssel; der Filter wirkt auf Karte und Baum.
+- `id` des Tree-Items und `errorId` des Map-Features sind identisch; daran verknüpft das Frontend Karte und Baum (Cross-Select).
+

--- a/docs/pipeline/Prozessoren/xtf-matcher.md
+++ b/docs/pipeline/Prozessoren/xtf-matcher.md
@@ -1,0 +1,26 @@
+# XTF Matcher
+
+Filtert eine Liste von Dateien anhand konfigurierbarer Kriterien und gibt die übereinstimmenden Dateien als Ausgabe zurück. Alle konfigurierten Filter werden mit UND-Logik kombiniert: Eine Datei muss alle aktiven Filter erfüllen, um in der Ausgabe enthalten zu sein. Innerhalb eines einzelnen Filters werden die Werte mit ODER-Logik kombiniert (z.B. Dateiendungen `xtf` und `itf` stimmen mit einer der beiden überein). Filter, deren Konfiguration `null` oder leer ist, werden übersprungen und schränken das Ergebnis nicht ein.
+
+## Implementierung
+
+Ein XTF Matcher Prozess muss unter `processes[X].implementation` den Wert `Geopilot.Pipeline.Processes.Matcher.XtfMatcher.XtfMatcherProcess` definieren.
+
+## Konfiguration
+
+- `fileExtensions`: Optionaler Parameter vom Typ `HashSet<string>`. Definiert die Dateiendungen, nach denen gefiltert werden soll (z.B. `xtf`, `itf`). Der Vergleich erfolgt ohne Berücksichtigung der Gross-/Kleinschreibung. Wenn `null` oder leer, wird nicht nach Dateiendung gefiltert.
+- `iliModels`: Optionaler Parameter vom Typ `HashSet<string>`. Definiert die ILI-Modellnamen, nach denen in den XTF-Header-Metadaten gefiltert werden soll. Unterstützt werden sowohl INTERLIS 2.4 (Elemente mit `ili:`-Präfix, Modellname als Elementtext) als auch INTERLIS 2.3 (Elemente in Grossbuchstaben im Default-Namespace, Modellname im `NAME`-Attribut). Dateien, welche nicht als XTF geparst werden können, werden bei aktiviertem Modellfilter ausgeschlossen. Der Vergleich erfolgt ohne Berücksichtigung der Gross-/Kleinschreibung. Wenn `null` oder leer, wird nicht nach ILI-Modell gefiltert.
+- `fileNamePatterns`: Optionaler Parameter vom Typ `HashSet<string>`. Definiert reguläre Ausdrücke (Regex), welche gegen den originalen Dateinamen geprüft werden (z.B. `Road.*`, `Map.*`). Der Vergleich ist case-sensitive. Wenn `null` oder leer, wird nicht nach Dateiname gefiltert.
+
+## Input
+
+Der Name des Prozessor-Inputs, welcher als Schlüssel im `input`-Map des Schrittes (`pipelines[X].steps[X].input`) verwendet werden muss.
+
+- `files`: Eine Liste von Dateien vom Typ `IPipelineFile[]`, welche gefiltert wird. Die Quelle wird in der Pipeline-Definition festgelegt; in den ausgelieferten Pipelines ist der Parameter mit `${upload()}` (die hochgeladenen Dateien) verdrahtet.
+
+## Output
+
+Die öffentlichen Result-Properties des Prozesses stehen den nachfolgenden Schritten implizit unter ihrem Property-Namen (PascalCase) zur Verfügung und werden über `${step_output(stepId.PropertyName)}` referenziert. Soll eine Property zusätzlich behandelt werden (Download, Lieferung, Statusnachricht oder Visualisierung), wird sie in `pipelines[X].steps[X].output_actions` getaggt.
+
+- `XtfFiles`: Ein Array von Dateien vom Typ `IPipelineFile[]`, welche den konfigurierten Filterkriterien entsprechen. Dieses Array kann leer sein, wenn keine Datei den Kriterien entspricht.
+- `StatusMessage`: Eine lokalisierte Status-Nachricht vom Typ `LocalizedText`, welche über die Anzahl der übereinstimmenden Dateien informiert (z.B. `"1 von 3 Datei(en) entsprechen den XTF-Filterkriterien."`) oder meldet, dass keine Dateien den Kriterien entsprechen.

--- a/docs/pipeline/Prozessoren/xtf-validierung.md
+++ b/docs/pipeline/Prozessoren/xtf-validierung.md
@@ -1,0 +1,30 @@
+# XTF Validierung
+
+Validiert ein XTF-File anhand eines konfigurierbaren Profils. Dabei wird IliCop als REST-Service verwendet, um die Validierung durchzuführen.
+
+Die Basis-URL für den IliCop-Service wird über den Pflichtparameter `checkServiceBaseUrl` definiert (siehe [Konfiguration eines Pipeline-Prozessors](../Pipelines.md#konfiguration-eines-pipeline-prozessors)). Da diese URL pro Umgebung gilt, wird sie üblicherweise als nicht überschreibbare Basis-Konfiguration in den Appsettings unter `Pipeline:ProcessConfigs` für diesen Prozessor hinterlegt.
+
+## Implementierung
+
+Ein XTF Validator Prozess muss unter `processes[X].implementation` den Wert `Geopilot.Pipeline.Processes.XtfValidation.XtfValidatorProcess` definieren.
+
+## Konfiguration
+
+- `checkServiceBaseUrl`: Pflichtparameter, welcher die Basis URL des IliCop-Services definiert, welcher für die Validierung verwendet wird.
+- `validationProfile`: Optionaler Parameter, welcher das Profil definiert, anhand dessen die Validierung durchgeführt wird. Die möglichen Werte müssen in der Dokumentation von IliCop nachgeschlagen werden.
+- `pollInterval`: Optionaler Parameter, welcher das Intervall definiert, in welchem der Prozess den Status der Validierung abfragt. Der Wert wird in Millisekunden angegeben. Der Standardwert ist zwei Sekunden.
+
+## Input
+
+Der Name des Inputs, welcher als Schlüssel im `input`-Map des Schrittes (`pipelines[X].steps[X].input`) verwendet werden muss.
+
+- `iliFile`: Ein Input-File vom Typ `IPipelineFile`. Dieses File muss die XTF-Datei enthalten, welche validiert werden soll.
+
+## Output
+
+Die öffentlichen Result-Properties des Prozesses stehen den nachfolgenden Schritten implizit unter ihrem Property-Namen (PascalCase) zur Verfügung und werden über `${step_output(stepId.PropertyName)}` referenziert. Soll eine Property zusätzlich behandelt werden (Download, Lieferung, Statusnachricht oder Visualisierung), wird sie in `pipelines[X].steps[X].output_actions` getaggt.
+
+- `ErrorLog`: Ein Output-File vom Typ `IPipelineFile?`, welches das Error-Log der Validierung enthält. Dieses Log enthält alle Fehler, welche bei der Validierung aufgetreten sind. Kann `null` sein, wenn die Validierung bereits vor der Validierung mit dem IliValidator fehlschlägt. Weitere Informationen können in diesem Fall von `StatusMessage` entnommen werden.
+- `XtfLog`: Ein Output-File vom Typ `IPipelineFile?`, welches das XTF-Log der Validierung enthält. Dieses Log enthält alle Informationen über die Validierung, wie z.B. die Anzahl der validierten Objekte, die Anzahl der Fehler, etc. Kann `null` sein, wenn die Validierung bereits vor der Validierung mit dem IliValidator fehlschlägt. Weitere Informationen können in diesem Fall von `StatusMessage` entnommen werden.
+- `StatusMessage`: Eine lokalisierte Status-Nachricht der Validierung vom Typ `LocalizedText`, welche über den Status der Validierung informiert. Die Status-Nachricht kann auch ein leerer String sein.
+- `ValidationSuccessful`: Wert vom Typ `bool`. Ist `true`, wenn das Input-File erfolgreich validiert werden konnte und valide ist. Ist `false`, wenn das Input-file nicht erfolgreich validiert werden konnte oder invalide ist.

--- a/docs/pipeline/Prozessoren/zip-paketierung.md
+++ b/docs/pipeline/Prozessoren/zip-paketierung.md
@@ -1,0 +1,26 @@
+# ZIP Paketierung
+
+Nimmt eine Liste von Dateien entgegen und packt sie in ein ZIP-Archiv, welches als Ausgabe bereitgestellt wird. Sowohl Input als auch Output sind vom Typ `IPipelineFile`, welches die Dateien bzw. das ZIP-Archiv enthält. Die ursprüngliche Verzeichnisstruktur der Eingabedateien wird anhand von `IPipelineFile.OriginalRelativePath` im ZIP-Archiv beibehalten, Dateien mit einem gesetzten Pfad (z.B. aus dem ZIP Unpacker) werden unter dem entsprechenden Verzeichnis im Archiv abgelegt.
+
+## Implementierung
+
+Ein ZIP Prozess muss unter `processes[X].implementation` den Wert `Geopilot.Pipeline.Processes.ZipPackage.ZipPackageProcess` definieren.
+
+## Konfiguration
+
+- `archiveFileName`: Optionaler Parameter, welcher den Namen des ZIP-Archivs definiert, welches erstellt wird. Wenn dieser Parameter nicht definiert ist, wird dem Archiv der Name `archive.zip` vergeben.
+
+## Input
+
+Der Name des Prozessor-Inputs, welcher als Schlüssel im `input`-Map des Schrittes (`pipelines[X].steps[X].input`) verwendet werden muss.
+
+- `input`: Eine Liste von Input-Files vom Typ `IPipelineFile?`. Auf diesen Namen können 0-n Files gemappt werden, welche in das ZIP-Archiv gepackt werden sollen. `null` als ein Input-File in der Liste ist erlaubt und wird vom Prozessor einfach ignoriert.
+
+Falls Dateien mit identischem Pfad (Kombination aus `OriginalRelativePath` und `OriginalFileName`) vorhanden sind, wird eine Warnung im Log ausgegeben. Dateien mit gleichem Namen in unterschiedlichen Verzeichnissen gelten nicht als Duplikate. Das ZIP-Archiv wird trotzdem erstellt, wobei echte Duplikate zu mehreren Einträgen mit dem gleichen Pfad im Archiv führen.
+
+## Output
+
+Die öffentlichen Result-Properties des Prozesses stehen den nachfolgenden Schritten implizit unter ihrem Property-Namen (PascalCase) zur Verfügung und werden über `${step_output(stepId.PropertyName)}` referenziert. Soll eine Property zusätzlich behandelt werden (Download, Lieferung, Statusnachricht oder Visualisierung), wird sie in `pipelines[X].steps[X].output_actions` getaggt.
+
+- `ZipPackage`: Ein Output-File vom Typ `IPipelineFile`, welches das erstellte ZIP-Archiv enthält. Dieses Archiv enthält alle Dateien, welche über den Input `input` an den Prozess übergeben wurden. Falls die Liste an Input-Files nur `null`-Werte enthält, ist dieser Output `null`.
+- `StatusMessage`: Eine lokalisierte Status-Nachricht der Validierung vom Typ `LocalizedText`, welche über den Status des ZIP-Prozesses informiert. Die Status-Nachricht kann auch ein leerer String sein.

--- a/docs/pipeline/Prozessoren/zip-unpacker.md
+++ b/docs/pipeline/Prozessoren/zip-unpacker.md
@@ -1,0 +1,24 @@
+# ZIP Unpacker
+
+Entpackt ein einzelnes ZIP-Archiv und stellt dessen Dateien als flachen Array von `IPipelineFile` zur Verfügung. Die ursprüngliche Verzeichnisstruktur des Archivs bleibt als Metadaten via `IPipelineFile.OriginalRelativePath` erhalten.
+
+## Implementierung
+
+Ein ZIP Entpacker Prozess muss unter `processes[X].implementation` den Wert `Geopilot.Pipeline.Processes.Unzip.UnzipProcess` definieren.
+
+## Konfiguration
+
+Keine spezifische Konfiguration.
+
+## Input
+
+Der Name des Inputs, welcher als Schlüssel im `input`-Map des Schrittes (`pipelines[X].steps[X].input`) verwendet werden muss.
+
+- `zipFile`: Ein Input-File vom Typ `IPipelineFile`. Auf diesen Namen muss genau ein File gemappt werden, welches das zu entpackende ZIP-Archiv enthält.
+
+## Output
+
+Die öffentlichen Result-Properties des Prozesses stehen den nachfolgenden Schritten implizit unter ihrem Property-Namen (PascalCase) zur Verfügung und werden über `${step_output(stepId.PropertyName)}` referenziert. Soll eine Property zusätzlich behandelt werden (Download, Lieferung, Statusnachricht oder Visualisierung), wird sie in `pipelines[X].steps[X].output_actions` getaggt.
+
+- `ExtractedFiles`: Ein Array von Dateien vom Typ `IPipelineFile[]`, welche dem Inhalt des ZIP-Archivs entsprechen. Auf jeder Datei steht via `OriginalRelativePath` der Verzeichnispfad innerhalb des Archivs (oder ein leerer String für Dateien auf der obersten Ebene). Dieses Array kann leer sein, wenn das Archiv keine Dateien enthält.
+- `StatusMessage`: Eine lokalisierte Status-Nachricht des Entpackers vom Typ `LocalizedText`, welche über die Anzahl der entpackten Dateien bzw. ein leeres Archiv informiert.

--- a/docs/pipeline/pluginSystem.md
+++ b/docs/pipeline/pluginSystem.md
@@ -1,0 +1,149 @@
+# Plugin System für Pipeline Prozessoren
+
+Die grundsätzliche Funktionsweise der Pipeline ist in der "[Dokumentation und Konzepte im Zusammenhang mit geopilot und Pipelines](Pipelines.md)" beschrieben. Hier konzentrieren wir uns auf die funktionale Erweiterung durch Plugins.
+
+## Einführung
+
+Pipeline-Prozessoren sind zentrale Komponenten in den geopilot Pipelines, die von Verarbeitungsschritten durchgeführt werden, um Daten zu transformieren oder zu analysieren. Das Pipeline-Plugin-System ermöglicht es den Funktionsumfang der Pipelines zu erweitern indem solche Prozessoren dazugeladen werden können ohne die Codebasis von geopilot zu verändern oder zu erweitern.
+
+Dies ermöglicht es den verschiedenen Kunden von geopilot spezifische Anforderungen zu erfüllen, indem sie massgeschneiderte Prozessoren entwickeln und in ihre Pipelines integrieren können.
+
+Geopilot definiert von sich aus bereits eine Reihe von Standard-Pipeline-Prozessoren, die für gängige Anwendungsfälle geeignet sind und mit geopilot ausgeliefert werden. Diese sind beispielsweise:
+
+- **XTF Matcher**: Filtert die hochgeladenen Dateien anhand konfigurierbarer Kriterien (Dateiendungen, ILI-Modelle, Dateinamen-Muster).
+- **Interlis Validator**: Validiert Interlis Files auf inhaltliche Fehler.
+- **ZIP Packetierer**: Packt Dateien in ein ZIP-Archiv.
+- **XTF Fehlervisualisierung**: Erzeugt aus den Fehlern einer Interlis-Validierung eine Fehlervisualisierung (Kartenansicht und Fehlerbaum).
+
+Aus dieser Menge von Standardprozessoren und Pluginprozessoren können die Pipelines gebaut werden. Die vollständige Liste der mitgelieferten Prozessoren, je mit Konfiguration, Inputs und Outputs, ist unter [Prozesse](Pipelines.md#prozesse) verlinkt.
+
+## Dependency Management
+
+Ein Pipeline-Prozessor wird in C# entwickelt. Dieser Prozessor muss das NuGet-Package [`GeoWerkstatt.Geopilot.PipelineCore`](../../src/Geopilot.PipelineCore/README.md) einbinden, um die notwendigen Definitionen nutzen zu können. Das Package wird unabhängig von der geopilot-Version versioniert (SemVer auf der öffentlichen Plugin-Oberfläche).
+
+Beim Laden prüft geopilot, gegen welche PipelineCore-Version ein Plugin gebaut wurde, und lehnt inkompatible Plugins ab (das Plugin wird übersprungen, geopilot läuft weiter):
+
+- Die **Major-Version** muss mit der von geopilot verwendeten übereinstimmen. Ein Major-Update von PipelineCore erfordert also einen Rebuild aller Plugins.
+- Die **Minor-Version** des Plugins darf nicht höher sein als die von geopilot verwendete. Ein Plugin kann somit keine Funktionalität voraussetzen, welche die Zielumgebung noch nicht kennt.
+- Ein Plugin, welches gegen eine ältere Minor- oder Patch-Version gebaut wurde, wird geladen; geopilot schreibt dazu eine Warnung ins Log.
+
+Die PipelineCore-Bibliothek beinhaltet die folgenden Definitionen:
+
+- **File**:
+  - `IPipelineFileManager`: Interface zum Verwalten von Dateien innerhalb der Pipeline. Erzeugt `IPipelineFile`-Instanzen mit denen innerhalb der Prozessoren Dateien geschrieben, gelesen und zwischen den Schritten übertragen werden können. Dateien, welche über `IPipelineFileManager` erzeugt werden, werden automatisch von geopilot verwaltet und am Ende des Pipeline-Runs gelöscht. Bei Bedarf kann mit der Überladung `GeneratePipelineFile(originalRelativePath, originalFileName, fileExtension)` ein ursprünglicher relativer Pfad als Metadatum auf der erzeugten Datei mitgegeben werden (z.B. die Position einer Datei innerhalb eines entpackten ZIP-Archivs). Auf der Festplatte werden die Dateien immer flach im temporären Schritt-Verzeichnis abgelegt; der relative Pfad ist reines Metadatum.
+  - `IPipelineFile`: Interface zum Übertragen von Dateien innerhalb der Pipeline. Stellt unter anderem die Eigenschaften `OriginalFileName`, `FileExtension` und `OriginalRelativePath` bereit. `OriginalRelativePath` ist Forward-Slash-getrennt, ohne führenden oder folgenden Trenner, ohne `..`-Segmente und ist ein leerer String für Dateien auf der obersten Ebene. Verwendung u.a. durch den ZIP Entpacker, um die ursprüngliche Verzeichnisstruktur eines Archivs auf den entpackten Dateien zu erhalten; nachgelagerte Prozessoren, welche eine flache Sicht benötigen, ignorieren die Eigenschaft.
+- **Verarbeitung** (`PipelineProcessRun`-Annotation): Funktionen, welche die eigentliche Verarbeitung implementieren müssen mit dieser Annotation gekennzeichnet werden. Es muss genau eine Funktion mit dieser Annotation vorhanden sein, da sie die Hauptfunktion des Prozessors darstellt.
+  - Rückgabewert: `Task<TResult>`, wobei `TResult` eine prozessspezifische Result-Klasse ist. Deren öffentliche Properties definieren die Resultate des Prozessors, welche folgenden Pipeline-Schritten zur Verfügung stehen. Alle öffentlichen, lesbaren Properties stehen dabei implizit zur Verfügung; sie müssen in der Pipeline-Definition nicht einzeln deklariert werden. Der Property-Name (PascalCase) ist der Name, unter dem ein Output referenziert wird (`${step_output(stepId.PropertyName)}` bzw. `[stepId.PropertyName]`); die Engine liest die Property per Reflection. In älteren Versionen wurde stattdessen ein `Task<Dictionary<string, object>>` mit frei vergebenen String-Keys zurückgegeben.
+  - Parameter: Variabel werden anhand des Parameter-Namens und Typs der Run-Methode übergeben. Das Mapping hierzu wird über die Pipeline-Definition bestimmt. Als letzter Parameter kann ein optionales `CancellationToken` übergeben werden, um die Möglichkeit zu bieten, die Verarbeitung vorzeitig zu beenden.
+  - Input-Quelle: Woher ein Parameter seinen Wert erhält (Output eines Vorschritts, die hochgeladenen Dateien via `${upload()}`, eine Ressourcendatei via `${file()}` oder ein Literal), wird in der Pipeline-Definition über das `input`-Mapping festgelegt (siehe [Pipelines.md](Pipelines.md)). Aus Sicht des Prozessors ist das jeweils ein gewöhnlicher Parameter: Eine Datei-Sammlung nimmt man als `IPipelineFile[]` entgegen (aus jeder Quelle befüllbar, auch `${upload()}`), ohne besondere Kennzeichnung.
+- **Dateien-Sammlung**:
+  - Datei-Sammlung: Eine Sammlung von `IPipelineFile` ist ein `IPipelineFile[]` (an Kontext-Flächen wie dem Upload auch `IReadOnlyList<IPipelineFile>`). Ein Run-Parameter für mehrere Dateien ist ein `IPipelineFile[]`, aus jeder Quelle befüllbar.
+  - Datei-Filter stehen als Extension-Methods auf `IEnumerable<IPipelineFile>` zur Verfügung (also auf `IPipelineFile[]` wie auf jeder Datei-Sequenz) und können verkettet werden:
+    - `WithExtensions(HashSet<string> extensions)`: Filtert nach Dateiendungen (ohne Punkt, z.B. `xtf`). Vergleich ist case-insensitive.
+    - `WithMatchingName(string namePattern)`: Filtert nach einem Regex-Muster gegen den originalen Dateinamen.
+
+## Anforderungen an Pipeline-Prozessoren
+
+- **Instanzierung**: Es muss ein Konstruktor vorhanden sein, welcher die Initialisierung des Prozessors ermöglicht. Dieser Konstruktor kann 0-n Parameter besitzen, welche in der Pipeline-Definition angegeben werden können. Es muss jedoch sichergestellt werden, dass die Pflichtparameter durch die Konfiguration eindeutig identifizierbar sind, damit sie korrekt zugeordnet werden können. Optionale und Parameter nichtidentifizierbare Parameter werden mit `null` initialisiert. Die Parameter sind variabel und können die folgenden Typen aufnehmen:
+  - `ILogger`: Logger-Instanz für das Logging innerhalb des Prozessors.
+  - `IPipelineFileManager`: Instanz zum Verwalten von Dateien innerhalb der Pipeline.
+  - `IIli2GpkgClient`: Client für ili2gpkg-Operationen (Schema-Import, Daten-Import, Export) gegen den ilitools-wrapper-Service. Die Adresse des Services wird von geopilot konfiguriert; das Plugin benötigt dazu keine eigene Konfiguration.
+  - `int` und `int?`: Ganzzahlige Werte, welche in der Pipeline-Definition als Konfiguration angegeben werden können.
+  - `double` und `double?`: Gleitkommazahlen, welche in der Pipeline-Definition als Konfiguration angegeben werden können.
+  - `string` und `string?`: Zeichenfolgen, welche in der Pipeline-Definition als Konfiguration angegeben werden können.
+  - `bool` und `bool?`: Boolesche Werte, welche in der Pipeline-Definition als Konfiguration angegeben werden können.
+  - `HashSet<string>` und `HashSet<string>?`: Mengen von Zeichenfolgen, welche in der Pipeline-Definition als Liste konfiguriert werden können (z.B. für Dateiendungen oder Muster).
+  - Weitere Typen sind möglich, sofern sich der konfigurierte Wert in den Parametertyp konvertieren lässt (z.B. `TimeSpan`, Enums oder Listen wie `IReadOnlyList<string>`). Listen können allerdings nur in der Pipeline-Definition (`default_config`) angegeben werden, nicht in den Appsettings unter `Pipeline:ProcessConfigs`; diese Ebene trägt nur skalare Werte.
+- **Verarbeitung**: Die Verarbeitung der Daten erfolgt in der `PipelineProcessRun` Methode, welche die Hauptverarbeitungslogik des Prozessors enthält.
+- **Ressourcenmanagement** (optional): Wenn der Prozessor Ressourcen verwendet, die freigegeben werden müssen (z.B. Datenbankverbindungen, Dateihandles, etc.), sollte er das `IDisposable` Interface implementieren und die entsprechenden Aufräumarbeiten in der `Dispose` Methode durchführen.
+
+## Beispiel eines Pipeline-Prozessors
+
+```csharp
+public class MyProcess : IDisposable
+{
+    private ILogger logger;
+
+    public MyProcess(string someStringParameter, int someIntParameter, HashSet<string>? someFilterList, IPipelineFileManager pipelineFileManager, ILogger logger)
+    {
+        // Initialize the processor with the provided configuration and parameters
+        this.logger = logger;
+    }
+
+    public void Dispose()
+    {
+        // Cleanup resources if necessary
+    }
+
+    [PipelineProcessRun]
+    public Task<MyProcessResult> PipelineProcessRun(IPipelineFile[] files, string someRandomStringInput, int[] someRandomIntInput, CancellationToken cancellationToken)
+    {
+        // files ist ein gewöhnlicher Input-Parameter; die Quelle (hier ${upload()}) wird in der Pipeline-Definition festgelegt
+        // Die Dateien können gefiltert werden (Extension-Methods auf IEnumerable<IPipelineFile>):
+        // var filtered = files.WithExtensions(new HashSet<string> { "xtf" }).ToArray();
+
+        logger.LogInformation($"run process <MyProcess>.");
+        return Task.FromResult(new MyProcessResult
+        {
+            OutputA = "some output A",
+            OutputB = "some output B",
+        });
+    }
+}
+
+// Result-Klasse des Prozessors: Jede öffentliche Property ist ein Output, der in der
+// Pipeline-Definition implizit über den Property-Namen (PascalCase) referenziert wird.
+public class MyProcessResult
+{
+    public required string OutputA { get; set; }
+
+    public required string OutputB { get; set; }
+}
+
+```
+
+## Lokalisierte Status-Nachrichten
+
+Ein Prozessor kann eine lokalisierte Status-Nachricht zurückgeben, die in der Benutzeroberfläche angezeigt wird. Dazu wird eine Result-Property über `output_actions` mit der Aktion `StatusMessage` (siehe [Pipelines](Pipelines.md)) getaggt. Der Wert eines solchen Outputs ist vom Typ `LocalizedText` (ab PipelineCore 1.3), einem unveränderlichen lokalisierten Text mit dem Sprachcode als Key:
+
+```csharp
+// Property auf der Result-Klasse des Prozessors:
+public required LocalizedText StatusMessage { get; set; }
+
+// ... beim Erzeugen des Results gesetzt:
+StatusMessage = new LocalizedText(new Dictionary<string, string>
+{
+    { "de", "Verarbeitung erfolgreich abgeschlossen." },
+    { "en", "Processing completed successfully." },
+    { "fr", "Traitement terminé avec succès." },
+    { "it", "Elaborazione completata con successo." },
+}),
+```
+
+Ein `Dictionary<string, string>` (Key = Sprachcode) wird aus Gründen der Abwärtskompatibilität weiterhin akzeptiert, sodass bestehende Prozessoren ohne Anpassung weiterlaufen.
+
+## Einbinden des Plugins in geopilot
+
+Die Appsettings von geopilot bieten die Möglichkeit, die zu ladenden Pipeline-Prozessor-Plugins zu definieren. Hierzu werden die Namen der Assemblies angegeben, welche die Prozessoren enthalten. Die Plugins werden im Abschnitt `Pipeline:Plugins` definiert. Hier erwarten wir eine Liste von Strings, welche die Namen der zu ladenden Assemblies enthalten.
+
+- `Pipeline:Definition`: Definiert den Pfad zur Pipeline-Definition, welche die Struktur der Pipelines und die Konfiguration der einzelnen Schritte beschreibt. Dieser Pfad kann absolut oder relativ sein.
+- `Pipeline:Plugins`: Absolute oder Relative Pfade zu den Assemblies, welche die Pipeline-Prozessoren enthalten. Es können mehrere Plugins angegeben werden, welche dann alle geladen werden. Neben der JSON-Liste ist auch ein einzelner, kommaseparierter Wert möglich, damit die Plugins als flache Umgebungsvariable gesetzt werden können (`Pipeline__Plugins=a.dll,b.dll`).
+- `Pipeline:ProcessConfigs`: Hier können spezifische Konfigurationen für die einzelnen Prozessoren angegeben werden. Der Key ist der vollständige Name der Prozessklasse (inklusive Namespace). Der Value ist ein Dictionary von Schlüssel-Wert-Paaren, welche die Basis-Konfiguration für diesen Prozessor darstellen. Diese Konfigurationen werden den Prozessor-Initialisierungsfunktionen mittels Parameter übergeben und können in der Pipeline-Definition nicht überschrieben werden. Es sind nur skalare Werte möglich; listenwertige Parameter gehören in die `default_config` der Pipeline-Definition.
+
+Ein typisches Beispiel für die Konfiguration könnte wie folgt aussehen:
+
+```json
+{
+  "Pipeline": {
+    "Definition": "path/to/myPipeline.yaml",
+    "Plugins": [
+      "directory/myProcessorPluginA.dll"
+    ],
+    "ProcessConfigs": {
+      "Geopilot.Pipeline.Processes.XtfValidation.XtfValidatorProcess": {
+        "checkServiceBaseUrl": "http://localhost:3080/"
+      }
+    }
+  }
+}
+```

--- a/src/Geopilot.Api/PipelineDefinitions/basicPipeline_01.yaml
+++ b/src/Geopilot.Api/PipelineDefinitions/basicPipeline_01.yaml
@@ -1,3 +1,5 @@
+# Beispiel einer Pipeline-Definition. Format, Prozessoren und Plugin-System sind
+# unter docs/pipeline/Pipelines.md dokumentiert.
 processes:
   - id: xtf_matcher
     implementation: Geopilot.Pipeline.Processes.Matcher.XtfMatcher.XtfMatcherProcess

--- a/src/Geopilot.Api/PipelineDefinitions/basicPipeline_02.yaml
+++ b/src/Geopilot.Api/PipelineDefinitions/basicPipeline_02.yaml
@@ -1,3 +1,5 @@
+# Beispiel einer Pipeline-Definition. Format, Prozessoren und Plugin-System sind
+# unter docs/pipeline/Pipelines.md dokumentiert.
 processes:
   - id: xtf_matcher
     implementation: Geopilot.Pipeline.Processes.Matcher.XtfMatcher.XtfMatcherProcess

--- a/src/Geopilot.PipelineCore/Geopilot.PipelineCore.csproj
+++ b/src/Geopilot.PipelineCore/Geopilot.PipelineCore.csproj
@@ -7,7 +7,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <!-- NuGet package metadata (shared metadata comes from Directory.Build.props) -->
-    <!-- Versioned independently from the API: bump per SemVer based on the public surface tracked in PublicAPI.Shipped.txt. A major bump here forces every plugin to rebuild (see ValidatePluginCoreCompatibility). -->
+    <!-- Versioned independently from the API: bump per SemVer based on the public surface tracked in PublicAPI.Shipped.txt. A major bump here forces every plugin to rebuild (see ProcessPluginLoadContext.ValidateCompatibility in Geopilot.Pipeline). -->
     <VersionPrefix>2.0</VersionPrefix>
     <IsPackable>true</IsPackable>
     <PackageId>GeoWerkstatt.Geopilot.PipelineCore</PackageId>

--- a/src/Geopilot.PipelineCore/README.md
+++ b/src/Geopilot.PipelineCore/README.md
@@ -34,19 +34,26 @@ using Geopilot.PipelineCore.Pipeline;
 public class MyCustomProcess
 {
     [PipelineProcessRun]
-    public Task<Dictionary<string, object?>> RunAsync(IPipelineFile[] files)
+    public Task<MyCustomProcessResult> RunAsync(IPipelineFile[] files, CancellationToken cancellationToken)
     {
         // The pipeline definition wires this parameter to any source, e.g. files: "${upload()}"
         // ... your logic
-        return Task.FromResult(new Dictionary<string, object?>
-        {
-            { "result", "..." },
-        });
+        return Task.FromResult(new MyCustomProcessResult { Result = "..." });
     }
+}
+
+// Every public property of the result is an output, referenced from a later step by its
+// PascalCase name, for example "${step_output(myStep.Result)}".
+public class MyCustomProcessResult
+{
+    public required string Result { get; set; }
 }
 ```
 
-See the [geopilot repository](https://github.com/GeoWerkstatt/geopilot) for documentation and examples.
+Documentation:
+
+- [Plugin System](https://github.com/GeoWerkstatt/geopilot/blob/main/docs/pipeline/pluginSystem.md): the plugin contract, processor requirements and how to load a plugin into geopilot.
+- [Pipelines](https://github.com/GeoWerkstatt/geopilot/blob/main/docs/pipeline/Pipelines.md): the pipeline concepts and the YAML definition format a processor is wired into.
 
 ## License
 


### PR DESCRIPTION
Closes #827

Die Doku zum Pipeline-Definitionsformat, zu den mitgelieferten Prozessoren und zum Plugin-System beschreibt das Produkt und liegt damit beim Code statt im internen `geopilot-doc`. Damit hat auch das README des NuGet-Packages `GeoWerkstatt.Geopilot.PipelineCore` erstmals ein echtes Doku-Ziel zum Verlinken.

Gegenstück im internen Repo: geowerkstatt/geopilot-doc#43 (entfernt `Pipeline/` und stellt die ADR-Verweise auf absolute URLs um). Die beiden PRs gehören zusammen, dieser hier kann zuerst gemerged werden.

## Neu

- `docs/pipeline/Pipelines.md`, `docs/pipeline/pluginSystem.md` und `docs/pipeline/Prozessoren/` (6 Dateien), Struktur wie im Issue vorgegeben
- `docs/README.md` als Einstieg, verlinkt aus dem Root-README (Intro und Abschnitt Pipeline-Konfiguration)

Die sechs Prozessor-Dateien sind unverändert übernommen. In den beiden anderen Dateien habe ich das korrigiert, was nicht mehr gestimmt hat:

| Stelle | Vorher | Jetzt |
| --- | --- | --- |
| `Pipelines.md`, 2 Links | `[Text][Abschnittstitel]` ohne Link-Definition, rendert als Literaltext | Anchor-Links |
| `pluginSystem.md`, Versionsregel | "exakte Versionsgleichheit mit geopilot" | PipelineCore wird eigenständig versioniert: Major muss übereinstimmen, Plugin-Minor darf nicht höher sein, ältere Minor/Patch nur mit Warnung (`ProcessPluginLoadContext`) |
| `pluginSystem.md`, Konstruktor-Parameter | `IIli2GpkgClient` fehlte, Typliste unvollständig | ergänzt, inklusive Hinweis, dass listenwertige Parameter nur in `default_config` gehen und nicht in `Pipeline:ProcessConfigs` |
| `pluginSystem.md`, Appsettings-Keys | `Pipeline.Definition` | `Pipeline:Definition`, plus kommaseparierte Env-Var-Form für `Plugins` |
| `pluginSystem.md`, Beispiel | `async` ohne `await` (CS1998) | `Task.FromResult` |

## Weitere Anpassungen

- `src/Geopilot.PipelineCore/README.md`: das Beispiel gab noch ein `Task<Dictionary<string, object?>>` mit frei gewählten String-Keys zurück, also den alten Kontrakt. Jetzt eine Result-Klasse. Der Verweis "See the geopilot repository for documentation" zeigt auf die zwei konkreten Seiten (absolute URLs, weil das README im NuGet-Package mitgeht).
- Beide `PipelineDefinitions/*.yaml` mit Kommentar-Header auf die Doku.
- CHANGELOG-Eintrag unter Added.
- Aufgeräumt, weil es beim Prüfen der Doku aufgefallen ist: das README nannte für die API noch Port 7188. Tatsächlich sind es 7443 (`launchSettings.json`, Vite-Proxy, Appsettings und Keycloak-Realm stimmen alle überein). Und der Versionskommentar in `Geopilot.PipelineCore.csproj` verwies auf ein `ValidatePluginCoreCompatibility`, das es nicht gibt.

## Verifikation

- `dotnet build Geopilot.slnx`: 0 Warnings, 0 Errors
- `Geopilot.Pipeline.Test`: 361/361 grün
- beide Pipeline-YAMLs nach dem Kommentar-Header geparst
- alle relativen Markdown-Links und Anchors in `docs/`, README, CHANGELOG und PipelineCore-README aufgelöst, keine Restverweise auf die alten Pfade

Das Rendering auf GitHub selbst bitte in der Preview anschauen, insbesondere den Anchor mit Umlauten (`#einschränkungen-für-die-datenlieferung-delivery-restrictions`).