### PR TITLE
Zeitstempel in Job- und Upload-Store auf UTC vereinheitlichen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
 - The `ili2gpkg-worker` container and its shared job directory have been removed. ili2gpkg operations now run exclusively through the [ilitools-wrapper](https://github.com/geowerkstatt/ilitools-wrapper) service configured with `Ilitools:IlitoolsWrapperAddress`. Deployments must drop the `ili2gpkg-worker` service and the `/shared/ili2gpkg` mount from their compose file; pipeline definitions must drop the `jobsDirectory` configuration of processes that used the worker.
 - The `Storage:SharedDirectory` setting and the `/shared` volume of the geopilot image have been removed along with the file-drop integration. A `Storage__SharedDirectory` environment variable or `/shared` mount left in a deployment is ignored.
 
+### Fixed
+
+- Processing job and upload timestamps are now recorded in UTC, so the cleanup retention windows (job, download and visualization) are honored regardless of the container time zone. Previously, with the image default `TZ=Europe/Zurich`, expired downloads and visualizations lingered up to two hours longer than configured.
+
 ## v3.0.341 - 2026-06-17
 
 ### Added

--- a/src/Geopilot.Api/Processing/ProcessingJobStore.cs
+++ b/src/Geopilot.Api/Processing/ProcessingJobStore.cs
@@ -26,7 +26,7 @@ public class ProcessingJobStore : IProcessingJobStore
             Id: Guid.NewGuid(),
             Files: new List<ProcessingJobFile>(),
             MandateId: null,
-            CreatedAt: DateTime.Now);
+            CreatedAt: DateTime.UtcNow);
 
         jobs[newJob.Id] = newJob;
         return newJob;

--- a/src/Geopilot.Api/Processing/UploadStore.cs
+++ b/src/Geopilot.Api/Processing/UploadStore.cs
@@ -18,7 +18,7 @@ public class UploadStore : IUploadStore
         var upload = new UploadInfo(
             Id: id,
             Files: files,
-            CreatedAt: DateTime.Now);
+            CreatedAt: DateTime.UtcNow);
 
         if (!uploads.TryAdd(id, upload))
             throw new InvalidOperationException($"An upload with id <{id}> already exists.");

--- a/src/Geopilot.Api/StacServices/StacConverter.cs
+++ b/src/Geopilot.Api/StacServices/StacConverter.cs
@@ -73,7 +73,7 @@ public class StacConverter
 
         if (items.Values.Count == 0)
         {
-            var nowTimestamp = DateTime.Now.ToUniversalTime();
+            var nowTimestamp = DateTime.UtcNow;
             var extent = new StacExtent(ToStacSpatialExtent(mandate.SpatialExtent), new StacTemporalExtent(nowTimestamp, nowTimestamp));
             return new StacCollection(collectionId, string.Empty, extent, null, null)
             {

--- a/src/Geopilot.PipelineCore/Geopilot.PipelineCore.csproj
+++ b/src/Geopilot.PipelineCore/Geopilot.PipelineCore.csproj
@@ -7,7 +7,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <!-- NuGet package metadata (shared metadata comes from Directory.Build.props) -->
-    <!-- Versioned independently from the API: bump per SemVer based on the public surface tracked in PublicAPI.Shipped.txt. A major bump here forces every plugin to rebuild (see ProcessPluginLoadContext.ValidateCompatibility in Geopilot.Pipeline). -->
     <VersionPrefix>2.0</VersionPrefix>
     <IsPackable>true</IsPackable>
     <PackageId>GeoWerkstatt.Geopilot.PipelineCore</PackageId>

--- a/tests/Geopilot.Api.Test/Processing/ProcessingJobCleanupServiceTest.cs
+++ b/tests/Geopilot.Api.Test/Processing/ProcessingJobCleanupServiceTest.cs
@@ -6,13 +6,14 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 
-namespace Geopilot.Api.Test.Validation;
+namespace Geopilot.Api.Test.Processing;
 
 [TestClass]
 public class ProcessingJobCleanupServiceTest
 {
     private const double JobRetentionHours = 24;
     private const double DownloadRetentionHours = 1;
+    private const double VisualizationRetentionHours = 0.5;
     private Mock<IProcessingJobStore> jobStoreMock;
     private Mock<IDirectoryProvider> directoryProviderMock;
     private Mock<ILogger<ProcessingJobCleanupService>> loggerMock;
@@ -20,6 +21,7 @@ public class ProcessingJobCleanupServiceTest
     private string tempUploadRoot;
     private string tempAssetRoot;
     private string tempDownloadRoot;
+    private string tempVisualizationRoot;
     private string tempPipelineRoot;
     private ProcessingJobCleanupService service;
 
@@ -35,6 +37,7 @@ public class ProcessingJobCleanupServiceTest
         {
             JobRetention = TimeSpan.FromHours(JobRetentionHours),
             DownloadRetention = TimeSpan.FromHours(DownloadRetentionHours),
+            VisualizationRetention = TimeSpan.FromHours(VisualizationRetentionHours),
             JobCleanupInterval = TimeSpan.FromHours(24),
             JobTimeout = TimeSpan.FromHours(12),
         };
@@ -59,14 +62,17 @@ public class ProcessingJobCleanupServiceTest
         tempUploadRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         tempAssetRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         tempDownloadRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        tempVisualizationRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         tempPipelineRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(tempUploadRoot);
         Directory.CreateDirectory(tempAssetRoot);
         Directory.CreateDirectory(tempDownloadRoot);
+        Directory.CreateDirectory(tempVisualizationRoot);
         Directory.CreateDirectory(tempPipelineRoot);
         directoryProviderMock.Setup(d => d.UploadDirectory).Returns(tempUploadRoot);
         directoryProviderMock.Setup(d => d.AssetDirectory).Returns(tempAssetRoot);
         directoryProviderMock.Setup(d => d.DownloadDirectory).Returns(tempDownloadRoot);
+        directoryProviderMock.Setup(d => d.VisualizationDirectory).Returns(tempVisualizationRoot);
         directoryProviderMock.Setup(d => d.PipelineDirectory).Returns(tempPipelineRoot);
         directoryProviderMock
             .Setup(d => d.GetUploadDirectoryPath(It.IsAny<Guid>()))
@@ -78,6 +84,9 @@ public class ProcessingJobCleanupServiceTest
             .Setup(d => d.GetDownloadDirectoryPath(It.IsAny<Guid>()))
             .Returns<Guid>(jobId => Path.Combine(tempDownloadRoot, jobId.ToString()));
         directoryProviderMock
+            .Setup(d => d.GetVisualizationDirectoryPath(It.IsAny<Guid>()))
+            .Returns<Guid>(jobId => Path.Combine(tempVisualizationRoot, jobId.ToString()));
+        directoryProviderMock
             .Setup(d => d.GetPipelineDirectoryPath(It.IsAny<Guid>()))
             .Returns<Guid>(jobId => Path.Combine(tempPipelineRoot, jobId.ToString()));
     }
@@ -85,7 +94,7 @@ public class ProcessingJobCleanupServiceTest
     [TestCleanup]
     public void Cleanup()
     {
-        foreach (var root in new[] { tempUploadRoot, tempAssetRoot, tempDownloadRoot, tempPipelineRoot })
+        foreach (var root in new[] { tempUploadRoot, tempAssetRoot, tempDownloadRoot, tempVisualizationRoot, tempPipelineRoot })
         {
             if (Directory.Exists(root))
                 Directory.Delete(root, true);
@@ -99,7 +108,7 @@ public class ProcessingJobCleanupServiceTest
     public void RunCleanupRetiresOrphanedJob()
     {
         var orphanJobId = Guid.NewGuid();
-        var (uploadDir, assetDir, downloadDir, pipelineDir) = CreateJobDirectories(orphanJobId);
+        var (uploadDir, assetDir, downloadDir, visualizationDir, pipelineDir) = CreateJobDirectories(orphanJobId);
 
         jobStoreMock.Setup(s => s.GetJob(orphanJobId)).Returns((ProcessingJob?)null);
         jobStoreMock.Setup(s => s.RemoveJob(orphanJobId)).Returns(true);
@@ -108,6 +117,7 @@ public class ProcessingJobCleanupServiceTest
 
         Assert.IsFalse(Directory.Exists(uploadDir));
         Assert.IsFalse(Directory.Exists(downloadDir));
+        Assert.IsFalse(Directory.Exists(visualizationDir));
         Assert.IsFalse(Directory.Exists(assetDir));
         Assert.IsFalse(Directory.Exists(pipelineDir));
         jobStoreMock.Verify(s => s.RemoveJob(orphanJobId), Times.Once);
@@ -117,7 +127,7 @@ public class ProcessingJobCleanupServiceTest
     public void RunCleanupRetiresExpiredUnsubmittedJob()
     {
         var jobId = Guid.NewGuid();
-        var (uploadDir, assetDir, downloadDir, pipelineDir) = CreateJobDirectories(jobId);
+        var (uploadDir, assetDir, downloadDir, visualizationDir, pipelineDir) = CreateJobDirectories(jobId);
 
         var oldJob = new ProcessingJob(
             jobId,
@@ -132,6 +142,7 @@ public class ProcessingJobCleanupServiceTest
 
         Assert.IsFalse(Directory.Exists(uploadDir));
         Assert.IsFalse(Directory.Exists(downloadDir));
+        Assert.IsFalse(Directory.Exists(visualizationDir));
         Assert.IsFalse(Directory.Exists(assetDir));
         Assert.IsFalse(Directory.Exists(pipelineDir));
         jobStoreMock.Verify(s => s.RemoveJob(jobId), Times.Once);
@@ -141,7 +152,7 @@ public class ProcessingJobCleanupServiceTest
     public void RunCleanupKeepsAssetDirForSubmittedDelivery()
     {
         var jobId = Guid.NewGuid();
-        var (uploadDir, assetDir, downloadDir, pipelineDir) = CreateJobDirectories(jobId);
+        var (uploadDir, assetDir, downloadDir, visualizationDir, pipelineDir) = CreateJobDirectories(jobId);
 
         // The job has been submitted as a delivery; the asset directory must survive cleanup.
         SeedDelivery(jobId);
@@ -159,6 +170,7 @@ public class ProcessingJobCleanupServiceTest
 
         Assert.IsFalse(Directory.Exists(uploadDir), "Upload directory should be cleaned on JobRetention.");
         Assert.IsFalse(Directory.Exists(downloadDir), "Download directory should be cleaned on JobRetention.");
+        Assert.IsFalse(Directory.Exists(visualizationDir), "Visualization directory should be cleaned on JobRetention.");
         Assert.IsFalse(Directory.Exists(pipelineDir), "Pipeline working directory should be cleaned on JobRetention.");
         Assert.IsTrue(Directory.Exists(assetDir), "Asset directory must survive cleanup for submitted deliveries.");
         jobStoreMock.Verify(s => s.RemoveJob(jobId), Times.Once);
@@ -168,7 +180,7 @@ public class ProcessingJobCleanupServiceTest
     public void RunCleanupExpiresDownloadsBeforeFullRetention()
     {
         var jobId = Guid.NewGuid();
-        var (uploadDir, assetDir, downloadDir, pipelineDir) = CreateJobDirectories(jobId);
+        var (uploadDir, assetDir, downloadDir, visualizationDir, pipelineDir) = CreateJobDirectories(jobId);
 
         var partlyExpiredJob = new ProcessingJob(
             jobId,
@@ -184,6 +196,55 @@ public class ProcessingJobCleanupServiceTest
         Assert.IsTrue(Directory.Exists(assetDir), "Asset directory should still exist within JobRetention.");
         Assert.IsTrue(Directory.Exists(pipelineDir), "Pipeline working directory should still exist within JobRetention.");
         Assert.IsFalse(Directory.Exists(downloadDir), "Download directory should be cleaned after DownloadRetention.");
+        Assert.IsFalse(Directory.Exists(visualizationDir), "Visualization directory should be cleaned after VisualizationRetention.");
+        jobStoreMock.Verify(s => s.RemoveJob(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [TestMethod]
+    public void RunCleanupExpiresVisualizationsBeforeDownloadRetention()
+    {
+        var jobId = Guid.NewGuid();
+        var (uploadDir, assetDir, downloadDir, visualizationDir, pipelineDir) = CreateJobDirectories(jobId);
+
+        var partlyExpiredJob = new ProcessingJob(
+            jobId,
+            new List<ProcessingJobFile>(),
+            null,
+            DateTime.UtcNow.AddHours(-(VisualizationRetentionHours + 0.25)));
+
+        jobStoreMock.Setup(s => s.GetJob(jobId)).Returns(partlyExpiredJob);
+
+        service.RunCleanup();
+
+        Assert.IsTrue(Directory.Exists(uploadDir), "Upload directory should still exist within JobRetention.");
+        Assert.IsTrue(Directory.Exists(assetDir), "Asset directory should still exist within JobRetention.");
+        Assert.IsTrue(Directory.Exists(downloadDir), "Download directory should still exist within DownloadRetention.");
+        Assert.IsTrue(Directory.Exists(pipelineDir), "Pipeline working directory should still exist within JobRetention.");
+        Assert.IsFalse(Directory.Exists(visualizationDir), "Visualization directory should be cleaned after VisualizationRetention.");
+        jobStoreMock.Verify(s => s.RemoveJob(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [TestMethod]
+    public void RunCleanupKeepsFreshJobDirectories()
+    {
+        var jobId = Guid.NewGuid();
+        var (uploadDir, assetDir, downloadDir, visualizationDir, pipelineDir) = CreateJobDirectories(jobId);
+
+        var freshJob = new ProcessingJob(
+            jobId,
+            new List<ProcessingJobFile>(),
+            null,
+            DateTime.UtcNow);
+
+        jobStoreMock.Setup(s => s.GetJob(jobId)).Returns(freshJob);
+
+        service.RunCleanup();
+
+        Assert.IsTrue(Directory.Exists(uploadDir));
+        Assert.IsTrue(Directory.Exists(assetDir));
+        Assert.IsTrue(Directory.Exists(downloadDir));
+        Assert.IsTrue(Directory.Exists(visualizationDir));
+        Assert.IsTrue(Directory.Exists(pipelineDir));
         jobStoreMock.Verify(s => s.RemoveJob(It.IsAny<Guid>()), Times.Never);
     }
 
@@ -219,17 +280,19 @@ public class ProcessingJobCleanupServiceTest
         jobStoreMock.Verify(s => s.RemoveJob(It.IsAny<Guid>()), Times.Never);
     }
 
-    private (string Upload, string Asset, string Download, string Pipeline) CreateJobDirectories(Guid jobId)
+    private (string Upload, string Asset, string Download, string Visualization, string Pipeline) CreateJobDirectories(Guid jobId)
     {
         var upload = Path.Combine(tempUploadRoot, jobId.ToString());
         var asset = Path.Combine(tempAssetRoot, jobId.ToString());
         var download = Path.Combine(tempDownloadRoot, jobId.ToString());
+        var visualization = Path.Combine(tempVisualizationRoot, jobId.ToString());
         var pipeline = Path.Combine(tempPipelineRoot, jobId.ToString());
         Directory.CreateDirectory(upload);
         Directory.CreateDirectory(asset);
         Directory.CreateDirectory(download);
+        Directory.CreateDirectory(visualization);
         Directory.CreateDirectory(pipeline);
-        return (upload, asset, download, pipeline);
+        return (upload, asset, download, visualization, pipeline);
     }
 
     private void SeedDelivery(Guid jobId)

--- a/tests/Geopilot.Api.Test/Processing/ProcessingJobStoreTest.cs
+++ b/tests/Geopilot.Api.Test/Processing/ProcessingJobStoreTest.cs
@@ -28,6 +28,18 @@ public class ProcessingJobStoreTest
     }
 
     [TestMethod]
+    public void CreateJobSetsUtcCreatedAt()
+    {
+        var before = DateTime.UtcNow;
+        var job = store.CreateJob();
+        var after = DateTime.UtcNow;
+
+        Assert.AreEqual(DateTimeKind.Utc, job.CreatedAt.Kind);
+        Assert.IsTrue(before <= job.CreatedAt);
+        Assert.IsTrue(job.CreatedAt <= after);
+    }
+
+    [TestMethod]
     public void GetJob()
     {
         var created = store.CreateJob();

--- a/tests/Geopilot.Api.Test/Processing/UploadStoreTest.cs
+++ b/tests/Geopilot.Api.Test/Processing/UploadStoreTest.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Immutable;
+
+namespace Geopilot.Api.Processing;
+
+[TestClass]
+public class UploadStoreTest
+{
+    private UploadStore store;
+
+    [TestInitialize]
+    public void Initialize()
+    {
+        store = new UploadStore();
+    }
+
+    [TestMethod]
+    public void CreateUpload()
+    {
+        var id = Guid.NewGuid();
+        var files = ImmutableList.Create(new CloudFileInfo("test.xtf", "cloud/key/test.xtf", 42));
+
+        var upload = store.CreateUpload(id, files);
+
+        Assert.AreEqual(id, upload.Id);
+        Assert.AreSame(files, upload.Files);
+        Assert.AreSame(upload, store.GetUpload(id));
+    }
+
+    [TestMethod]
+    public void CreateUploadSetsUtcCreatedAt()
+    {
+        var before = DateTime.UtcNow;
+        var upload = store.CreateUpload(Guid.NewGuid(), ImmutableList<CloudFileInfo>.Empty);
+        var after = DateTime.UtcNow;
+
+        Assert.AreEqual(DateTimeKind.Utc, upload.CreatedAt.Kind);
+        Assert.IsTrue(before <= upload.CreatedAt);
+        Assert.IsTrue(upload.CreatedAt <= after);
+    }
+
+    [TestMethod]
+    public void CreateUploadThrowsIfIdAlreadyExists()
+    {
+        var id = Guid.NewGuid();
+        store.CreateUpload(id, ImmutableList<CloudFileInfo>.Empty);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => store.CreateUpload(id, ImmutableList<CloudFileInfo>.Empty));
+    }
+}


### PR DESCRIPTION
## Problem

`ProcessingJobStore.CreateJob` und `UploadStore.CreateUpload` haben `CreatedAt` mit `DateTime.Now` (Lokalzeit) gestempelt, der `ProcessingJobCleanupService` vergleicht aber gegen `DateTime.UtcNow`. Mit dem Image-Default `TZ=Europe/Zurich` wurde das Alter jedes Jobs dadurch um 1 bis 2 Stunden unterschätzt, alle Retention-Fenster liefen entsprechend zu spät ab. Bei den Defaults `DownloadRetention` (1 h) und `VisualizationRetention` (30 min) dominiert der Offset das konfigurierte Fenster komplett. In einer Zeitzone westlich von UTC würde umgekehrt zu früh gelöscht.

## Änderungen

- `CreatedAt` in `ProcessingJobStore` und `UploadStore` wird neu mit `DateTime.UtcNow` gesetzt (bei `UploadInfo.CreatedAt` reine Konsistenz, der Wert wird aktuell nirgends gelesen). Beide Stores sind In-Memory-Singletons; `CreatedAt` wird weder serialisiert noch persistiert, die Umstellung hat also keine API- oder DB-Auswirkung.
- `StacConverter`: redundantes `DateTime.Now.ToUniversalTime()` durch `DateTime.UtcNow` ersetzt. Damit gibt es unter `src/` keine `DateTime.Now`-Verwendung mehr (Audit gemäss Issue).
- Regressionstests: `CreatedAt` wird in beiden Stores auf `Kind == Utc` plus Wertebereich geprüft; das schlägt mit `DateTime.Now` in jeder Zeitzone fehl, auch auf UTC-Runnern. Neue `UploadStoreTest`-Klasse.
- Cleanup-Tests: die Visualization-Retention-Stufe war bisher ein stiller No-op (`VisualizationRetention` nicht gesetzt, Verzeichnis nicht gestubbt) und wird jetzt echt getestet, inklusive Stufen-Reihenfolge (Visualization vor Download vor Job-Retention) und einem Frisch-Job-Test gegen vorzeitiges Löschen.
- CHANGELOG-Eintrag unter Fixed.

Separater Commit, unabhängig vom Issue: der veraltete Kommentar in `Geopilot.PipelineCore.csproj`, der auf das entfernte `PublicAPI.Shipped.txt` verwies, ist entfernt. Deshalb springt der `pipelinecore-version-check` an; er ist grün, weil `VersionPrefix` 2.0 über dem letzten Release-Tag `pipelinecore/v1.3` liegt.

## Verifikation

- Build mit `/warnaserror`: 0 Warnings
- `Geopilot.Api.Test`: 456/456 grün (nach Rebase auf #826)
- Negativ-Probe: mit temporär auf `DateTime.Now` zurückgesetztem Store schlägt `CreateJobSetsUtcCreatedAt` über die Kind-Assertion fehl

Closes #835