### PR TITLE
Veraltete Referenzen auf direkten Upload entfernen

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,11 +194,11 @@ Folgende Appsettings können definiert werden (Beispiel aus [appsettings.Develop
 
 Falls die `AuthorizationUrl` und/oder `TokenUrl` nicht definiert sind, wird im Swagger UI die OpenID Konfiguration der Authority (`<authority-url>/.well-known/openid-configuration`) geladen und alle vom Identity Provider unterstützten Flows angezeigt.
 
-## Cloud Upload (optional)
+## Cloud Upload
 
-geopilot kann optional mit einem Cloud-Upload-Flow betrieben werden, bei dem Dateien über Presigned URLs direkt in einen Object Storage hochgeladen werden. Die Standardimplementierung verwendet Azure Blob Storage (bzw. [Azurite](https://github.com/Azure/Azurite) als Emulator für die Entwicklung). Für die Virenprüfung wird optional [ClamAV](https://www.clamav.net/) unterstützt.
+Dateien werden über Presigned URLs direkt in einen Object Storage hochgeladen. Die Standardimplementierung verwendet Azure Blob Storage (bzw. [Azurite](https://github.com/Azure/Azurite) als Emulator für die Entwicklung). Für die Virenprüfung wird optional [ClamAV](https://www.clamav.net/) unterstützt.
 
-Beide Features sind standardmässig deaktiviert. Ohne Konfiguration wird ausschliesslich der klassische direkte Upload verwendet.
+Der Upload ist von der Verarbeitung entkoppelt: `POST /api/v2/upload` erstellt eine Upload-Session und liefert Presigned URLs, über welche die Dateien direkt in den Object Storage hochgeladen werden. Anschliessend startet `POST /api/v2/processing` mit der Upload-ID den Verarbeitungsjob.
 
 ### Entwicklung
 
@@ -210,11 +210,13 @@ docker compose up -d azurite clamav
 
 ### Konfiguration
 
+Die `CloudStorage`-Konfiguration ist erforderlich; ohne `ConnectionString` und `BucketName` startet die Applikation nicht.
+
 ```json5
 "CloudStorage": {
-    "Enabled": true,
     "ConnectionString": "...",
     "BucketName": "uploads",
+    "BlobEndpoint": "https://localhost:10000", // Öffentlicher Storage-Endpoint, wird der CSP (connect-src) hinzugefügt
     "AutoCreateContainer": false, // Nur für Entwicklung auf true setzen
     "AllowedOrigins": ["https://localhost:5173"] // CORS für Presigned-URL-Uploads
 },
@@ -227,6 +229,5 @@ docker compose up -d azurite clamav
 
 Weitere Einstellungen (`MaxFileSizeMB`, `MaxFilesPerJob`, `MaxJobSizeMB`, `MaxGlobalActiveSizeMB`, `MaxActiveJobs`, `PresignedUrlExpiryMinutes`, `CleanupAgeHours`, `CleanupIntervalMinutes`, `RateLimitRequests`, `RateLimitWindowMinutes`) werden in `appsettings.json` konfiguriert. Veraltete, verwaiste und überdimensionierte Uploads werden automatisch durch den `CloudCleanupService` bereinigt.
 
-- **Cloud Storage deaktiviert (Standard):** Nur der direkte Upload (`/api/v1/validation`) ist verfügbar. ClamAV-Einstellungen werden ignoriert.
-- **Cloud Storage aktiviert, ClamAV deaktiviert:** Cloud-Upload funktioniert ohne Virenprüfung. Pro Upload wird eine Warnung geloggt.
-- **Cloud Storage aktiviert, ClamAV aktiviert:** Cloud-Upload mit Virenprüfung vor der Validierung.
+- **ClamAV deaktiviert (Standard):** Uploads werden ohne Virenprüfung verarbeitet. Pro Upload wird eine Warnung geloggt.
+- **ClamAV aktiviert:** Virenprüfung vor der Verarbeitung.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,7 +111,6 @@ services:
       Auth__FullScope: "profile email openid geopilot.api"
       Auth__ApiServerScope: "geopilot.api"
       Pipeline__ProcessConfigs__Geopilot.Pipeline.Processes.XtfValidation.XtfValidatorProcess__checkServiceBaseUrl: http://interlis-check-service:8080/
-      CloudStorage__Enabled: true
       CloudStorage__ConnectionString: "DefaultEndpointsProtocol=https;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=https://localhost:10000/devstoreaccount1;"
       CloudStorage__BucketName: uploads
       CloudStorage__BlobEndpoint: https://localhost:10000

--- a/src/Geopilot.Api/ClamAvOptions.cs
+++ b/src/Geopilot.Api/ClamAvOptions.cs
@@ -6,7 +6,7 @@
 public class ClamAvOptions
 {
     /// <summary>
-    /// Whether ClamAV virus scanning is enabled. Requires cloud storage to be enabled.
+    /// Whether ClamAV virus scanning is enabled.
     /// </summary>
     public bool Enabled { get; set; }
 

--- a/src/Geopilot.Api/appsettings.Development.json
+++ b/src/Geopilot.Api/appsettings.Development.json
@@ -47,7 +47,6 @@
     }
   },
   "CloudStorage": {
-    "Enabled": true,
     "ConnectionString": "DefaultEndpointsProtocol=https;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=https://localhost:10000/devstoreaccount1;",
     "BucketName": "uploads",
     "BlobEndpoint": "https://localhost:10000",


### PR DESCRIPTION
Commit 9bb54905 hat den Cloud-Upload (Azure Blob) zum einzigen Upload-Pfad gemacht und den direkten Multipart-Upload sowie den Schalter `CloudStorage:Enabled` entfernt. Doku und Settings beschrieben aber noch den alten, optionalen Flow; dieser PR zieht sie nach.

## Änderungen

- **README**: Der Abschnitt "Cloud Upload (optional)" heisst neu "Cloud Upload" und beschreibt den Cloud-Upload als einzigen Upload-Pfad, inklusive des entkoppelten v2-Flows (`POST /api/v2/upload` liefert Presigned URLs, `POST /api/v2/processing` startet den Job mit der Upload-ID). Der Verweis auf den entfernten Endpoint `/api/v1/validation` und die Formulierung "standardmässig deaktiviert" sind weg. Das Konfigurationsbeispiel zeigt kein `"Enabled": true` mehr; stattdessen steht neu, dass die `CloudStorage`-Konfiguration erforderlich ist (ohne `ConnectionString`/`BucketName` startet die App nicht), und das Beispiel enthält neu `BlobEndpoint` (wird der CSP `connect-src` hinzugefügt). Die drei Szenario-Bullets sind auf zwei reduziert, da nur noch ClamAV ein- oder ausschaltbar ist.
- **appsettings.Development.json**: Toten Key `CloudStorage:Enabled` entfernt, er wird nirgends mehr gebunden.
- **docker-compose.yml**: Tote Env-Variable `CloudStorage__Enabled` entfernt.
- **ClamAvOptions.cs**: Veralteten Satz "Requires cloud storage to be enabled." aus dem Doc-Kommentar entfernt.

## Verifikation

- `dotnet build -c Release /warnaserror`: 0 Warnungen
- `docker compose config --quiet`: valide
- Repo-weites Grep: keine verbleibenden Referenzen auf den entfernten Schalter oder den alten direkten Upload; einzig der CHANGELOG-Eintrag, der die Entfernung selbst dokumentiert, bleibt (korrekt)

Kein neuer CHANGELOG-Eintrag: Die Entfernung ist bereits unter Unreleased dokumentiert, dieser PR zieht nur Doku und Dev-Konfiguration nach.