### PR TITLE
Fix save button disabled after extent change

### DIFF
--- a/src/Geopilot.Frontend/cypress/e2e/mandates.cy.js
+++ b/src/Geopilot.Frontend/cypress/e2e/mandates.cy.js
@@ -290,6 +290,11 @@ describe("Mandate tests", () => {
     cy.dataCy("reset-button").should("be.disabled");
     cy.dataCy("save-button").should("be.disabled");
 
+    // Editing only the spatial extent must enable the buttons on its own, without touching any other field.
+    setInput("extent-upper-right-latitude", "47.47");
+    cy.dataCy("reset-button").should("be.enabled");
+    cy.dataCy("save-button").should("be.enabled");
+
     // Make change and check if buttons are now enabled after change.
     setNonFreeSoloAutocomplete("organisations", "Brown and Sons");
     evaluateAutocomplete("organisations", ["Schumm, Runte and Macejkovic", "Brown and Sons"]);

--- a/src/Geopilot.Frontend/src/components/form/formExtent.tsx
+++ b/src/Geopilot.Frontend/src/components/form/formExtent.tsx
@@ -125,7 +125,10 @@ export const FormExtent: FC<FormExtentProps> = ({ fieldName, required, disabled,
         renderFields(
           field.value,
           (index, key, e) =>
-            setValue(fieldName!, updateCoordinate(field.value, index, key, e), { shouldValidate: true }),
+            setValue(fieldName!, updateCoordinate(field.value, index, key, e), {
+              shouldValidate: true,
+              shouldDirty: true,
+            }),
           getFormFieldError(fieldName, formState.errors),
         )
       }


### PR DESCRIPTION
setValue in FormExtent wrote the new coordinate without shouldDirty, so react-hook-form skipped its dirty bookkeeping and formState.isDirty stayed false. The save button only became enabled once another field was edited, because the dirty check compares the whole form and then counted the coordinate that was already written.

Cover the case in the mandate edit test, which changed the organisations autocomplete before touching the extent and so never exercised an extent-only change.

Closes #906 