### PR TITLE
Set SameSite Strict on auth cookie

### DIFF
--- a/src/Geopilot.Frontend/src/auth/cookieSynchronizer.tsx
+++ b/src/Geopilot.Frontend/src/auth/cookieSynchronizer.tsx
@@ -2,11 +2,11 @@ import { FC, useEffect } from "react";
 import { useAuth } from "react-oidc-context";
 
 const setCookie = (access_token: string) => {
-  document.cookie = `geopilot.auth=${access_token};Path=/;Secure`;
+  document.cookie = `geopilot.auth=${access_token};Path=/;Secure;SameSite=Strict`;
 };
 
 const clearCookie = () => {
-  document.cookie = "geopilot.auth=;expires=Thu, 01 Jan 1970 00:00:00 GMT;Path=/;Secure";
+  document.cookie = "geopilot.auth=;expires=Thu, 01 Jan 1970 00:00:00 GMT;Path=/;Secure;SameSite=Strict";
 };
 
 export const CookieSynchronizer: FC = () => {


### PR DESCRIPTION
The geopilot.auth cookie carried no SameSite attribute, so its cross-site behavior rested on the browser default of Lax. Stating Strict makes it a property of the application instead of an assumption about the client. The cookie is cleared with the same attributes.

Closes #902 