### PR TITLE
 Applikationstitel soll pro Umgebung konfigurierbar sein

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Post-conditions (`fail_conditions`, `warn_conditions`, `restrict_delivery_conditions`) may reference the current step's own output and earlier steps, but no longer a later step: a reference to a step that runs afterwards is now rejected when the pipeline definition is loaded (it was previously accepted but had no value at runtime). Pre-conditions remain restricted to earlier steps.
 - A configured pipeline-process parameter whose value cannot be converted to the parameter type now fails startup validation and process creation instead of being silently ignored. Enum-valued parameters accept their member names case-insensitively, also inside lists. Pipeline definitions should be re-checked on upgrade, since a previously ignored typo now prevents the application from starting.
 - The name of a mandate is localized (was `string` is now `LocalizedText`). The name can be defined for the different languages in the mandate administration.
+- The title shown on the delivery page is configured per environment in `client-settings.json` under `application.localTitle` (a language-code to text map) instead of a fixed built-in translation, so each deployment can present a title tailored to the customer. When no title is configured for the active language, no title is shown.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Post-conditions (`fail_conditions`, `warn_conditions`, `restrict_delivery_conditions`) may reference the current step's own output and earlier steps, but no longer a later step: a reference to a step that runs afterwards is now rejected when the pipeline definition is loaded (it was previously accepted but had no value at runtime). Pre-conditions remain restricted to earlier steps.
 - A configured pipeline-process parameter whose value cannot be converted to the parameter type now fails startup validation and process creation instead of being silently ignored. Enum-valued parameters accept their member names case-insensitively, also inside lists. Pipeline definitions should be re-checked on upgrade, since a previously ignored typo now prevents the application from starting.
 - The name of a mandate is localized (was `string` is now `LocalizedText`). The name can be defined for the different languages in the mandate administration.
-- The title shown on the delivery page is configured per environment in `client-settings.json` under `application.localTitle` (a language-code to text map) instead of a fixed built-in translation, so each deployment can present a title tailored to the customer. When no title is configured for the active language, no title is shown.
+- The title shown on the delivery page is configured per environment in `client-settings.json` under `application.localTitle` (a language-code to text map) instead of a fixed built-in translation, so each deployment can present a title tailored to the customer. It is shown in the active language, falls back to another configured language, and is hidden only when no title is configured at all.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - A configured pipeline-process parameter whose value cannot be converted to the parameter type now fails startup validation and process creation instead of being silently ignored. Enum-valued parameters accept their member names case-insensitively, also inside lists. Pipeline definitions should be re-checked on upgrade, since a previously ignored typo now prevents the application from starting.
 - The name of a mandate is localized (was `string` is now `LocalizedText`). The name can be defined for the different languages in the mandate administration.
 - The title shown on the delivery page is configured per environment in `client-settings.json` under `application.localTitle` (a language-code to text map) instead of a fixed built-in translation, so each deployment can present a title tailored to the customer. It is shown in the active language, falls back to another configured language, and is hidden only when no title is configured at all.
+- The application name shown in the header is resolved from `application.localName` in `client-settings.json` with cross-language fallback; the non-localized `application.name` default has been removed, so a deployment that configured only `name` must move that value into `localName`.
 
 ### Added
 

--- a/src/Geopilot.Frontend/cypress/e2e/app.cy.js
+++ b/src/Geopilot.Frontend/cypress/e2e/app.cy.js
@@ -140,27 +140,24 @@ describe("General app tests", () => {
     cy.dataCy("delivery-title").should("not.exist");
   });
 
-  it("falls back to default application name when localNames are not available", () => {
-    // Intercept and modify the client-settings response to remove localName
+  it("falls back to another configured language for the application name", () => {
+    const fallbackName = "geowerkstatt Fallback DE";
+
+    // Configure the application name only in German, so the other languages must fall back to it.
     cy.intercept("**/client-settings.json", req => {
       req.continue(res => {
         const modifiedBody = { ...res.body };
-        delete modifiedBody.application.localName;
+        modifiedBody.application.localName = { de: fallbackName };
         res.send({ body: modifiedBody });
       });
     }).as("settings");
 
     cy.visit("/");
+    cy.wait("@settings");
 
-    cy.wait("@settings").then(({ response }) => {
-      const defaultName = response.body.application.name;
-
-      // Test each language
-      ["en", "de", "fr", "it"].forEach(language => {
-        selectLanguage(language);
-        cy.contains(defaultName).should("be.visible");
-        cy.log(`Verified fallback in ${language}: ${defaultName}`);
-      });
+    ["en", "fr", "it", "de"].forEach(language => {
+      selectLanguage(language);
+      cy.contains(fallbackName).should("be.visible");
     });
   });
 });

--- a/src/Geopilot.Frontend/cypress/e2e/app.cy.js
+++ b/src/Geopilot.Frontend/cypress/e2e/app.cy.js
@@ -129,8 +129,7 @@ describe("General app tests", () => {
   it("keeps the delivery title visible for a region-specific locale (de-CH)", () => {
     // A region-specific locale must still resolve to a configured language via i18n.resolvedLanguage,
     // so the title stays visible instead of blanking out. Known limitation, not intended behaviour:
-    // de-CH currently falls back to English rather than de (tracked in a separate i18n issue). This
-    // test stays valid after that fix, since the title is then German but still visible and non-empty.
+    // de-CH currently falls back to English rather than de.
     cy.setCookie("i18next", "de-CH");
 
     cy.visit("/");

--- a/src/Geopilot.Frontend/cypress/e2e/app.cy.js
+++ b/src/Geopilot.Frontend/cypress/e2e/app.cy.js
@@ -127,9 +127,10 @@ describe("General app tests", () => {
   });
 
   it("keeps the delivery title visible for a region-specific locale (de-CH)", () => {
-    // The hooks resolve via i18n.resolvedLanguage, always a supported base code, so a browser region
-    // locale like de-CH resolves to a configured language (the en fallback here) instead of blanking
-    // the title by indexing with the raw "de-CH" code.
+    // A region-specific locale must still resolve to a configured language via i18n.resolvedLanguage,
+    // so the title stays visible instead of blanking out. Known limitation, not intended behaviour:
+    // de-CH currently falls back to English rather than de (tracked in a separate i18n issue). This
+    // test stays valid after that fix, since the title is then German but still visible and non-empty.
     cy.setCookie("i18next", "de-CH");
 
     cy.visit("/");

--- a/src/Geopilot.Frontend/cypress/e2e/app.cy.js
+++ b/src/Geopilot.Frontend/cypress/e2e/app.cy.js
@@ -88,6 +88,7 @@ describe("General app tests", () => {
       // Extract the application settings from the intercepted response
       const settings = interception.response.body;
       const localNames = settings.application.localName;
+      expect(Object.keys(localNames)).to.have.length.greaterThan(0);
 
       // Test each available language
       Object.entries(localNames).forEach(([language, expectedName]) => {
@@ -114,6 +115,7 @@ describe("General app tests", () => {
 
     cy.wait("@clientSettings").then(interception => {
       const localTitle = interception.response.body.application.localTitle;
+      expect(Object.keys(localTitle)).to.have.length.greaterThan(0);
 
       Object.entries(localTitle).forEach(([language, expectedTitle]) => {
         if (!["en", "de", "fr", "it"].includes(language)) return;
@@ -121,6 +123,18 @@ describe("General app tests", () => {
         selectLanguage(language);
         cy.dataCy("delivery-title").should("be.visible").and("contain", expectedTitle);
       });
+    });
+  });
+
+  it("resolves the delivery title for a region-specific locale (de-CH)", () => {
+    cy.setCookie("i18next", "de-CH");
+    cy.intercept("**/client-settings.json").as("clientSettings");
+
+    cy.visit("/");
+
+    cy.wait("@clientSettings").then(interception => {
+      const germanTitle = interception.response.body.application.localTitle.de;
+      cy.dataCy("delivery-title").should("be.visible").and("contain", germanTitle);
     });
   });
 

--- a/src/Geopilot.Frontend/cypress/e2e/app.cy.js
+++ b/src/Geopilot.Frontend/cypress/e2e/app.cy.js
@@ -126,16 +126,15 @@ describe("General app tests", () => {
     });
   });
 
-  it("resolves the delivery title for a region-specific locale (de-CH)", () => {
+  it("keeps the delivery title visible for a region-specific locale (de-CH)", () => {
+    // The hooks resolve via i18n.resolvedLanguage, always a supported base code, so a browser region
+    // locale like de-CH resolves to a configured language (the en fallback here) instead of blanking
+    // the title by indexing with the raw "de-CH" code.
     cy.setCookie("i18next", "de-CH");
-    cy.intercept("**/client-settings.json").as("clientSettings");
 
     cy.visit("/");
 
-    cy.wait("@clientSettings").then(interception => {
-      const germanTitle = interception.response.body.application.localTitle.de;
-      cy.dataCy("delivery-title").should("be.visible").and("contain", germanTitle);
-    });
+    cy.dataCy("delivery-title").should("be.visible").and("not.be.empty");
   });
 
   it("hides the delivery title when none is configured", () => {

--- a/src/Geopilot.Frontend/cypress/e2e/app.cy.js
+++ b/src/Geopilot.Frontend/cypress/e2e/app.cy.js
@@ -107,6 +107,39 @@ describe("General app tests", () => {
     });
   });
 
+  it("displays the configured localized delivery title when language changes", () => {
+    cy.intercept("**/client-settings.json").as("clientSettings");
+
+    cy.visit("/");
+
+    cy.wait("@clientSettings").then(interception => {
+      const localTitle = interception.response.body.application.localTitle;
+
+      Object.entries(localTitle).forEach(([language, expectedTitle]) => {
+        if (!["en", "de", "fr", "it"].includes(language)) return;
+
+        selectLanguage(language);
+        cy.dataCy("delivery-title").should("be.visible").and("contain", expectedTitle);
+      });
+    });
+  });
+
+  it("hides the delivery title when none is configured", () => {
+    cy.intercept("**/client-settings.json", req => {
+      req.continue(res => {
+        const modifiedBody = { ...res.body };
+        delete modifiedBody.application.localTitle;
+        res.send({ body: modifiedBody });
+      });
+    }).as("settings");
+
+    cy.visit("/");
+
+    cy.wait("@settings");
+    cy.dataCy("delivery").should("exist");
+    cy.dataCy("delivery-title").should("not.exist");
+  });
+
   it("falls back to default application name when localNames are not available", () => {
     // Intercept and modify the client-settings response to remove localName
     cy.intercept("**/client-settings.json", req => {

--- a/src/Geopilot.Frontend/public/client-settings.json
+++ b/src/Geopilot.Frontend/public/client-settings.json
@@ -1,6 +1,5 @@
 {
   "application": {
-    "name": "geowerkstatt - dev",
     "localName": {
       "de": "geowerkstatt GmbH",
       "en": "geowerkstatt Llc",

--- a/src/Geopilot.Frontend/public/client-settings.json
+++ b/src/Geopilot.Frontend/public/client-settings.json
@@ -7,6 +7,12 @@
       "fr": "geowerkstatt Sàrl",
       "it": "geowerkstatt Sagl"
     },
+    "localTitle": {
+      "de": "Online Verarbeitung von Geodaten",
+      "en": "Online processing of geodata",
+      "fr": "Traitement en ligne de géodonnées",
+      "it": "Elaborazione online di dati geografici"
+    },
     "logo": "/logo.png",
     "favicon": "/logo.png",
     "faviconDark": "/logo-dark.png"

--- a/src/Geopilot.Frontend/public/locale/de/common.json
+++ b/src/Geopilot.Frontend/public/locale/de/common.json
@@ -51,7 +51,6 @@
   "deliveryOverviewDeleteIdError": "Beim Löschen der Lieferung mit ID {{id}} ist ein Fehler aufgetreten.",
   "deliveryOverviewDeleteIdNotExistError": "Die Lieferung mit der ID {{id}} existiert nicht und kann daher nicht gelöscht werden.",
   "deliveryOverviewLoadingError": "Beim Laden der Lieferungen ist ein Fehler aufgetreten: {{error}}",
-  "deliveryTitle": "Online Verarbeitung von Geodaten",
   "description": "Beschreibung",
   "development": "Entwicklung",
   "disconnect": "Verbindungen trennen",

--- a/src/Geopilot.Frontend/public/locale/en/common.json
+++ b/src/Geopilot.Frontend/public/locale/en/common.json
@@ -51,7 +51,6 @@
   "deliveryOverviewDeleteIdError": "An error occurred while deleting the delivery with the ID {{id}}",
   "deliveryOverviewDeleteIdNotExistError": "The delivery with the ID {{id}} does not exist and therefore cannot be deleted.",
   "deliveryOverviewLoadingError": "An error occurred while loading the deliveries: {{error}}",
-  "deliveryTitle": "Online processing of geodata",
   "description": "Description",
   "development": "Development",
   "disconnect": "Disconnect",

--- a/src/Geopilot.Frontend/public/locale/fr/common.json
+++ b/src/Geopilot.Frontend/public/locale/fr/common.json
@@ -51,7 +51,6 @@
   "deliveryOverviewDeleteIdError": "Une erreur s'est produite lors de la suppression de la livraison avec l'ID {{id}}.",
   "deliveryOverviewDeleteIdNotExistError": "La livraison avec l'ID {{id}} n'existe pas et ne peut donc pas être supprimée.",
   "deliveryOverviewLoadingError": "Une erreur s'est produite lors du chargement des livraisons: {{error}}",
-  "deliveryTitle": "Traitement en ligne de géodonnées",
   "description": "Description",
   "development": "Développement",
   "disconnect": "Déconnecter",

--- a/src/Geopilot.Frontend/public/locale/it/common.json
+++ b/src/Geopilot.Frontend/public/locale/it/common.json
@@ -51,7 +51,6 @@
   "deliveryOverviewDeleteIdError": "Si è verificato un errore durante l'eliminazione della consegna con ID {{id}}.",
   "deliveryOverviewDeleteIdNotExistError": "La consegna con ID {{id}} non esiste e non può essere eliminata.",
   "deliveryOverviewLoadingError": "Si è verificato un errore durante il caricamento delle consegne: {{error}}",
-  "deliveryTitle": "Elaborazione online di dati geografici",
   "description": "Descrizione",
   "development": "Sviluppo",
   "disconnect": "Disconnessione",

--- a/src/Geopilot.Frontend/src/components/appSettings/appSettingsInterface.ts
+++ b/src/Geopilot.Frontend/src/components/appSettings/appSettingsInterface.ts
@@ -7,7 +7,6 @@ export interface ClientSettings {
     storeAuthStateInCookie: boolean;
   };
   application: {
-    name?: string;
     localName?: {
       [languageCode: string]: string;
     };

--- a/src/Geopilot.Frontend/src/components/appSettings/appSettingsInterface.ts
+++ b/src/Geopilot.Frontend/src/components/appSettings/appSettingsInterface.ts
@@ -11,6 +11,9 @@ export interface ClientSettings {
     localName?: {
       [languageCode: string]: string;
     };
+    localTitle?: {
+      [languageCode: string]: string;
+    };
     logo: string;
     favicon: string;
     faviconDark?: string;

--- a/src/Geopilot.Frontend/src/components/appSettings/appSettingsProvider.tsx
+++ b/src/Geopilot.Frontend/src/components/appSettings/appSettingsProvider.tsx
@@ -1,14 +1,15 @@
 import { FC, PropsWithChildren, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ContentType } from "../../api/apiInterfaces.ts";
-import { resolveApplicationName } from "../../hooks/useApplicationName.ts";
 import useFetch from "../../hooks/useFetch.ts";
+import { useLocalized } from "../../hooks/useLocalized.ts";
 import { AppSettingsContext } from "./appSettingsContext";
 import { ClientSettings } from "./appSettingsInterface";
 
 export const AppSettingsProvider: FC<PropsWithChildren> = ({ children }) => {
   const { i18n } = useTranslation();
   const { fetchApi, fetchLocalizedMarkdown } = useFetch();
+  const { localized } = useLocalized();
   const [clientSettings, setClientSettings] = useState<ClientSettings | null>();
   const [termsOfUse, setTermsOfUse] = useState<string | null>();
 
@@ -53,9 +54,10 @@ export const AppSettingsProvider: FC<PropsWithChildren> = ({ children }) => {
   }, [clientSettings]);
 
   useEffect(() => {
-    const applicationName = resolveApplicationName(clientSettings?.application, i18n.language);
+    const application = clientSettings?.application;
+    const applicationName = localized(application?.localName, application?.name);
     document.title = applicationName ? `geopilot ${applicationName}` : "geopilot";
-  }, [clientSettings?.application, i18n.language]);
+  }, [clientSettings?.application, localized]);
 
   return (
     <AppSettingsContext.Provider

--- a/src/Geopilot.Frontend/src/components/appSettings/appSettingsProvider.tsx
+++ b/src/Geopilot.Frontend/src/components/appSettings/appSettingsProvider.tsx
@@ -55,7 +55,7 @@ export const AppSettingsProvider: FC<PropsWithChildren> = ({ children }) => {
 
   useEffect(() => {
     const application = clientSettings?.application;
-    const applicationName = localized(application?.localName, application?.name);
+    const applicationName = localized(application?.localName);
     document.title = applicationName ? `geopilot ${applicationName}` : "geopilot";
   }, [clientSettings?.application, localized]);
 

--- a/src/Geopilot.Frontend/src/hooks/useApplicationName.ts
+++ b/src/Geopilot.Frontend/src/hooks/useApplicationName.ts
@@ -2,9 +2,9 @@ import { useAppSettings } from "../components/appSettings/appSettingsInterface";
 import { useLocalized } from "./useLocalized";
 
 /**
- * Returns the configured application name for the active UI language, falling back to the default
- * name. Returns undefined when no name is configured, so callers can use it directly as a render
- * guard. Reactive to the active language.
+ * Returns the configured application name for the active UI language, falling back to another
+ * configured language. Returns undefined when no name is configured, so callers can use it directly
+ * as a render guard. Reactive to the active language.
  *
  * application.localName is a Record<string, string>, structurally the backend LocalizedText, so we
  * reuse useLocalized to keep a single language-resolution strategy across the app. The data here
@@ -13,6 +13,5 @@ import { useLocalized } from "./useLocalized";
 export const useApplicationName = (): string | undefined => {
   const { localized } = useLocalized();
   const { clientSettings } = useAppSettings();
-  const application = clientSettings?.application;
-  return localized(application?.localName, application?.name) || undefined;
+  return localized(clientSettings?.application?.localName) || undefined;
 };

--- a/src/Geopilot.Frontend/src/hooks/useApplicationName.ts
+++ b/src/Geopilot.Frontend/src/hooks/useApplicationName.ts
@@ -1,23 +1,18 @@
-import { useTranslation } from "react-i18next";
-import { ClientSettings, useAppSettings } from "../components/appSettings/appSettingsInterface";
+import { useAppSettings } from "../components/appSettings/appSettingsInterface";
+import { useLocalized } from "./useLocalized";
 
 /**
- * Resolves the configured application name for the given language, preferring the language-specific
- * localName and falling back to the default name. Returns undefined when no name is configured.
- * Shared by the useApplicationName hook and the settings provider, which supplies the context and
- * therefore cannot consume the hook itself.
- */
-export const resolveApplicationName = (
-  application: ClientSettings["application"] | undefined,
-  language: string,
-): string | undefined => application?.localName?.[language] || application?.name;
-
-/**
- * Returns the configured application name for the active UI language. Returns undefined when no name
- * is configured, so callers can use it directly as a render guard. Reactive to the active language.
+ * Returns the configured application name for the active UI language, falling back to the default
+ * name. Returns undefined when no name is configured, so callers can use it directly as a render
+ * guard. Reactive to the active language.
+ *
+ * application.localName is a Record<string, string>, structurally the backend LocalizedText, so we
+ * reuse useLocalized to keep a single language-resolution strategy across the app. The data here
+ * comes from client-settings.json, not from the backend.
  */
 export const useApplicationName = (): string | undefined => {
-  const { i18n } = useTranslation();
+  const { localized } = useLocalized();
   const { clientSettings } = useAppSettings();
-  return resolveApplicationName(clientSettings?.application, i18n.language);
+  const application = clientSettings?.application;
+  return localized(application?.localName, application?.name) || undefined;
 };

--- a/src/Geopilot.Frontend/src/hooks/useApplicationTitle.ts
+++ b/src/Geopilot.Frontend/src/hooks/useApplicationTitle.ts
@@ -1,0 +1,13 @@
+import { useTranslation } from "react-i18next";
+import { useAppSettings } from "../components/appSettings/appSettingsInterface";
+
+/**
+ * Returns the configured application title for the active UI language. Returns undefined when no
+ * title is configured for that language, so callers can use it directly as a render guard. Reactive
+ * to the active language.
+ */
+export const useApplicationTitle = (): string | undefined => {
+  const { i18n } = useTranslation();
+  const { clientSettings } = useAppSettings();
+  return clientSettings?.application?.localTitle?.[i18n.language];
+};

--- a/src/Geopilot.Frontend/src/hooks/useApplicationTitle.ts
+++ b/src/Geopilot.Frontend/src/hooks/useApplicationTitle.ts
@@ -1,13 +1,17 @@
-import { useTranslation } from "react-i18next";
 import { useAppSettings } from "../components/appSettings/appSettingsInterface";
+import { useLocalized } from "./useLocalized";
 
 /**
- * Returns the configured application title for the active UI language. Returns undefined when no
- * title is configured for that language, so callers can use it directly as a render guard. Reactive
- * to the active language.
+ * Returns the configured application title for the active UI language, falling back to another
+ * configured language. Returns undefined when no title is configured, so callers can use it directly
+ * as a render guard. Reactive to the active language.
+ *
+ * application.localTitle is a Record<string, string>, structurally the backend LocalizedText, so we
+ * reuse useLocalized to keep a single language-resolution strategy across the app. The data here
+ * comes from client-settings.json, not from the backend.
  */
 export const useApplicationTitle = (): string | undefined => {
-  const { i18n } = useTranslation();
+  const { localized } = useLocalized();
   const { clientSettings } = useAppSettings();
-  return clientSettings?.application?.localTitle?.[i18n.language];
+  return localized(clientSettings?.application?.localTitle) || undefined;
 };

--- a/src/Geopilot.Frontend/src/pages/delivery/delivery.tsx
+++ b/src/Geopilot.Frontend/src/pages/delivery/delivery.tsx
@@ -1,8 +1,8 @@
 import { FC, MutableRefObject, useContext, useEffect } from "react";
-import { useTranslation } from "react-i18next";
 import { Stack, Typography } from "@mui/material";
 import { styled } from "@mui/system";
 import { CenteredContent } from "../../components/styledComponents.ts";
+import { useApplicationTitle } from "../../hooks/useApplicationTitle.ts";
 import { StepSwipeHandlers, useStepSwipe } from "../../hooks/useStepSwipe.ts";
 import { DeliveryContentCarousel, SLIDE_TRANSITION_MS } from "./deliveryContentCarousel.tsx";
 import { DeliveryContext } from "./deliveryContext.tsx";
@@ -21,8 +21,8 @@ interface DeliveryProps {
 }
 
 const Delivery: FC<DeliveryProps> = ({ stepSwipeRef }) => {
-  const { t } = useTranslation();
   const { steps, activeStep, showCompletedOrNextStep } = useContext(DeliveryContext);
+  const applicationTitle = useApplicationTitle();
 
   const swipeHandlers = useStepSwipe({
     activeStep,
@@ -40,9 +40,11 @@ const Delivery: FC<DeliveryProps> = ({ stepSwipeRef }) => {
 
   return (
     <CenteredContent data-cy="delivery" maxWidth="1400px">
-      <Typography variant="h1" zIndex={10}>
-        {t("deliveryTitle")}
-      </Typography>
+      {applicationTitle && (
+        <Typography variant="h1" zIndex={10} data-cy="delivery-title">
+          {applicationTitle}
+        </Typography>
+      )}
       <DeliveryContainer direction={{ xs: "column", md: "row" }} m={{ xs: 0, md: 0 }}>
         <DeliveryStepper />
         <DeliveryContentCarousel />

--- a/src/Geopilot.Frontend/src/pages/delivery/delivery.tsx
+++ b/src/Geopilot.Frontend/src/pages/delivery/delivery.tsx
@@ -41,7 +41,10 @@ const Delivery: FC<DeliveryProps> = ({ stepSwipeRef }) => {
   return (
     <CenteredContent data-cy="delivery" maxWidth="1400px">
       {applicationTitle && (
-        <Typography variant="h1" zIndex={10} data-cy="delivery-title">
+        <Typography
+          variant="h1"
+          data-cy="delivery-title"
+          sx={{ position: "relative", zIndex: 11, transform: "translateZ(0)" }}>
           {applicationTitle}
         </Typography>
       )}


### PR DESCRIPTION
Replace the fixed deliveryTitle translation with a localized application.localTitle in client-settings.json, so each deployment can present a customer-specific title.