### PR TITLE
Allow single-touch pan and scroll-zoom in fullscreen map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 ### Fixed
 
+- The error map in fullscreen can be moved with a single finger and zoomed by scrolling without holding Ctrl (⌘ on macOS). Inline the map keeps asking for two fingers and the modifier key so that it does not swallow the page scroll.
 - Processing job and upload timestamps are now recorded in UTC, so the cleanup retention windows (job, download and visualization) are honored regardless of the container time zone. Previously, with the image default `TZ=Europe/Zurich`, expired downloads and visualizations lingered up to two hours longer than configured.
 
 ## v3.0.341 - 2026-06-17

--- a/src/Geopilot.Frontend/src/components/visualizations/map/mapVisualizationProvider.tsx
+++ b/src/Geopilot.Frontend/src/components/visualizations/map/mapVisualizationProvider.tsx
@@ -146,6 +146,8 @@ interface MapVisualizationProviderProps {
   onSelectFeature?: (featureId: string) => void;
   /** Whether to show the metadata popup when a feature is selected. */
   showMapSelectionPopup?: boolean;
+  /** Whether the map is shown fullscreen, where it may claim single-touch drag and plain scroll-zoom. */
+  fullscreen?: boolean;
 }
 
 /**
@@ -160,6 +162,7 @@ export const MapVisualizationProvider: FC<PropsWithChildren<MapVisualizationProv
   zoomRequest,
   onSelectFeature,
   showMapSelectionPopup = false,
+  fullscreen = false,
   children,
 }) => {
   const { t } = useTranslation();
@@ -175,6 +178,7 @@ export const MapVisualizationProvider: FC<PropsWithChildren<MapVisualizationProv
   const visibleIdsRef = useRef<ReadonlySet<string> | undefined>(visibleFeatureIds);
   const highlightedIdsRef = useRef<ReadonlySet<string>>(highlightedFeatureIds);
   const lastZoomTokenRef = useRef<number | undefined>(undefined);
+  const fullscreenRef = useRef(fullscreen);
 
   // Padding and max zoom used whenever the view is fit to features.
   const fitOptions = useRef<FitOptions>({ padding: [40, 40, 40, 40], maxZoom: 12 });
@@ -216,15 +220,18 @@ export const MapVisualizationProvider: FC<PropsWithChildren<MapVisualizationProv
     if (!config) return;
 
     const isTouch: Condition = e => e.originalEvent instanceof PointerEvent && e.originalEvent.pointerType === "touch";
+    // Inline the map shares the page with the surrounding scroll, so panning takes two fingers and zooming
+    // the platform modifier key. Fullscreen there is nothing behind the map, so both gestures are handed to
+    // the map unrestricted (issue #848).
     const interactions = defaultInteractions({
       dragPan: false,
       mouseWheelZoom: false,
       pinchRotate: false,
     }).extend([
       new DragPan({
-        condition: e => !isTouch(e) || e.activePointers?.length === 2,
+        condition: e => fullscreenRef.current || !isTouch(e) || e.activePointers?.length === 2,
       }),
-      new MouseWheelZoom({ condition: platformModifierKeyOnly }),
+      new MouseWheelZoom({ condition: e => fullscreenRef.current || platformModifierKeyOnly(e) }),
     ]);
 
     const map = new Map({
@@ -249,6 +256,7 @@ export const MapVisualizationProvider: FC<PropsWithChildren<MapVisualizationProv
     map.getViewport().appendChild(interactionHint.element);
 
     const onWheel = (event: WheelEvent) => {
+      if (fullscreenRef.current) return;
       const modifierKey = MAC ? event.metaKey : event.ctrlKey;
       if (!modifierKey) {
         interactionHint.show(t("mapInteractionHintScroll", { key: MAC ? "⌘" : "Ctrl" }));
@@ -259,6 +267,7 @@ export const MapVisualizationProvider: FC<PropsWithChildren<MapVisualizationProv
     map.getViewport().addEventListener("wheel", onWheel, { passive: true });
 
     const dragHintKey = map.on("pointerdrag", event => {
+      if (fullscreenRef.current) return;
       if (isTouch(event) && event.activePointers?.length === 1) {
         interactionHint.show(t("mapInteractionHintTouch"));
       } else {
@@ -304,6 +313,15 @@ export const MapVisualizationProvider: FC<PropsWithChildren<MapVisualizationProv
       map.setTarget(undefined);
     };
   }, [config, selectionOverlay, t, theme]);
+
+  // The interaction conditions and the gesture hints read the fullscreen state from a ref, so toggling
+  // fullscreen does not rebuild the map (which would re-fetch the base map and reset the view). The viewport
+  // additionally has to give up the touch-action ol.css reserves for page scrolling, otherwise the browser
+  // keeps the single-finger gesture and the map never sees it.
+  useEffect(() => {
+    fullscreenRef.current = fullscreen;
+    if (map) map.getViewport().style.touchAction = fullscreen ? "none" : "";
+  }, [fullscreen, map]);
 
   useEffect(() => {
     if (!map) return;

--- a/src/Geopilot.Frontend/src/components/visualizations/xtfErrorVisualization.tsx
+++ b/src/Geopilot.Frontend/src/components/visualizations/xtfErrorVisualization.tsx
@@ -143,7 +143,8 @@ export const XtfErrorVisualization: FC<XtfErrorVisualizationProps> = ({ config }
       highlightedFeatureIds={highlightedErrorIds}
       zoomRequest={zoomRequest}
       onSelectFeature={handleSelectFeature}
-      showMapSelectionPopup={!config.tree}>
+      showMapSelectionPopup={!config.tree}
+      fullscreen={fullscreen}>
       {config.map && (
         <IconButton
           size="small"


### PR DESCRIPTION
Resolves #848

Die OL-Interaktionen wurden einmalig beim Map-Aufbau erzeugt und kannten den Fullscreen-Zustand nicht: `DragPan` verlangte immer zwei Pointer, `MouseWheelZoom` immer die Modifier-Taste. Der Zustand liegt in `xtfErrorVisualization` und ging bisher nur an `MapVisualization` und `TreeVisualization`.

Dazu kam ein zweiter Teil, der beim Lesen der Conditions nicht auffällt: `ol.css` setzt `.ol-viewport { touch-action: pan-x pan-y }`. Damit beansprucht der Browser die Ein-Finger-Geste fürs Seiten-Scrollen und OpenLayers sieht sie gar nie. Die Condition allein zu lockern hätte auf Touch nichts bewirkt.

Umsetzung:

- `fullscreen` als Prop in den `MapVisualizationProvider`, gehalten in einem Ref wie `visibleIdsRef`/`highlightedIdsRef`. Ein Toggle baut die Map damit nicht neu, also kein WMTS-Refetch und keine verlorene View.
- Beide Conditions kurzschliessen im Fullscreen. Inline bleibt es bei zwei Fingern bzw. Ctrl/⌘ + Scroll, damit die Karte den Seiten-Scroll nicht schluckt.
- Die Gesten-Hinweise (`mapInteractionHintScroll` / `mapInteractionHintTouch`) sind im Fullscreen unterdrückt, dort funktionieren die Gesten ja.
- `touch-action: none` auf dem Viewport solange Fullscreen aktiv ist, beim Verlassen zurück auf den Stylesheet-Wert.

Zum Review-Kommentar im Issue (Hintergrund darf nicht mitscrollen): braucht kein zusätzliches `stopPropagation`. MUI `Modal` sperrt den Body-Scroll per Default (`disableScrollLock` ist nirgends gesetzt), OL registriert den Wheel-Listener mit `{ passive: false }` und ruft `preventDefault()`, sobald die Condition greift, und der Backdrop hängt im Portal an `body`, kann also nicht in einen App-internen Scroll-Container hineinscrollen. `stopStepSwipePropagation` liegt bereits auf Modal-Box und Map-Box.

Zum Testen: der Fullscreen-Button ist `display: { xs: "none", md: "block" }`, auf dem Handy gibt es also gar keinen Fullscreen, der Touch-Teil greift erst ab Tablet-Breite. Automatisierte Abdeckung gibt es keine: die Cypress-Specs mocken `visualizations: []`, es existiert im E2E also gar keine Karte, und Multi-Touch auf einem Canvas wäre flaky. Wenn eine Absicherung gewünscht ist, wäre der Wheel-Fall stabil machbar.