### PR TITLE
update pipeline delivery restriction message

### DIFF
--- a/src/Geopilot.Api/PipelineDefinitions/basicPipeline_01.yaml
+++ b/src/Geopilot.Api/PipelineDefinitions/basicPipeline_01.yaml
@@ -65,10 +65,10 @@ pipelines:
             restrict_delivery_conditions:
               - expression: "!([validation.ValidationSuccessful])"
                 message:
-                  de: "Die Validierung war nicht erfolgreich. Datenlieferung nicht möglich."
-                  en: "Validation was not successful. Delivery is not possible."
-                  fr: "La validation n'a pas réussi. La livraison n'est pas possible."
-                  it: "La validazione non è riuscita. La consegna non è possibile."
+                  de: "Die Validierung war nicht erfolgreich."
+                  en: "Validation was not successful."
+                  fr: "La validation n'a pas réussi."
+                  it: "La validazione non è riuscita."
         process_config_overwrites:
         input:
           iliFile: "${step_output(xtf_matching.XtfFiles)}"

--- a/src/Geopilot.Api/PipelineDefinitions/basicPipeline_02.yaml
+++ b/src/Geopilot.Api/PipelineDefinitions/basicPipeline_02.yaml
@@ -68,10 +68,10 @@ pipelines:
             restrict_delivery_conditions:
               - expression: "!([validation.ValidationSuccessful])"
                 message:
-                  de: "Die Validierung war nicht erfolgreich. Datenlieferung nicht möglich."
-                  en: "Validation was not successful. Delivery is not possible."
-                  fr: "La validation n'a pas réussi. La livraison n'est pas possible."
-                  it: "La validazione non è riuscita. La consegna non è possibile."
+                  de: "Die Validierung war nicht erfolgreich."
+                  en: "Validation was not successful."
+                  fr: "La validation n'a pas réussi."
+                  it: "La validazione non è riuscita."
         input:
           iliFile: "${step_output(xtf_matching.XtfFiles)}"
         output_actions:
@@ -150,10 +150,10 @@ pipelines:
             restrict_delivery_conditions:
               - expression: "!([validation.ValidationSuccessful])"
                 message:
-                  de: "Die Validierung war nicht erfolgreich. Datenlieferung nicht möglich."
-                  en: "Validation was not successful. Delivery is not possible."
-                  fr: "La validation n'a pas réussi. La livraison n'est pas possible."
-                  it: "La validazione non è riuscita. La consegna non è possibile."
+                  de: "Die Validierung war nicht erfolgreich."
+                  en: "Validation was not successful."
+                  fr: "La validation n'a pas réussi."
+                  it: "La validazione non è riuscita."
         input:
           iliFile: "${step_output(xtf_matching.XtfFiles)}"
         output_actions:
@@ -249,10 +249,10 @@ pipelines:
             restrict_delivery_conditions:
               - expression: "!([validation.ValidationSuccessful])"
                 message:
-                  de: "Die Validierung war nicht erfolgreich. Datenlieferung nicht möglich."
-                  en: "Validation was not successful. Delivery is not possible."
-                  fr: "La validation n'a pas réussi. La livraison n'est pas possible."
-                  it: "La validazione non è riuscita. La consegna non è possibile."
+                  de: "Die Validierung war nicht erfolgreich."
+                  en: "Validation was not successful."
+                  fr: "La validation n'a pas réussi."
+                  it: "La validazione non è riuscita."
         input:
           iliFile: "${step_output(xtf_matching.XtfFiles)}"
         output_actions:


### PR DESCRIPTION
all pipeline delivery restriction messages had a suffix "Delivery is not possible." but the frontend adds this information as pre-fix before the configured message. so we had it twice.