### PR TITLE
Add local plugin config linking for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -412,3 +412,6 @@ certs/
 
 # Local environment variables
 .env
+
+# Local developer overlays (symlinks created by scripts/link-plugin-config.ps1)
+**/appsettings.Local*.json

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -35,8 +35,8 @@ Beispiele:
 
 1. Sucht `appsettings.<Profile>.json` im Nachbar-Plugin-Repository (Build-Ausgabe unter `bin`/`obj` wird ignoriert).
 2. Erstellt einen **Symlink** `src/Geopilot.Api/appsettings.Local[.<Name>].json`, der auf diese Datei zeigt.
-3. Stellt sicher, dass der Link git-ignoriert ist: fehlt ein passender Eintrag, wird das Muster `**/appsettings.Local*.json` in die `.gitignore` geschrieben (ein Eintrag deckt alle Overlays ab).
-4. geopilot lädt **jede** `appsettings.Local*.json` als optionales Konfig-Overlay, als letzte Schicht, sodass die Plugin-Einstellungen die Basis-Appsettings überschreiben (siehe `src/Geopilot.Api/Program.cs`).
+3. Der Link ist über das Muster `**/appsettings.Local*.json` in der `.gitignore` abgedeckt und erscheint deshalb nie in `git status`.
+4. geopilot lädt **jede** `appsettings.Local*.json` als optionales Konfig-Overlay (siehe `src/Geopilot.Api/ConfigurationBuilderExtensions.cs`). Die Overlays greifen **nur in der Development-Umgebung** und liegen in der Konfigurationsreihenfolge nach den Appsettings, aber vor den Umgebungsvariablen: sie überschreiben also `appsettings.json` und `appsettings.Development.json`, verlieren aber gegen Umgebungsvariablen und Kommandozeilen-Argumente.
 
 ## Mehrere Plugins gleichzeitig
 
@@ -49,7 +49,8 @@ Gib jedem Link einen `Name`. Alle `appsettings.Local.<name>.json` werden zusamme
 
 ## Gut zu wissen
 
-- **geopilot neu starten** nach dem Verlinken. Konfig-Overlays und Plugins werden beim Start gelesen.
+- **geopilot neu starten** nach dem Verlinken und nach jeder Änderung an der verlinkten Datei. Konfig-Overlays und Plugins werden beim Start gelesen, es gibt kein automatisches Neuladen.
+- Findet das Skript **mehrere** `appsettings.<Profile>.json` im Plugin (z.B. Plugin- und Testprojekt), bricht es mit der Trefferliste ab, statt eine beliebige zu verlinken.
 - Der Link ist **git-ignoriert**: er erscheint nie in `git status` und ist im Visual-Studio-Solution-Explorer standardmässig ausgeblendet. Das ist so gewollt.
 - Halte die `appsettings.<Profile>.json` im Plugin **dünn** (nur plugin-relevante Schlüssel) und nutze Pfade, die aus geopilots Sicht gültig sind.
 - **Editor-Tabs können einseitig wirken:** bearbeitest du den Link, aktualisiert sich die Plugin-Datei; bearbeitest du die Plugin-Datei, frischt sich der Tab des Links evtl. erst nach erneutem Öffnen auf. Auf der Platte ist es immer ein und dieselbe Datei.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,65 @@
+# Lokale Plugin-Konfiguration
+
+Werkzeug, um ein geopilot-Plugin lokal gegen geopilot zu entwickeln, ohne Konfiguration von Hand zu kopieren.
+
+`link-plugin-config.ps1` verlinkt die Entwicklungs-Appsettings eines Plugins als git-ignorierten Symlink in geopilot, sodass geopilot die Plugin-Einstellungen direkt liest. Das Plugin-Repository bleibt die einzige Quelle der Wahrheit.
+
+## Voraussetzungen
+
+- **Symlink-Rechte auf Windows:** einen Symlink zu erstellen braucht Administrator-Rechte oder aktivierten Developer Mode (Einstellungen > Für Entwickler > Entwicklermodus).
+- Das Plugin-Repository liegt als **Nachbarordner** neben geopilot (gleiches übergeordnetes Verzeichnis).
+
+## Verwendung
+
+```powershell
+./scripts/link-plugin-config.ps1 <Plugin> <Profile> [Name]
+```
+
+| Parameter | Bedeutung |
+| --- | --- |
+| `Plugin` | Ordnername des Plugin-Repositorys neben geopilot. |
+| `Profile` | Welche `appsettings.<Profile>.json` im Plugin verlinkt wird (z.B. `Development`). |
+| `Name` | Optional. Benennt das Overlay: `appsettings.Local.<Name>.json`. Ohne Angabe schlicht `appsettings.Local.json`. |
+
+Beispiele:
+
+```powershell
+# appsettings.Development.json des Plugins als appsettings.Local.json verlinken
+./scripts/link-plugin-config.ps1 mein-plugin Development
+
+# benanntes Overlay, damit mehrere Plugins gleichzeitig verlinkt sein koennen
+./scripts/link-plugin-config.ps1 mein-plugin Development meinplugin
+```
+
+## Funktionsweise
+
+1. Sucht `appsettings.<Profile>.json` im Nachbar-Plugin-Repository (Build-Ausgabe unter `bin`/`obj` wird ignoriert).
+2. Erstellt einen **Symlink** `src/Geopilot.Api/appsettings.Local[.<Name>].json`, der auf diese Datei zeigt.
+3. Stellt sicher, dass der Link git-ignoriert ist: fehlt ein passender Eintrag, wird das Muster `**/appsettings.Local*.json` in die `.gitignore` geschrieben (ein Eintrag deckt alle Overlays ab).
+4. geopilot lädt **jede** `appsettings.Local*.json` als optionales Konfig-Overlay, als letzte Schicht, sodass die Plugin-Einstellungen die Basis-Appsettings überschreiben (siehe `src/Geopilot.Api/Program.cs`).
+
+## Mehrere Plugins gleichzeitig
+
+Gib jedem Link einen `Name`. Alle `appsettings.Local.<name>.json` werden zusammen geladen, du kannst also mehrere Plugins gleichzeitig verlinkt haben.
+
+## Warum ein Symlink
+
+- **Eine Quelle der Wahrheit:** die Datei im Plugin-Repository. Kein Kopieren von Hand, kein Auseinanderlaufen über die Zeit.
+- **Robust:** ein Symlink löst bei jedem Zugriff über den Pfad auf, funktioniert also weiter nach Editor-Speichern und git-Operationen (Pull, Checkout, Branch-Wechsel), die die Zieldatei ersetzen. Ein Hardlink würde dabei still brechen.
+
+## Gut zu wissen
+
+- **geopilot neu starten** nach dem Verlinken. Konfig-Overlays und Plugins werden beim Start gelesen.
+- Der Link ist **git-ignoriert**: er erscheint nie in `git status` und ist im Visual-Studio-Solution-Explorer standardmässig ausgeblendet. Das ist so gewollt.
+- Halte die `appsettings.<Profile>.json` im Plugin **dünn** (nur plugin-relevante Schlüssel) und nutze Pfade, die aus geopilots Sicht gültig sind.
+- **Editor-Tabs können einseitig wirken:** bearbeitest du den Link, aktualisiert sich die Plugin-Datei; bearbeitest du die Plugin-Datei, frischt sich der Tab des Links evtl. erst nach erneutem Öffnen auf. Auf der Platte ist es immer ein und dieselbe Datei.
+
+## Link entfernen
+
+Die Link-Datei löschen, zum Beispiel:
+
+```powershell
+Remove-Item src/Geopilot.Api/appsettings.Local.<Name>.json
+```
+
+Das Löschen des Symlinks fasst die Plugin-Datei nicht an.

--- a/scripts/link-plugin-config.ps1
+++ b/scripts/link-plugin-config.ps1
@@ -1,0 +1,75 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Links a plugin's dev appsettings into geopilot for local development.
+
+.DESCRIPTION
+    Creates a git-ignored symbolic link under src/Geopilot.Api that points at a plugin's
+    appsettings.<Profile>.json. geopilot loads every appsettings.Local*.json as a config overlay,
+    so the plugin's settings take effect without copying anything by hand, and several plugins can
+    be linked at once under different names. The plugin repo stays the single source of truth.
+
+    A symlink resolves by path on every access, so it survives editor saves and git operations
+    (pull, checkout, branch switch) that replace the target file.
+
+    Requirement on Windows: creating a symlink needs Administrator rights or enabled Developer Mode
+    (Settings > For developers > Developer Mode). Without it, mklink fails with a privilege error.
+
+.PARAMETER Plugin
+    Folder name of the plugin repository next to geopilot (for example: my-plugin).
+
+.PARAMETER Profile
+    Appsettings profile to link, i.e. appsettings.<Profile>.json in the plugin (for example: Development).
+
+.PARAMETER Name
+    Optional overlay name. Given "name" the link becomes appsettings.Local.name.json; omitted it is
+    plain appsettings.Local.json. geopilot loads any appsettings.Local*.json, so no Program.cs change
+    is needed per name.
+
+.EXAMPLE
+    ./scripts/link-plugin-config.ps1 my-plugin Development myplugin
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory, Position = 0)][string]$Plugin,
+    [Parameter(Mandatory, Position = 1)][string]$Profile,
+    [Parameter(Position = 2)][string]$Name
+)
+
+$ErrorActionPreference = 'Stop'
+
+# geopilot repository root (this script lives inside it)
+$geopilotRoot = (Resolve-Path (git -C $PSScriptRoot rev-parse --show-toplevel).Trim()).Path
+
+# Local overlay file name: appsettings.Local.json, or appsettings.Local.<Name>.json when a name is given
+$linkFileName = if ([string]::IsNullOrWhiteSpace($Name)) { 'appsettings.Local.json' } else { "appsettings.Local.$Name.json" }
+$linkPath = Join-Path $geopilotRoot "src\Geopilot.Api\$linkFileName"
+
+# The plugin repository is expected next to geopilot
+$pluginRoot = Join-Path (Split-Path -Parent $geopilotRoot) $Plugin
+if (-not (Test-Path $pluginRoot)) { throw "Plugin repository not found: $pluginRoot" }
+
+# Find the requested profile config in the plugin, ignoring build output
+$target = Get-ChildItem -Path $pluginRoot -Recurse -File -Filter "appsettings.$Profile.json" |
+    Where-Object { $_.FullName -notmatch '[\\/](bin|obj)[\\/]' } |
+    Select-Object -First 1 -ExpandProperty FullName
+if (-not $target) { throw "No appsettings.$Profile.json found under $pluginRoot" }
+
+# (Re)create the symbolic link
+if (Test-Path $linkPath) { Remove-Item -Force $linkPath }
+& cmd.exe /c "mklink `"$linkPath`" `"$target`"" | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    throw "mklink failed (exit code $LASTEXITCODE). Symlinks need Administrator rights or enabled Developer Mode (Settings > For developers > Developer Mode)."
+}
+Write-Host "Linked $linkPath -> $target"
+
+# Make sure the link is git-ignored. If nothing covers it yet, add the shared glob so every
+# appsettings.Local*.json is ignored with a single entry (idempotent across runs and names).
+git -C $geopilotRoot check-ignore -q -- $linkPath
+if ($LASTEXITCODE -ne 0) {
+    Add-Content -Path (Join-Path $geopilotRoot '.gitignore') -Value "`r`n# Local developer overlays (symlinks created by scripts/link-plugin-config.ps1)`r`n**/appsettings.Local*.json"
+    Write-Host "Added **/appsettings.Local*.json to .gitignore"
+}
+else {
+    Write-Host "Already git-ignored"
+}

--- a/scripts/link-plugin-config.ps1
+++ b/scripts/link-plugin-config.ps1
@@ -49,27 +49,24 @@ $linkPath = Join-Path $geopilotRoot "src\Geopilot.Api\$linkFileName"
 $pluginRoot = Join-Path (Split-Path -Parent $geopilotRoot) $Plugin
 if (-not (Test-Path $pluginRoot)) { throw "Plugin repository not found: $pluginRoot" }
 
-# Find the requested profile config in the plugin, ignoring build output
-$target = Get-ChildItem -Path $pluginRoot -Recurse -File -Filter "appsettings.$Profile.json" |
+# Find the requested profile config in the plugin, ignoring build output.
+# Abort on multiple matches (e.g. plugin project plus test project) instead of picking one silently.
+$candidates = @(Get-ChildItem -Path $pluginRoot -Recurse -File -Filter "appsettings.$Profile.json" |
     Where-Object { $_.FullName -notmatch '[\\/](bin|obj)[\\/]' } |
-    Select-Object -First 1 -ExpandProperty FullName
-if (-not $target) { throw "No appsettings.$Profile.json found under $pluginRoot" }
+    Select-Object -ExpandProperty FullName)
+if ($candidates.Count -eq 0) { throw "No appsettings.$Profile.json found under $pluginRoot" }
+if ($candidates.Count -gt 1) {
+    throw "Multiple appsettings.$Profile.json found under ${pluginRoot}:`n$($candidates -join "`n")"
+}
+$target = $candidates[0]
 
-# (Re)create the symbolic link
-if (Test-Path $linkPath) { Remove-Item -Force $linkPath }
+# (Re)create the symbolic link. Delete any existing or dangling link first: File.Delete is a no-op when
+# the path is absent and removes a stale link that Test-Path can miss. mklink is used deliberately because
+# it honors Windows Developer Mode, whereas New-Item -ItemType SymbolicLink requires elevation on Windows
+# PowerShell 5.1.
+[System.IO.File]::Delete($linkPath)
 & cmd.exe /c "mklink `"$linkPath`" `"$target`"" | Out-Null
 if ($LASTEXITCODE -ne 0) {
-    throw "mklink failed (exit code $LASTEXITCODE). Symlinks need Administrator rights or enabled Developer Mode (Settings > For developers > Developer Mode)."
+    throw "mklink failed (exit code $LASTEXITCODE). On Windows this needs Administrator rights or enabled Developer Mode (Settings > For developers > Developer Mode)."
 }
 Write-Host "Linked $linkPath -> $target"
-
-# Make sure the link is git-ignored. If nothing covers it yet, add the shared glob so every
-# appsettings.Local*.json is ignored with a single entry (idempotent across runs and names).
-git -C $geopilotRoot check-ignore -q -- $linkPath
-if ($LASTEXITCODE -ne 0) {
-    Add-Content -Path (Join-Path $geopilotRoot '.gitignore') -Value "`r`n# Local developer overlays (symlinks created by scripts/link-plugin-config.ps1)`r`n**/appsettings.Local*.json"
-    Write-Host "Added **/appsettings.Local*.json to .gitignore"
-}
-else {
-    Write-Host "Already git-ignored"
-}

--- a/src/Geopilot.Api/ConfigurationBuilderExtensions.cs
+++ b/src/Geopilot.Api/ConfigurationBuilderExtensions.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.Extensions.Configuration.EnvironmentVariables;
+using Microsoft.Extensions.Configuration.Json;
+
+namespace Geopilot.Api;
+
+/// <summary>
+/// Configuration helpers for local development.
+/// </summary>
+internal static class ConfigurationBuilderExtensions
+{
+    /// <summary>
+    /// Adds git-ignored developer overlays (<c>appsettings.Local*.json</c>) as JSON configuration sources
+    /// for local plugin development. The overlays are inserted right before the application environment-variable
+    /// source so environment variables and command-line arguments still take precedence, and they are only
+    /// loaded in the Development environment. The files are populated by <c>scripts/link-plugin-config.ps1</c>.
+    /// </summary>
+    /// <param name="builder">The web application builder whose configuration sources are extended.</param>
+    public static void AddDeveloperOverlays(this WebApplicationBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        if (!builder.Environment.IsDevelopment())
+            return;
+
+        var overlayFiles = Directory
+            .EnumerateFiles(builder.Environment.ContentRootPath, "appsettings.Local*.json")
+            .OrderBy(f => f, StringComparer.Ordinal)
+            .ToList();
+        if (overlayFiles.Count == 0)
+            return;
+
+        // WebApplicationBuilder has several environment-variable sources (host and application). Insert before the
+        // last (application) one so the overlays override the appsettings files but lose to environment variables.
+        var sources = builder.Configuration.Sources;
+        var envIndex = sources.ToList().FindLastIndex(s => s is EnvironmentVariablesConfigurationSource);
+        var insertAt = envIndex < 0 ? sources.Count : envIndex;
+
+        foreach (var overlayFile in overlayFiles)
+        {
+            sources.Insert(insertAt++, new JsonConfigurationSource
+            {
+                FileProvider = builder.Environment.ContentRootFileProvider,
+                Path = Path.GetFileName(overlayFile),
+                Optional = true,
+                ReloadOnChange = false,
+            });
+        }
+    }
+}

--- a/src/Geopilot.Api/Program.cs
+++ b/src/Geopilot.Api/Program.cs
@@ -25,13 +25,8 @@ using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Optional, git-ignored developer overlays, layered last so they win over the appsettings files.
-// Loads appsettings.Local.json plus any appsettings.Local.<name>.json, so several plugins can be
-// linked at once. Populated by scripts/link-plugin-config.ps1 as symlinks; never committed.
-foreach (var overlay in Directory.EnumerateFiles(builder.Environment.ContentRootPath, "appsettings.Local*.json").OrderBy(f => f))
-{
-    builder.Configuration.AddJsonFile(Path.GetFileName(overlay), optional: true, reloadOnChange: true);
-}
+// Optional git-ignored developer overlays (appsettings.Local*.json) for local plugin development.
+builder.AddDeveloperOverlays();
 
 builder.Services.AddCors(options =>
 {

--- a/src/Geopilot.Api/Program.cs
+++ b/src/Geopilot.Api/Program.cs
@@ -25,6 +25,14 @@ using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Optional, git-ignored developer overlays, layered last so they win over the appsettings files.
+// Loads appsettings.Local.json plus any appsettings.Local.<name>.json, so several plugins can be
+// linked at once. Populated by scripts/link-plugin-config.ps1 as symlinks; never committed.
+foreach (var overlay in Directory.EnumerateFiles(builder.Environment.ContentRootPath, "appsettings.Local*.json").OrderBy(f => f))
+{
+    builder.Configuration.AddJsonFile(Path.GetFileName(overlay), optional: true, reloadOnChange: true);
+}
+
 builder.Services.AddCors(options =>
 {
     // DotNetStac.Api uses the "All" policy for access in the STAC browser.

--- a/tests/Geopilot.Api.Test/ConfigurationBuilderExtensionsTest.cs
+++ b/tests/Geopilot.Api.Test/ConfigurationBuilderExtensionsTest.cs
@@ -1,0 +1,125 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+
+namespace Geopilot.Api;
+
+/// <summary>
+/// Each test uses its own configuration key: environment variables are process global, so a shared key
+/// would let the environment variable test bleed into the others when tests run in parallel. The keys are
+/// flat so they can be set through an environment variable of the same name.
+/// </summary>
+[TestClass]
+public sealed class ConfigurationBuilderExtensionsTest
+{
+    [TestMethod]
+    public void AddDeveloperOverlaysOverridesAppsettingsInDevelopment()
+    {
+        const string key = "OverlayProbeDevelopment";
+        var contentRoot = CreateContentRoot(
+            ("appsettings.json", key, "base"),
+            ("appsettings.Local.json", key, "overlay"));
+        try
+        {
+            var builder = CreateBuilder(contentRoot, Environments.Development);
+
+            builder.AddDeveloperOverlays();
+
+            Assert.AreEqual("overlay", builder.Configuration[key]);
+        }
+        finally
+        {
+            Directory.Delete(contentRoot, true);
+        }
+    }
+
+    [TestMethod]
+    public void AddDeveloperOverlaysLoadsNamedOverlays()
+    {
+        var contentRoot = CreateContentRoot(
+            ("appsettings.Local.first.json", "OverlayProbeFirstPlugin", "first"),
+            ("appsettings.Local.second.json", "OverlayProbeSecondPlugin", "second"));
+        try
+        {
+            var builder = CreateBuilder(contentRoot, Environments.Development);
+
+            builder.AddDeveloperOverlays();
+
+            Assert.AreEqual("first", builder.Configuration["OverlayProbeFirstPlugin"]);
+            Assert.AreEqual("second", builder.Configuration["OverlayProbeSecondPlugin"]);
+        }
+        finally
+        {
+            Directory.Delete(contentRoot, true);
+        }
+    }
+
+    /// <summary>
+    /// The overlays are inserted before the application environment variable source, so deployment
+    /// configuration (for example the environment variables set in docker-compose) keeps precedence.
+    /// </summary>
+    [TestMethod]
+    public void AddDeveloperOverlaysLosesToEnvironmentVariables()
+    {
+        const string key = "OverlayProbeEnvironment";
+        var contentRoot = CreateContentRoot(
+            ("appsettings.json", key, "base"),
+            ("appsettings.Local.json", key, "overlay"));
+        Environment.SetEnvironmentVariable(key, "environment");
+        try
+        {
+            var builder = CreateBuilder(contentRoot, Environments.Development);
+
+            builder.AddDeveloperOverlays();
+
+            Assert.AreEqual("environment", builder.Configuration[key]);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(key, null);
+            Directory.Delete(contentRoot, true);
+        }
+    }
+
+    [TestMethod]
+    public void AddDeveloperOverlaysIgnoresOverlaysOutsideDevelopment()
+    {
+        const string key = "OverlayProbeProduction";
+        var contentRoot = CreateContentRoot(
+            ("appsettings.json", key, "base"),
+            ("appsettings.Local.json", key, "overlay"));
+        try
+        {
+            var builder = CreateBuilder(contentRoot, Environments.Production);
+
+            builder.AddDeveloperOverlays();
+
+            Assert.AreEqual("base", builder.Configuration[key]);
+        }
+        finally
+        {
+            Directory.Delete(contentRoot, true);
+        }
+    }
+
+    private static WebApplicationBuilder CreateBuilder(string contentRoot, string environmentName)
+    {
+        return WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            ContentRootPath = contentRoot,
+            EnvironmentName = environmentName,
+        });
+    }
+
+    private static string CreateContentRoot(params (string FileName, string Key, string Value)[] files)
+    {
+        var contentRoot = Path.Combine(Path.GetTempPath(), $"overlayTest_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(contentRoot);
+
+        foreach (var (fileName, key, value) in files)
+        {
+            File.WriteAllText(Path.Combine(contentRoot, fileName), $$"""{ "{{key}}": "{{value}}" }""");
+        }
+
+        return contentRoot;
+    }
+}


### PR DESCRIPTION
Developers can point geopilot at a plugin's appsettings without copying it by hand: geopilot loads every appsettings.Local*.json as a git-ignored config overlay, and scripts/link-plugin-config.ps1 symlinks the plugin's appsettings.<Profile>.json. See scripts/README.md.

Closes #764 