### PR TITLE
Update stac browser

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,10 @@
 services:
   stac-browser:
-    image: ghcr.io/geowerkstatt/stac-browser:3.2.0
+    image: ghcr.io/radiantearth/stac-browser:5.0.0
     ports:
       - 8080:8080
     environment:
+      SB_pathPrefix: "/browser/"
       SB_catalogUrl: "https://localhost:5173/api/stac"
       SB_locale: "de-CH"
       SB_fallbackLocale: "de-CH"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       SB_catalogUrl: "https://localhost:5173/api/stac"
       SB_locale: "de-CH"
       SB_fallbackLocale: "de-CH"
-      SB_supportedLocales: "de-CH"
+      SB_supportedLocales: "de-CH,fr-CH,it-CH,en"
 
   db:
     image: postgis/postgis

--- a/src/Geopilot.Api/Program.cs
+++ b/src/Geopilot.Api/Program.cs
@@ -330,7 +330,7 @@ app.Use(async (context, next) =>
         {
             context.Response.Headers.Append(
                 "Content-Security-Policy",
-                "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; object-src 'none'; base-uri 'none'; form-action 'self'; frame-ancestors 'none';");
+                "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';");
         }
 
         await next(context);

--- a/src/Geopilot.Api/StacServices/StacItemsProvider.cs
+++ b/src/Geopilot.Api/StacServices/StacItemsProvider.cs
@@ -2,6 +2,8 @@
 using Microsoft.EntityFrameworkCore;
 using Stac;
 using Stac.Api.Interfaces;
+using Stac.Api.Services.Pagination;
+using Stac.Api.WebApi.Services;
 
 namespace Geopilot.Api.StacServices;
 
@@ -79,6 +81,8 @@ public class StacItemsProvider : IItemsProvider
     {
         ArgumentNullException.ThrowIfNull(stacApiContext);
 
+        FixPaginationParameters(stacApiContext);
+
         var items = new List<StacItem>();
 
         var collectionIds = stacApiContext.Collections?.ToList();
@@ -96,5 +100,19 @@ public class StacItemsProvider : IItemsProvider
         }
 
         return items;
+    }
+
+    private void FixPaginationParameters(IStacApiContext stacApiContext)
+    {
+        // Fix limit defaulting to 0 instead of null, resulting in no items returned from search.
+        switch (stacApiContext.Properties[PaginationExtensions.PaginationPropertiesKey])
+        {
+            case QueryStringPaginationParameters queryPagination when queryPagination.Limit == 0:
+                queryPagination.Limit = null;
+                break;
+            case BodyPaginationParameters bodyPagination when bodyPagination.Limit == 0:
+                bodyPagination.Limit = null;
+                break;
+        }
     }
 }

--- a/tests/Geopilot.Api.Test/StacApi/SearchTest.cs
+++ b/tests/Geopilot.Api.Test/StacApi/SearchTest.cs
@@ -54,4 +54,16 @@ public class SearchTest
         Assert.AreEqual(20, result.NumberMatched);
         Assert.AreEqual(limit, result.NumberReturned);
     }
+
+    [TestMethod]
+    public async Task SearchWithoutLimit()
+    {
+        var result = await searchClient.PostItemSearchAsync(new SearchBody
+        {
+            Collections = Array.Empty<string>(),
+        });
+
+        Assert.AreEqual(20, result.NumberMatched);
+        Assert.AreEqual(20, result.NumberReturned);
+    }
 }


### PR DESCRIPTION
- Die neue Version des STAC Browsers unterstützt den Path-Prefix zur Laufzeit (soweit ich mich erinnere, brauchte es den Pfad früher schon zur Buildzeit, weshalb wir einen Fork des Projekts gemacht hatten)
- API fix, damit eine Suche ohne `limit` auch Ergebnisse zurückgibt (der Browser hatte vorher immer ein `limit` mitgeschickt)
- Übersetzungen (fr, it, en) im Browser aktiviert

Resolves #731 