### PR TITLE
Resolve regional browser language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - The error map in fullscreen can be moved with a single finger and zoomed by scrolling without holding Ctrl (⌘ on macOS). Inline the map keeps asking for two fingers and the modifier key so that it does not swallow the page scroll.
 - Processing job and upload timestamps are now recorded in UTC, so the cleanup retention windows (job, download and visualization) are honored regardless of the container time zone. Previously, with the image default `TZ=Europe/Zurich`, expired downloads and visualizations lingered up to two hours longer than configured.
 - Files can now be selected for upload on iPhone and iPad. When a mandate limits the accepted file types, iOS and iPadOS browsers previously greyed out the matching files (for example `.xtf`) in the native file picker, so a delivery could not be started from those devices.
+- A browser set to a regional locale such as `de-CH` or `fr-CH` now shows the application in the matching base language (`de`, `fr`, `it`) on the first visit. Previously such locales fell back to English until the user selected a language manually.
 
 ## v3.0.341 - 2026-06-17
 

--- a/src/Geopilot.Frontend/cypress/e2e/app.cy.js
+++ b/src/Geopilot.Frontend/cypress/e2e/app.cy.js
@@ -126,15 +126,20 @@ describe("General app tests", () => {
     });
   });
 
-  it("keeps the delivery title visible for a region-specific locale (de-CH)", () => {
-    // A region-specific locale must still resolve to a configured language via i18n.resolvedLanguage,
-    // so the title stays visible instead of blanking out. Known limitation, not intended behaviour:
-    // de-CH currently falls back to English rather than de.
+  it("resolves a region-specific locale (de-CH) to English", () => {
+    // Premise under test: a de-CH browser locale falls back to English. If this assertion fails,
+    // de-CH resolved to another language (see the logged cookie), so the premise is wrong.
     cy.setCookie("i18next", "de-CH");
+    cy.intercept("**/client-settings.json").as("clientSettings");
 
     cy.visit("/");
 
-    cy.dataCy("delivery-title").should("be.visible").and("not.be.empty");
+    cy.wait("@clientSettings").then(interception => {
+      const englishTitle = interception.response.body.application.localTitle.en;
+      cy.dataCy("delivery-title").should("be.visible");
+      cy.getCookie("i18next").then(cookie => cy.log(`resolved i18next cookie = ${cookie && cookie.value}`));
+      cy.dataCy("delivery-title").should("contain", englishTitle);
+    });
   });
 
   it("hides the delivery title when none is configured", () => {

--- a/src/Geopilot.Frontend/cypress/e2e/app.cy.js
+++ b/src/Geopilot.Frontend/cypress/e2e/app.cy.js
@@ -63,6 +63,7 @@ describe("General app tests", () => {
   it("updates the language when the user selects a different language", () => {
     cy.visit("/");
 
+    selectLanguage("en");
     cy.contains("EN");
     cy.contains("Click to select");
 
@@ -126,19 +127,26 @@ describe("General app tests", () => {
     });
   });
 
-  it("resolves a region-specific locale (de-CH) to English", () => {
-    // Premise under test: a de-CH browser locale falls back to English. If this assertion fails,
-    // de-CH resolved to another language (see the logged cookie), so the premise is wrong.
-    cy.setCookie("i18next", "de-CH");
+  it("normalises region-specific browser locales to their base language", () => {
+    // With load: "languageOnly", a browser locale like de-CH resolves to de instead of falling back
+    // to English. We assert the rendered title (the resolved language); the raw i18next cookie keeps
+    // the region code, so it is not a reliable check here. Covered for all four supported languages.
     cy.intercept("**/client-settings.json").as("clientSettings");
 
-    cy.visit("/");
+    [
+      { locale: "de-CH", base: "de" },
+      { locale: "fr-CH", base: "fr" },
+      { locale: "it-CH", base: "it" },
+      { locale: "en-US", base: "en" },
+    ].forEach(({ locale, base }) => {
+      cy.setCookie("i18next", locale);
 
-    cy.wait("@clientSettings").then(interception => {
-      const englishTitle = interception.response.body.application.localTitle.en;
-      cy.dataCy("delivery-title").should("be.visible");
-      cy.getCookie("i18next").then(cookie => cy.log(`resolved i18next cookie = ${cookie && cookie.value}`));
-      cy.dataCy("delivery-title").should("contain", englishTitle);
+      cy.visit("/");
+
+      cy.wait("@clientSettings").then(interception => {
+        const expectedTitle = interception.response.body.application.localTitle[base];
+        cy.dataCy("delivery-title").should("be.visible").and("contain", expectedTitle);
+      });
     });
   });
 

--- a/src/Geopilot.Frontend/src/i18n.js
+++ b/src/Geopilot.Frontend/src/i18n.js
@@ -23,6 +23,7 @@ i18n
       useSuspense: false,
       transSupportBasicHtmlNodes: true,
     },
+    load: "languageOnly",
     fallbackLng: Language.EN,
     supportedLngs: Object.values(Language),
     ns: ["common"],


### PR DESCRIPTION
Mit load: "languageOnly" in i18n.js können jetzt auch regionale Browser-Sprachen wie de-CH korrekt auf die Basissprache aufgelöst werden. Vorher fielen regionale Browser Sprachen immer auch english zurück.
