### PR TITLE
Add clustering to the error map

### DIFF
--- a/src/Geopilot.Frontend/public/locale/de/common.json
+++ b/src/Geopilot.Frontend/public/locale/de/common.json
@@ -99,6 +99,7 @@
   "mandates": "Mandate",
   "mandatesLoadingError": "Beim Laden der Mandate ist ein Fehler aufgetreten: {{error}}",
   "mapCopyrightPrefix": "© Daten:",
+  "mapFeatureWithoutMessage": "Fehler ohne Meldung",
   "mapInteractionHintScroll": "Zum Zoomen {{key}} + Scrollen verwenden",
   "mapInteractionHintTouch": "Zum Verschieben der Karte zwei Finger verwenden",
   "mapVisualizationFeatureLayer": "Objekte",

--- a/src/Geopilot.Frontend/public/locale/en/common.json
+++ b/src/Geopilot.Frontend/public/locale/en/common.json
@@ -99,6 +99,7 @@
   "mandates": "Mandates",
   "mandatesLoadingError": "An error occurred while loading the mandates: {{error}}",
   "mapCopyrightPrefix": "© Data:",
+  "mapFeatureWithoutMessage": "Error without message",
   "mapInteractionHintScroll": "Use {{key}} + scroll to zoom",
   "mapInteractionHintTouch": "Use two fingers to move the map",
   "mapVisualizationFeatureLayer": "Features",

--- a/src/Geopilot.Frontend/public/locale/fr/common.json
+++ b/src/Geopilot.Frontend/public/locale/fr/common.json
@@ -99,6 +99,7 @@
   "mandates": "Mandats",
   "mandatesLoadingError": "Une erreur s'est produite lors du chargement des mandats: {{error}}",
   "mapCopyrightPrefix": "© Données:",
+  "mapFeatureWithoutMessage": "Erreur sans message",
   "mapInteractionHintScroll": "Utilisez {{key}} + défilement pour zoomer",
   "mapInteractionHintTouch": "Utilisez deux doigts pour déplacer la carte",
   "mapVisualizationFeatureLayer": "Entités",

--- a/src/Geopilot.Frontend/public/locale/it/common.json
+++ b/src/Geopilot.Frontend/public/locale/it/common.json
@@ -99,6 +99,7 @@
   "mandates": "Mandati",
   "mandatesLoadingError": "Si è verificato un errore durante il caricamento dei mandati: {{error}}",
   "mapCopyrightPrefix": "© Dati:",
+  "mapFeatureWithoutMessage": "Errore senza messaggio",
   "mapInteractionHintScroll": "Usa {{key}} + scorrimento per ingrandire",
   "mapInteractionHintTouch": "Usa due dita per spostare la mappa",
   "mapVisualizationFeatureLayer": "Elementi",

--- a/src/Geopilot.Frontend/src/components/visualizations/map/layers.ts
+++ b/src/Geopilot.Frontend/src/components/visualizations/map/layers.ts
@@ -1,17 +1,19 @@
 import { MutableRefObject } from "react";
 import { alpha } from "@mui/material";
 import { createEmpty, extend as extendExtent, Extent, isEmpty as isExtentEmpty } from "ol/extent";
-import Feature from "ol/Feature";
+import Feature, { FeatureLike } from "ol/Feature";
 import WKT from "ol/format/WKT";
 import WMTSCapabilities from "ol/format/WMTSCapabilities";
+import Point from "ol/geom/Point";
 import BaseLayer from "ol/layer/Base";
 import LayerGroup from "ol/layer/Group";
 import TileLayer from "ol/layer/Tile";
 import VectorLayer from "ol/layer/Vector";
 import Map from "ol/Map";
+import Cluster from "ol/source/Cluster";
 import VectorSource from "ol/source/Vector";
 import WMTS, { optionsFromCapabilities } from "ol/source/WMTS";
-import { Circle, Fill, Stroke, Style } from "ol/style";
+import { Circle, Fill, Stroke, Style, Text } from "ol/style";
 import { FitOptions } from "ol/View";
 import { LocalizedText, MapLayer } from "../../../api/apiInterfaces";
 
@@ -98,6 +100,19 @@ interface MapFeatureColors {
   highlight: string;
 }
 
+/** Pixel distance within which point features are merged into one cluster marker. */
+const CLUSTER_DISTANCE = 40;
+
+/** Pixel distance kept between two cluster markers so their counts stay readable. */
+const CLUSTER_MIN_DISTANCE = 24;
+
+/** The property under which a cluster feature carries the features it stands for. */
+const CLUSTER_MEMBERS_PROPERTY = "features";
+
+/** Returns the features a cluster contains, or the feature itself, if its not a cluster. */
+export const getClusterMembers = (feature: FeatureLike): Feature[] =>
+  (feature.get(CLUSTER_MEMBERS_PROPERTY) as Feature[] | undefined) ?? [feature as Feature];
+
 export const buildFeatureLayer = (
   layer: MapLayer,
   colors: MapFeatureColors,
@@ -121,6 +136,25 @@ export const buildFeatureLayer = (
     }
   }
 
+  const isVisible = (feature: Feature): boolean => {
+    const id = feature.getId()?.toString();
+    const visible = visibleIdsRef.current;
+    return id === undefined || visible === undefined || visible.has(id);
+  };
+
+  // Clustering keeps markers of nearby errors from covering each other. It reduces every feature to a
+  // point, so a layer holding any other geometry is left unclustered instead of losing those shapes.
+  const clusterable = source.getFeatures().every(feature => feature.getGeometry() instanceof Point);
+  const layerSource = clusterable
+    ? new Cluster({
+        source,
+        distance: CLUSTER_DISTANCE,
+        minDistance: CLUSTER_MIN_DISTANCE,
+        // Filtered out features contribute no point, which keeps them out of the clusters and their counts.
+        geometryFunction: feature => (isVisible(feature) ? (feature.getGeometry() as Point) : null),
+      })
+    : source;
+
   const defaultStyle = new Style({
     image: new Circle({
       radius: 6,
@@ -141,29 +175,76 @@ export const buildFeatureLayer = (
     // Highlighted features are drawn on top so nearby unselected markers cannot cover them.
     zIndex: 1,
   });
+  const buildClusterStyle = (color: string, zIndex: number) =>
+    new Style({
+      image: new Circle({
+        radius: 12,
+        fill: new Fill({ color }),
+        stroke: new Stroke({ color: colors.stroke, width: 2 }),
+      }),
+      text: new Text({ font: "bold 12px sans-serif", fill: new Fill({ color: colors.stroke }) }),
+      zIndex,
+    });
+  const defaultClusterStyle = buildClusterStyle(colors.fill, 0);
+  const highlightClusterStyle = buildClusterStyle(colors.highlight, 1);
 
   return new VectorLayer({
-    source,
+    source: layerSource,
     properties: { [LOCALIZABLE_TITLE_PROPERTY]: title },
     // A style function (not a static style): filtering hides non-matching features and selection emphasizes
     // highlighted ones. It reads the current sets from refs, which the map's update effect keeps in sync,
     // so changing filter/selection only restyles the existing layer instead of rebuilding the map.
     style: feature => {
-      const id = feature.getId()?.toString();
-      const visible = visibleIdsRef.current;
-      if (id !== undefined && visible !== undefined && !visible.has(id)) return undefined;
-      return id !== undefined && highlightedIdsRef.current.has(id) ? highlightStyle : defaultStyle;
+      const members = getClusterMembers(feature).filter(isVisible);
+      if (members.length === 0) return undefined;
+      const highlighted = members.some(member => {
+        const id = member.getId()?.toString();
+        return id !== undefined && highlightedIdsRef.current.has(id);
+      });
+      if (members.length === 1) return highlighted ? highlightStyle : defaultStyle;
+
+      const clusterStyle = highlighted ? highlightClusterStyle : defaultClusterStyle;
+      clusterStyle.getText()?.setText(members.length.toString());
+      return clusterStyle;
     },
   });
+};
+
+/** The source holding the individual features: the wrapped source of a clustering layer, its own otherwise. */
+const getFeatureSource = (layer: BaseLayer): VectorSource | null => {
+  if (!(layer instanceof VectorLayer)) return null;
+  const source = layer.getSource();
+  return source instanceof Cluster ? source.getSource() : source;
+};
+
+/**
+ * Re-applies the current filter and selection to a feature layer. A clustering layer has to re-cluster,
+ * because the filter decides which features take part in a cluster and its count.
+ */
+export const refreshFeatureLayer = (layer: BaseLayer) => {
+  const source = layer instanceof VectorLayer ? layer.getSource() : null;
+  if (source instanceof Cluster) {
+    source.refresh();
+  } else {
+    layer.changed();
+  }
+};
+
+/** The combined extent of the specified features; empty when none of them has a geometry. */
+export const getFeaturesExtent = (features: Feature[]): Extent => {
+  const extent = createEmpty();
+  for (const feature of features) {
+    const geometry = feature.getGeometry();
+    if (geometry) extendExtent(extent, geometry.getExtent());
+  }
+  return extent;
 };
 
 const getFitExtent = (featureLayers: BaseLayer[], fallback: Extent): Extent => {
   const featureExtent = createEmpty();
   for (const featureLayer of featureLayers) {
-    if (featureLayer instanceof VectorLayer) {
-      const extent = featureLayer.getSource()?.getExtent();
-      if (extent) extendExtent(featureExtent, extent);
-    }
+    const extent = getFeatureSource(featureLayer)?.getExtent();
+    if (extent) extendExtent(featureExtent, extent);
   }
   return isExtentEmpty(featureExtent) ? fallback : featureExtent;
 };
@@ -176,21 +257,14 @@ export const fitToLayers = (map: Map, options: FitOptions, fallback: Extent) => 
 };
 
 const getExtentForFeatureIds = (featureLayers: BaseLayer[], featureIds: ReadonlySet<string>): Extent => {
-  const extent = createEmpty();
+  const matching: Feature[] = [];
   for (const featureLayer of featureLayers) {
-    if (!(featureLayer instanceof VectorLayer)) continue;
-
-    for (const feature of featureLayer.getSource()?.getFeatures() ?? []) {
+    for (const feature of getFeatureSource(featureLayer)?.getFeatures() ?? []) {
       const id = feature.getId()?.toString();
-      if (id !== undefined && featureIds.has(id)) {
-        const geometry = feature.getGeometry();
-        if (geometry) {
-          extendExtent(extent, geometry.getExtent());
-        }
-      }
+      if (id !== undefined && featureIds.has(id)) matching.push(feature);
     }
   }
-  return extent;
+  return getFeaturesExtent(matching);
 };
 
 /** Fits the map view to the combined extent of the specified feature IDs, doing nothing if there are no matching features. */

--- a/src/Geopilot.Frontend/src/components/visualizations/map/mapSelectionPopup.tsx
+++ b/src/Geopilot.Frontend/src/components/visualizations/map/mapSelectionPopup.tsx
@@ -1,0 +1,78 @@
+import { FC } from "react";
+import { useTranslation } from "react-i18next";
+import { List, ListItemButton, ListItemText, Paper } from "@mui/material";
+
+/** One error offered in the selection popup: the message to show and the feature id it selects. */
+export interface SelectionEntry {
+  id: string;
+  text: string;
+}
+
+interface MapSelectionPopupProps {
+  /** The errors the clicked marker stands for, listed as one row each. */
+  entries: SelectionEntry[];
+  /** Called with the feature id of the row the user picked. */
+  onSelect: (featureId: string) => void;
+}
+
+const OUTER_ARROW_SIZE = 8;
+const INNER_ARROW_SIZE = 7;
+
+/**
+ * The popup anchored to a clicked marker, listing every error it stands for so each of them can be selected.
+ * Errors sharing the same coordinate stay in one cluster marker at every zoom level, so the list is the only
+ * way to reach them on the map.
+ */
+export const MapSelectionPopup: FC<MapSelectionPopupProps> = ({ entries, onSelect }) => {
+  const { t } = useTranslation();
+  const label = (entry: SelectionEntry) => entry.text || t("mapFeatureWithoutMessage");
+
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        position: "relative",
+        maxWidth: "300px",
+        backgroundColor: theme => theme.palette.background.content,
+        border: theme => `1px solid ${theme.palette.primary.light}`,
+        // The overlay hosting the popup is click-through, the list rows need the clicks.
+        pointerEvents: "auto",
+        // The arrow pointing at the marker, as two stacked triangles: the outer one carries the border
+        // colour, the smaller inner one covers its face and leaves only the border edge visible.
+        "&::before, &::after": {
+          content: '""',
+          position: "absolute",
+          left: "50%",
+          transform: "translateX(-50%)",
+        },
+        "&::before": {
+          top: "100%",
+          borderLeft: `${OUTER_ARROW_SIZE}px solid transparent`,
+          borderRight: `${OUTER_ARROW_SIZE}px solid transparent`,
+          borderTop: theme => `${OUTER_ARROW_SIZE}px solid ${theme.palette.primary.light}`,
+        },
+        "&::after": {
+          top: "calc(100% - 1px)",
+          borderLeft: `${INNER_ARROW_SIZE}px solid transparent`,
+          borderRight: `${INNER_ARROW_SIZE}px solid transparent`,
+          borderTop: theme => `${INNER_ARROW_SIZE}px solid ${theme.palette.background.content}`,
+        },
+      }}>
+      <List
+        dense
+        disablePadding
+        sx={{ maxHeight: "180px", overflowY: "auto", borderRadius: theme => theme.radius.default }}>
+        {entries.map((entry, index) => (
+          <ListItemButton
+            key={entry.id}
+            disableGutters
+            divider={index < entries.length - 1}
+            onClick={() => onSelect(entry.id)}
+            sx={{ py: 1, px: 1.5 }}>
+            <ListItemText primary={label(entry)} slotProps={{ primary: { variant: "body2" } }} />
+          </ListItemButton>
+        ))}
+      </List>
+    </Paper>
+  );
+};

--- a/src/Geopilot.Frontend/src/components/visualizations/map/mapVisualizationProvider.tsx
+++ b/src/Geopilot.Frontend/src/components/visualizations/map/mapVisualizationProvider.tsx
@@ -1,8 +1,10 @@
 import { FC, PropsWithChildren, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { Theme, useTheme } from "@mui/material/styles";
+import { Coordinate } from "ol/coordinate";
 import { Condition, platformModifierKeyOnly } from "ol/events/condition";
-import { Extent, getCenter } from "ol/extent";
+import { Extent, getCenter, getHeight, getWidth } from "ol/extent";
 import { MAC } from "ol/has";
 import { defaults as defaultInteractions, DragPan, MouseWheelZoom } from "ol/interaction";
 import BaseLayer from "ol/layer/Base";
@@ -17,11 +19,21 @@ import proj4 from "proj4";
 import { LocalizedText, MapVisualizationConfig } from "../../../api/apiInterfaces";
 import { px2rem } from "../../../appTheme.ts";
 import { useLocalized } from "../../../hooks/useLocalized";
-import { buildFeatureLayer, buildWmtsLayer, fitToFeatures, fitToLayers } from "./layers";
+import {
+  buildFeatureLayer,
+  buildWmtsLayer,
+  fitToFeatures,
+  fitToLayers,
+  getClusterMembers,
+  getFeaturesExtent,
+  refreshFeatureLayer,
+} from "./layers";
 import { LayerSwitcherProperties } from "./layerSwitcherProps";
+import { MapSelectionPopup, SelectionEntry } from "./mapSelectionPopup";
 import { MapVisualizationContext, MapVisualizationContextInterface } from "./mapVisualizationContext";
 
 const ZOOM_TO_NODE_MAX_ZOOM = 13;
+const ZOOM_TO_CLUSTER_MAX_ZOOM = 18;
 const ZOOM_TO_NODE_DURATION = 400;
 
 const LOCALIZABLE_TITLE_PROPERTY = "localizableTitle";
@@ -38,51 +50,32 @@ proj4.defs(
 register(proj4);
 getProjection(SWISS_PROJECTION)?.setExtent(SWISS_EXTENT);
 
-const createPopupArrow = (size: number, color: string, top: string): HTMLDivElement => {
-  const arrow = document.createElement("div");
-  Object.assign(arrow.style, {
-    position: "absolute",
-    top,
-    left: "50%",
-    transform: "translateX(-50%)",
-    width: "0",
-    height: "0",
-    borderLeft: `${size}px solid transparent`,
-    borderRight: `${size}px solid transparent`,
-    borderTop: `${size}px solid ${color}`,
-  });
-  return arrow;
-};
-
-const createSelectionOverlay = (theme: Theme): [Overlay, (text: string) => void] => {
-  const popupElement = document.createElement("div");
-  Object.assign(popupElement.style, {
-    position: "relative",
-    backgroundColor: theme.palette.background.content,
-    border: `1px solid ${theme.palette.primary.light}`,
-    borderRadius: theme.radius.default,
-    padding: `${theme.spacing(1)} ${theme.spacing(1.5)}`,
-    maxWidth: "300px",
-    fontSize: px2rem(14),
-    pointerEvents: "none",
-  } satisfies Partial<CSSStyleDeclaration>);
-  const popupContent = document.createElement("div");
-  popupElement.appendChild(popupContent);
-  popupElement.appendChild(createPopupArrow(8, theme.palette.primary.light, "100%"));
-  popupElement.appendChild(createPopupArrow(7, theme.palette.background.content, "calc(100% - 1px)"));
+/**
+ * Creates the overlay that anchors the selection popup to a marker. It only owns the positioning and the
+ * host element, its content is rendered into that element with React (see MapSelectionPopup).
+ */
+const createSelectionOverlay = (): [Overlay, HTMLDivElement] => {
+  const element = document.createElement("div");
+  // The popup itself decides whether it takes clicks, so the host stays out of the way.
+  element.style.pointerEvents = "none";
+  // Scrolling a long list must not reach the viewport, which would answer with the zoom gesture hint.
+  element.addEventListener("wheel", event => event.stopPropagation());
   const overlay = new Overlay({
-    element: popupElement,
+    element,
     positioning: "bottom-center",
     offset: [0, -12],
-    stopEvent: false,
+    // The rows of a list are clickable, so the map must not act on events coming from the popup: it derives
+    // its own click from pointerup and would close the popup before the row is ever selected.
+    stopEvent: true,
   });
-  return [
-    overlay,
-    (text: string) => {
-      popupContent.textContent = text;
-    },
-  ];
+  return [overlay, element];
 };
+
+/** What the selection popup currently shows, and the coordinate it is anchored to. */
+interface MapSelection {
+  entries: SelectionEntry[];
+  position: Coordinate;
+}
 
 const createInteractionHint = (
   theme: Theme,
@@ -185,7 +178,23 @@ export const MapVisualizationProvider: FC<PropsWithChildren<MapVisualizationProv
     fitOptions.current = options;
   }, []);
 
-  const [selectionOverlay, setSelectionOverlayText] = useMemo(() => createSelectionOverlay(theme), [theme]);
+  const [selection, setSelection] = useState<MapSelection | null>(null);
+  const [selectionOverlay, selectionOverlayElement] = useMemo(() => createSelectionOverlay(), []);
+
+  // A changed filter re-clusters the markers, so the popup drops the errors the filter removed and closes
+  // once none is left. Derived rather than reset, so picking a row (which changes the selection, not the
+  // filter) leaves the popup open. Entries without an id are kept, as the feature style function does.
+  const shownSelection = useMemo<MapSelection | null>(() => {
+    if (!selection) return null;
+    const entries = selection.entries.filter(
+      entry => !visibleFeatureIds || !entry.id || visibleFeatureIds.has(entry.id),
+    );
+    return entries.length > 0 ? { ...selection, entries } : null;
+  }, [selection, visibleFeatureIds]);
+
+  useEffect(() => {
+    selectionOverlay.setPosition(shownSelection?.position);
+  }, [shownSelection, selectionOverlay]);
 
   const zoomToExtent = useCallback(() => {
     if (!map) return;
@@ -326,15 +335,45 @@ export const MapVisualizationProvider: FC<PropsWithChildren<MapVisualizationProv
     if (!map) return;
 
     const handler = map.on("click", event => {
-      const feature = map?.forEachFeatureAtPixel(event.pixel, f => f);
+      const clicked = map?.forEachFeatureAtPixel(event.pixel, f => f);
+      const members = clicked ? getClusterMembers(clicked) : [];
+
+      // If the clicked feature is a cluster, zoom into it
+      if (members.length > 1) {
+        const membersExtent = getFeaturesExtent(members);
+        const zoom = map.getView().getZoom() ?? 0;
+        const separable = getWidth(membersExtent) > 0 || getHeight(membersExtent) > 0;
+        if (separable && zoom < ZOOM_TO_CLUSTER_MAX_ZOOM) {
+          setSelection(null);
+          fitToFeatures(map, new Set(members.map(member => member.getId()?.toString() ?? "")), {
+            padding: fitOptions.current.padding,
+            maxZoom: ZOOM_TO_CLUSTER_MAX_ZOOM,
+            duration: ZOOM_TO_NODE_DURATION,
+          });
+          return;
+        }
+
+        setSelection({
+          entries: members.map(member => ({
+            id: member.getId()?.toString() ?? "",
+            text: (member.get("info") as string | undefined) ?? "",
+          })),
+          position: getCenter(membersExtent),
+        });
+        return;
+      }
+
+      const feature = members[0];
       const info = feature?.get("info") as string | undefined;
       const featureId = feature?.getId()?.toString();
       if (showMapSelectionPopup && feature && info) {
-        setSelectionOverlayText(info);
         const geometry = feature.getGeometry();
-        selectionOverlay.setPosition(geometry ? getCenter(geometry.getExtent()) : event.coordinate);
+        setSelection({
+          entries: [{ id: featureId ?? "", text: info }],
+          position: geometry ? getCenter(geometry.getExtent()) : event.coordinate,
+        });
       } else {
-        selectionOverlay.setPosition(undefined);
+        setSelection(null);
       }
       if (featureId) onSelectFeature?.(featureId);
     });
@@ -342,13 +381,12 @@ export const MapVisualizationProvider: FC<PropsWithChildren<MapVisualizationProv
     return () => {
       unByKey(handler);
     };
-  }, [map, onSelectFeature, selectionOverlay, setSelectionOverlayText, showMapSelectionPopup]);
+  }, [map, onSelectFeature, showMapSelectionPopup]);
 
   useEffect(() => {
     visibleIdsRef.current = visibleFeatureIds;
     highlightedIdsRef.current = highlightedFeatureIds;
-    // Trigger a re-render of the style function
-    featureLayers.forEach(layer => layer.changed());
+    featureLayers.forEach(refreshFeatureLayer);
   }, [visibleFeatureIds, highlightedFeatureIds, featureLayers]);
 
   useEffect(() => {
@@ -365,5 +403,19 @@ export const MapVisualizationProvider: FC<PropsWithChildren<MapVisualizationProv
     () => ({ map, zoomToExtent, zoomBy, setFitOptions }),
     [map, zoomToExtent, zoomBy, setFitOptions],
   );
-  return <MapVisualizationContext.Provider value={contextValue}>{children}</MapVisualizationContext.Provider>;
+  return (
+    <MapVisualizationContext.Provider value={contextValue}>
+      {children}
+      {shownSelection &&
+        createPortal(
+          <MapSelectionPopup
+            entries={shownSelection.entries}
+            onSelect={featureId => {
+              if (featureId) onSelectFeature?.(featureId);
+            }}
+          />,
+          selectionOverlayElement,
+        )}
+    </MapVisualizationContext.Provider>
+  );
 };


### PR DESCRIPTION
Betrifft Issue #762

Fügt Clustering bei der Error-Karte ein und zeigt ein Popup an, wenn mehrere Fehler an der gleichen Stelle liegen. Die Karte bleibt durch diesen Change schnell, auch bei mehreren tausend Fehlern.
Das Hauptproblem bei der Performance ist aber der Error-Tree, was hier nicht gelöst wird. Siehe dafür Kommentar im Issue.