### PR TITLE
Clean up and unmount pipeline working directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,6 @@ EXPOSE 8080
 VOLUME $Storage__UploadDirectory
 VOLUME $Storage__DownloadDirectory
 VOLUME $Storage__AssetsDirectory
-VOLUME $Storage__PipelineDirectory
 VOLUME $Storage__ResourcesDirectory
 VOLUME $Storage__VisualizationDirectory
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,7 +123,6 @@ services:
       - ./src/Geopilot.Api/Uploads:/uploads
       - ./src/Geopilot.Api/Downloads:/downloads
       - ./src/Geopilot.Api/Persistent:/assets
-      - ./src/Geopilot.Api/Pipeline:/pipeline
       - ./src/Geopilot.Api/Resources:/resources
       - ./src/Geopilot.Api/PipelineDefinitions/basicPipeline_01.yaml:/pipelines/pipelines.yaml:ro
       - ./src/Geopilot.Frontend/devPublic:/public

--- a/src/Geopilot.Api/Processing/ProcessingJobCleanupService.cs
+++ b/src/Geopilot.Api/Processing/ProcessingJobCleanupService.cs
@@ -102,8 +102,11 @@ public class ProcessingJobCleanupService : BackgroundService
             // is the long-term archive; for a job whose run was never submitted as a delivery
             // we wipe its asset directory too so dead data doesn't accumulate. Submitted
             // deliveries survive cleanup and are only removed via DeliveryController.Delete.
+            // Pipeline working directories are normally removed by Pipeline.Dispose, but survive
+            // a hard restart (nothing gets disposed), so they count as retirement candidates too.
             var retiredCandidates = EnumerateJobIds(directoryProvider.UploadDirectory);
             retiredCandidates.UnionWith(EnumerateJobIds(directoryProvider.AssetDirectory));
+            retiredCandidates.UnionWith(EnumerateJobIds(directoryProvider.PipelineDirectory));
             foreach (var jobId in retiredCandidates)
             {
                 var job = jobStore.GetJob(jobId);
@@ -148,6 +151,7 @@ public class ProcessingJobCleanupService : BackgroundService
             DeleteIfExists(directoryProvider.GetUploadDirectoryPath(jobId));
             DeleteIfExists(directoryProvider.GetDownloadDirectoryPath(jobId));
             DeleteIfExists(directoryProvider.GetVisualizationDirectoryPath(jobId));
+            DeleteIfExists(directoryProvider.GetPipelineDirectoryPath(jobId));
             if (!hasSubmittedDelivery)
                 DeleteIfExists(directoryProvider.GetAssetDirectoryPath(jobId));
             jobStore.RemoveJob(jobId);

--- a/tests/Geopilot.Api.Test/Processing/ProcessingJobCleanupServiceTest.cs
+++ b/tests/Geopilot.Api.Test/Processing/ProcessingJobCleanupServiceTest.cs
@@ -20,6 +20,7 @@ public class ProcessingJobCleanupServiceTest
     private string tempUploadRoot;
     private string tempAssetRoot;
     private string tempDownloadRoot;
+    private string tempPipelineRoot;
     private ProcessingJobCleanupService service;
 
     [TestInitialize]
@@ -58,12 +59,15 @@ public class ProcessingJobCleanupServiceTest
         tempUploadRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         tempAssetRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         tempDownloadRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        tempPipelineRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(tempUploadRoot);
         Directory.CreateDirectory(tempAssetRoot);
         Directory.CreateDirectory(tempDownloadRoot);
+        Directory.CreateDirectory(tempPipelineRoot);
         directoryProviderMock.Setup(d => d.UploadDirectory).Returns(tempUploadRoot);
         directoryProviderMock.Setup(d => d.AssetDirectory).Returns(tempAssetRoot);
         directoryProviderMock.Setup(d => d.DownloadDirectory).Returns(tempDownloadRoot);
+        directoryProviderMock.Setup(d => d.PipelineDirectory).Returns(tempPipelineRoot);
         directoryProviderMock
             .Setup(d => d.GetUploadDirectoryPath(It.IsAny<Guid>()))
             .Returns<Guid>(jobId => Path.Combine(tempUploadRoot, jobId.ToString()));
@@ -73,12 +77,15 @@ public class ProcessingJobCleanupServiceTest
         directoryProviderMock
             .Setup(d => d.GetDownloadDirectoryPath(It.IsAny<Guid>()))
             .Returns<Guid>(jobId => Path.Combine(tempDownloadRoot, jobId.ToString()));
+        directoryProviderMock
+            .Setup(d => d.GetPipelineDirectoryPath(It.IsAny<Guid>()))
+            .Returns<Guid>(jobId => Path.Combine(tempPipelineRoot, jobId.ToString()));
     }
 
     [TestCleanup]
     public void Cleanup()
     {
-        foreach (var root in new[] { tempUploadRoot, tempAssetRoot, tempDownloadRoot })
+        foreach (var root in new[] { tempUploadRoot, tempAssetRoot, tempDownloadRoot, tempPipelineRoot })
         {
             if (Directory.Exists(root))
                 Directory.Delete(root, true);
@@ -92,7 +99,7 @@ public class ProcessingJobCleanupServiceTest
     public void RunCleanupRetiresOrphanedJob()
     {
         var orphanJobId = Guid.NewGuid();
-        var (uploadDir, assetDir, downloadDir) = CreateJobDirectories(orphanJobId);
+        var (uploadDir, assetDir, downloadDir, pipelineDir) = CreateJobDirectories(orphanJobId);
 
         jobStoreMock.Setup(s => s.GetJob(orphanJobId)).Returns((ProcessingJob?)null);
         jobStoreMock.Setup(s => s.RemoveJob(orphanJobId)).Returns(true);
@@ -102,6 +109,7 @@ public class ProcessingJobCleanupServiceTest
         Assert.IsFalse(Directory.Exists(uploadDir));
         Assert.IsFalse(Directory.Exists(downloadDir));
         Assert.IsFalse(Directory.Exists(assetDir));
+        Assert.IsFalse(Directory.Exists(pipelineDir));
         jobStoreMock.Verify(s => s.RemoveJob(orphanJobId), Times.Once);
     }
 
@@ -109,7 +117,7 @@ public class ProcessingJobCleanupServiceTest
     public void RunCleanupRetiresExpiredUnsubmittedJob()
     {
         var jobId = Guid.NewGuid();
-        var (uploadDir, assetDir, downloadDir) = CreateJobDirectories(jobId);
+        var (uploadDir, assetDir, downloadDir, pipelineDir) = CreateJobDirectories(jobId);
 
         var oldJob = new ProcessingJob(
             jobId,
@@ -125,6 +133,7 @@ public class ProcessingJobCleanupServiceTest
         Assert.IsFalse(Directory.Exists(uploadDir));
         Assert.IsFalse(Directory.Exists(downloadDir));
         Assert.IsFalse(Directory.Exists(assetDir));
+        Assert.IsFalse(Directory.Exists(pipelineDir));
         jobStoreMock.Verify(s => s.RemoveJob(jobId), Times.Once);
     }
 
@@ -132,7 +141,7 @@ public class ProcessingJobCleanupServiceTest
     public void RunCleanupKeepsAssetDirForSubmittedDelivery()
     {
         var jobId = Guid.NewGuid();
-        var (uploadDir, assetDir, downloadDir) = CreateJobDirectories(jobId);
+        var (uploadDir, assetDir, downloadDir, pipelineDir) = CreateJobDirectories(jobId);
 
         // The job has been submitted as a delivery; the asset directory must survive cleanup.
         SeedDelivery(jobId);
@@ -150,6 +159,7 @@ public class ProcessingJobCleanupServiceTest
 
         Assert.IsFalse(Directory.Exists(uploadDir), "Upload directory should be cleaned on JobRetention.");
         Assert.IsFalse(Directory.Exists(downloadDir), "Download directory should be cleaned on JobRetention.");
+        Assert.IsFalse(Directory.Exists(pipelineDir), "Pipeline working directory should be cleaned on JobRetention.");
         Assert.IsTrue(Directory.Exists(assetDir), "Asset directory must survive cleanup for submitted deliveries.");
         jobStoreMock.Verify(s => s.RemoveJob(jobId), Times.Once);
     }
@@ -158,7 +168,7 @@ public class ProcessingJobCleanupServiceTest
     public void RunCleanupExpiresDownloadsBeforeFullRetention()
     {
         var jobId = Guid.NewGuid();
-        var (uploadDir, assetDir, downloadDir) = CreateJobDirectories(jobId);
+        var (uploadDir, assetDir, downloadDir, pipelineDir) = CreateJobDirectories(jobId);
 
         var partlyExpiredJob = new ProcessingJob(
             jobId,
@@ -172,31 +182,54 @@ public class ProcessingJobCleanupServiceTest
 
         Assert.IsTrue(Directory.Exists(uploadDir), "Upload directory should still exist within JobRetention.");
         Assert.IsTrue(Directory.Exists(assetDir), "Asset directory should still exist within JobRetention.");
+        Assert.IsTrue(Directory.Exists(pipelineDir), "Pipeline working directory should still exist within JobRetention.");
         Assert.IsFalse(Directory.Exists(downloadDir), "Download directory should be cleaned after DownloadRetention.");
         jobStoreMock.Verify(s => s.RemoveJob(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [TestMethod]
+    public void RunCleanupRetiresOrphanedPipelineDirectory()
+    {
+        // A pipeline working directory left behind by a hard restart: the in-memory job store
+        // is empty and no upload or asset directory exists that would flag the job for retirement.
+        var orphanJobId = Guid.NewGuid();
+        var pipelineDir = Path.Combine(tempPipelineRoot, orphanJobId.ToString());
+        Directory.CreateDirectory(pipelineDir);
+
+        jobStoreMock.Setup(s => s.GetJob(orphanJobId)).Returns((ProcessingJob?)null);
+
+        service.RunCleanup();
+
+        Assert.IsFalse(Directory.Exists(pipelineDir));
+        jobStoreMock.Verify(s => s.RemoveJob(orphanJobId), Times.Once);
     }
 
     [TestMethod]
     public void RunCleanupSkipsNonGuidFolders()
     {
         var nonGuidDir = Path.Combine(tempUploadRoot, "not-a-guid");
+        var nonGuidPipelineDir = Path.Combine(tempPipelineRoot, "not-a-guid");
         Directory.CreateDirectory(nonGuidDir);
+        Directory.CreateDirectory(nonGuidPipelineDir);
 
         service.RunCleanup();
 
         Assert.IsTrue(Directory.Exists(nonGuidDir));
+        Assert.IsTrue(Directory.Exists(nonGuidPipelineDir));
         jobStoreMock.Verify(s => s.RemoveJob(It.IsAny<Guid>()), Times.Never);
     }
 
-    private (string Upload, string Asset, string Download) CreateJobDirectories(Guid jobId)
+    private (string Upload, string Asset, string Download, string Pipeline) CreateJobDirectories(Guid jobId)
     {
         var upload = Path.Combine(tempUploadRoot, jobId.ToString());
         var asset = Path.Combine(tempAssetRoot, jobId.ToString());
         var download = Path.Combine(tempDownloadRoot, jobId.ToString());
+        var pipeline = Path.Combine(tempPipelineRoot, jobId.ToString());
         Directory.CreateDirectory(upload);
         Directory.CreateDirectory(asset);
         Directory.CreateDirectory(download);
-        return (upload, asset, download);
+        Directory.CreateDirectory(pipeline);
+        return (upload, asset, download, pipeline);
     }
 
     private void SeedDelivery(Guid jobId)


### PR DESCRIPTION
Closes #838

## Problem

`{PipelineDirectory}/{jobId}` (Copy-on-Write-Arbeitskopien und Zwischenresultate der Steps) wurde ausschliesslich über `Pipeline.Dispose()` gelöscht. Ein harter Neustart (Crash, OOM-Kill) und ein sauberer Shutdown mit Jobs in Queue oder Preflight erreichen keinen der Dispose-Pfade; da das Verzeichnis persistent gemountet war, akkumulierten die Reste unbegrenzt. Details im Issue.

## Änderungen

**Cleanup (Lösungsvorschlag aus dem Issue):** Der `ProcessingJobCleanupService` enumeriert Retire-Kandidaten zusätzlich aus `directoryProvider.PipelineDirectory` und löscht in `RetireJob` auch das Pipeline-Arbeitsverzeichnis. Doppelte Löschung (explizit und via `Pipeline.Dispose` durch `RemoveJob`) ist in beiden Reihenfolgen unkritisch, beide Pfade prüfen die Existenz. Damit sind die Reste innerhalb der Container-Lebensdauer zeitlich begrenzt (deckt insbesondere Restarts ab, bei denen der Writable Layer überlebt).

**Unmount (Entscheid aus dem Issue-Kommentar):** Der Dev-Compose-Mount und die `VOLUME`-Deklaration im Dockerfile sind entfernt. Die `VOLUME`-Zeile muss mit raus: Ohne expliziten Mount legt Docker sonst ein anonymes Volume an, das Compose beim Recreate standardmässig wieder anhängt, der Entscheid würde also nicht greifen. Das Arbeitsverzeichnis liegt jetzt im Writable Layer und stirbt spätestens mit dem Container-Recreate.

## Tests

- Neuer Testfall "verwaistes Pipeline-Verzeichnis ohne zugehöriges Upload- oder Asset-Verzeichnis" (test-first, Failure vor dem Fix verifiziert), Pipeline-Dir-Assertions in den bestehenden Retirement-Tests, Guard dass das Verzeichnis innerhalb der Retention überlebt
- Volle Backend-Suite grün (369 + 451), Release-Build mit `/warnaserror` sauber, `docker compose config` und `docker build --check` OK

Kein CHANGELOG-Eintrag: Das betroffene Cleanup-System ist noch in keinem Release beim Kunden.

Folgearbeiten: geopilot-hosting entfernt den Mount separat (PR im Hosting-Repo), ADR 0010 wird in geopilot-doc nachgeführt.