### PR TITLE
Move pipeline validation behind IPipelineFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Mandates can have a localized description. The description is shown to the users when they choose a mandate before processing.
 - The documentation of the pipeline definition format, of the processors shipped with geopilot and of the plugin system is now published with the code under [`docs/pipeline/`](docs/pipeline/Pipelines.md).
 - Pipeline steps can end in a `Warning` state through a post `warn_conditions` list: the step ran and reported issues but the pipeline continues, shown with a warning icon in the delivery view. A run whose only non-successful steps are warnings is reported as a warning overall, and a warning does not block delivery on its own.
+- A plugin test project can check its pipeline definition before running it: `IPipelineFactory.ValidateDefinition()` in `GeoWerkstatt.Geopilot.Pipeline` reports the same problems, in the same message, that the host reports when it refuses to start. Until now that check lived in the host and was unreachable from outside. Implementations of `IPipelineFactory` outside geopilot have to add the new member.
 
 ### Removed
 

--- a/docs/pipeline/pluginSystem.md
+++ b/docs/pipeline/pluginSystem.md
@@ -227,7 +227,16 @@ Ein Test gegen die produktive Definition prüft die Verdrahtung, wie sie beim Ku
 
 Hat der zu testende Schritt höchstens einen Datei-Input, lässt er sich aus dem Upload speisen (`someInput: "${upload()}"`) und über `pipeline.Run(uploadFiles, ct)` ausführen. Dann muss gar kein Ergebnis eines Vorgängerschritts gestellt werden. Bei mehreren Datei-Inputs geht das nicht, weil `${upload()}` allen verdrahteten Parametern dieselbe Liste reicht; dort führt `${file(...)}` mit einem auf die Testfixtures gesetzten `ResourcesDirectory` zum selben Ziel.
 
-Zu beachten bleibt: solange der erzeugende Schritt nicht mitläuft, deckt kein Test ab, ob ein `${step_output(...)}` noch auf eine existierende Eigenschaft des echten Result-Typs zeigt. Wer diese Abweichung ausschliessen will, muss die beteiligten Schritte gemeinsam ausführen.
+Ob ein `${step_output(...)}` auf eine existierende und typkompatible Eigenschaft des echten Result-Typs zeigt, lässt sich ohne Ausführung prüfen. `IPipelineFactory.ValidateDefinition()` beantwortet das statisch für die ganze Definition, also auch für Schritte, die der Test nicht mitlaufen lässt. Als Preflight vor dem Lauf:
+
+```csharp
+var validation = factory.ValidateDefinition();
+Assert.IsTrue(validation.IsValid, validation.ErrorMessage);
+```
+
+Die Meldung nennt Pipeline, Schritt und Prozess und ist dieselbe, mit der der Server den Start verweigert. Ein solcher Test schlägt also dort fehl, wo auch das Deployment scheitern würde, und zwar bevor irgendein Prozessor läuft.
+
+Zu beachten bleibt: der Preflight prüft die Verdrahtung, nicht das Laufzeitverhalten. Wer ausschliessen will, dass ein erzeugender Schritt etwas anderes liefert als sein Result-Typ verspricht, muss die beteiligten Schritte gemeinsam ausführen.
 
 **Prozessoren werden in einen eigenen `AssemblyLoadContext` geladen.** Der Typ einer Prozessor-Instanz ist deshalb *nicht identisch* mit dem direkt referenzierten Typ, obwohl Typname und DLL-Pfad übereinstimmen. `is`-Prüfungen und Casts schlagen fehl:
 

--- a/src/Geopilot.Api/ServiceCollectionExtensions.cs
+++ b/src/Geopilot.Api/ServiceCollectionExtensions.cs
@@ -28,11 +28,12 @@ public static class ServiceCollectionExtensions
     /// definition specified in the application configuration.
     /// </summary>
     /// <remarks>This method expects a configuration value at the key 'Pipeline:Definition' that specifies the
-    /// pipeline definition file. The pipeline configuration is validated during registration, and any validation errors
-    /// will prevent the application from starting.</remarks>
+    /// pipeline definition file. The definition itself is checked separately during startup through
+    /// <see cref="IPipelineFactory.ValidateDefinition"/>, which keeps the application from starting on an invalid
+    /// definition.</remarks>
     /// <param name="services">The IServiceCollection to which the IPipelineFactory singleton will be added. Cannot be null.</param>
-    /// <exception cref="InvalidOperationException">Thrown if the pipeline definition is missing from the configuration or if the pipeline configuration contains
-    /// validation errors.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the factory is resolved and the pipeline definition is
+    /// missing from the configuration or the definition file does not exist.</exception>
     public static void AddPipelineFactory(this IServiceCollection services)
     {
         Func<IServiceProvider, IPipelineFactory> cofigurePipelineFactory = (IServiceProvider sp) =>

--- a/src/Geopilot.Api/WebApplicationExtensions.cs
+++ b/src/Geopilot.Api/WebApplicationExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using Geopilot.Pipeline;
-using Geopilot.Pipeline.Process;
 using Geopilot.Pipeline.Processes.XtfErrorVisualization;
 using System.Security.Cryptography;
 
@@ -18,51 +17,10 @@ public static class WebApplicationExtensions
     {
         ArgumentNullException.ThrowIfNull(app, nameof(app));
 
-        var pipelineFactory = app.Services.GetRequiredService<IPipelineFactory>() as PipelineFactory;
-        if (pipelineFactory == null)
+        var validationResult = app.Services.GetRequiredService<IPipelineFactory>().ValidateDefinition();
+        if (!validationResult.IsValid)
         {
-            throw new InvalidOperationException("PipelineFactory is not registered correctly.");
-        }
-
-        var validationErrors = pipelineFactory.PipelineProcessConfig.Validate();
-        if (validationErrors.HasErrors)
-        {
-            throw new InvalidOperationException($"errors in pipeline definition:{Environment.NewLine}{validationErrors.ErrorMessage}");
-        }
-
-        var pipelineProcessFactory = app.Services.GetRequiredService<IPipelineProcessFactory>();
-        var resourcesDirectory = app.Services.GetRequiredService<Geopilot.Api.FileAccess.IDirectoryProvider>().ResourcesDirectory;
-
-        var invalidProcessesErrors = new HashSet<string>();
-        var processes = pipelineFactory.PipelineProcessConfig.Processes;
-        foreach (var pipeline in pipelineFactory.PipelineProcessConfig.Pipelines)
-        {
-            var stepResultTypes = pipelineProcessFactory.BuildStepResultTypes(pipeline.Steps, processes);
-            foreach (var step in pipeline.Steps)
-            {
-                try
-                {
-                    // Use Validate() rather than Build() so startup does not actually
-                    // construct processes — invoking constructors here would leak
-                    // per-step directories under $TEMP and allocate HttpClients /
-                    // other per-process resources for every restart.
-                    pipelineProcessFactory
-                        .Builder()
-                        .StepConfig(step)
-                        .StepResultTypes(stepResultTypes)
-                        .Processes(processes)
-                        .Validate(resourcesDirectory);
-                }
-                catch (Exception ex)
-                {
-                    invalidProcessesErrors.Add($"pipeline {pipeline.Id}, step {step.Id}, process {step.ProcessId}, error: {ex.Message}");
-                }
-            }
-        }
-
-        if (invalidProcessesErrors.Count > 0)
-        {
-            throw new InvalidOperationException($"Invalid pipeline processes found:{Environment.NewLine}{string.Join(Environment.NewLine, invalidProcessesErrors)}");
+            throw new InvalidOperationException(validationResult.ErrorMessage);
         }
     }
 

--- a/src/Geopilot.Pipeline/IPipelineFactory.cs
+++ b/src/Geopilot.Pipeline/IPipelineFactory.cs
@@ -20,4 +20,11 @@ public interface IPipelineFactory
     /// <returns>A <see cref="Pipeline"/> instance.</returns>
     /// <exception cref="Exception">Thrown when the pipeline cannot be created.</exception>
     IPipeline CreatePipeline(string id, Guid jobId);
+
+    /// <summary>
+    /// Validates the pipeline definition and the process configuration of every step, without constructing any
+    /// process. The caller decides what an invalid definition means; the host refuses to start.
+    /// </summary>
+    /// <returns>The outcome, with all problems in a single message.</returns>
+    PipelineDefinitionValidationResult ValidateDefinition();
 }

--- a/src/Geopilot.Pipeline/PipelineDefinitionValidationResult.cs
+++ b/src/Geopilot.Pipeline/PipelineDefinitionValidationResult.cs
@@ -1,0 +1,19 @@
+﻿namespace Geopilot.Pipeline;
+
+/// <summary>
+/// Outcome of validating a pipeline definition. Carries one ready to display message listing every problem
+/// found, so a caller can surface all of them at once without knowing how validation is structured.
+/// </summary>
+/// <param name="ErrorMessage">All problems found, or <see langword="null"/> when the definition is valid.</param>
+public sealed record PipelineDefinitionValidationResult(string? ErrorMessage)
+{
+    /// <summary>
+    /// Gets a value indicating whether the definition passed validation.
+    /// </summary>
+    public bool IsValid => ErrorMessage is null;
+
+    /// <summary>
+    /// Gets the result for a definition without problems.
+    /// </summary>
+    public static PipelineDefinitionValidationResult Valid { get; } = new(ErrorMessage: null);
+}

--- a/src/Geopilot.Pipeline/PipelineFactory.cs
+++ b/src/Geopilot.Pipeline/PipelineFactory.cs
@@ -72,6 +72,51 @@ public class PipelineFactory : IPipelineFactory
         }
     }
 
+    /// <inheritdoc />
+    public PipelineDefinitionValidationResult ValidateDefinition()
+    {
+        var definitionErrors = PipelineProcessConfig.Validate();
+        if (definitionErrors.HasErrors)
+        {
+            return new PipelineDefinitionValidationResult(
+                $"errors in pipeline definition:{Environment.NewLine}{definitionErrors.ErrorMessage}");
+        }
+
+        var processErrors = new HashSet<string>();
+        var processes = PipelineProcessConfig.Processes;
+        foreach (var pipeline in PipelineProcessConfig.Pipelines)
+        {
+            var stepResultTypes = pipelineProcessFactory.BuildStepResultTypes(pipeline.Steps, processes);
+            foreach (var step in pipeline.Steps)
+            {
+                try
+                {
+                    // Use Validate() rather than Build() so validation does not actually construct processes.
+                    // Invoking constructors here would leak per-step directories under $TEMP and allocate
+                    // HttpClients and other per-process resources on every restart.
+                    pipelineProcessFactory
+                        .Builder()
+                        .StepConfig(step)
+                        .StepResultTypes(stepResultTypes)
+                        .Processes(processes)
+                        .Validate(resourcesDirectory);
+                }
+                catch (Exception ex)
+                {
+                    processErrors.Add($"pipeline {pipeline.Id}, step {step.Id}, process {step.ProcessId}, error: {ex.Message}");
+                }
+            }
+        }
+
+        if (processErrors.Count > 0)
+        {
+            return new PipelineDefinitionValidationResult(
+                $"Invalid pipeline processes found:{Environment.NewLine}{string.Join(Environment.NewLine, processErrors)}");
+        }
+
+        return PipelineDefinitionValidationResult.Valid;
+    }
+
     private List<IPipelineStep> CreateSteps(PipelineConfig pipelineConfig, string pipelineTempDirectory, Guid jobId)
     {
         return pipelineConfig.Steps

--- a/src/Geopilot.Pipeline/PipelineFactory.cs
+++ b/src/Geopilot.Pipeline/PipelineFactory.cs
@@ -20,7 +20,7 @@ public class PipelineFactory : IPipelineFactory
     /// <summary>
     /// The pipeline process configuration used to create pipelines.
     /// </summary>
-    public PipelineProcessConfig PipelineProcessConfig { get; }
+    internal PipelineProcessConfig PipelineProcessConfig { get; }
 
     private IPipelineProcessFactory pipelineProcessFactory;
 

--- a/tests/Geopilot.Api.Test/WebApplicationExtensionsTest.cs
+++ b/tests/Geopilot.Api.Test/WebApplicationExtensionsTest.cs
@@ -14,8 +14,8 @@ public sealed class WebApplicationExtensionsTest
     // A structurally valid pipeline whose only fault is a cross-step type mismatch: the second step wires
     // the first step's StatusMessage (a LocalizedText) into the IPipelineFile run parameter 'xtfLog'.
     // Catching this requires the per-step validation to see the whole step list, which
-    // ValidatePipelineConfiguration supplies via .StepResultTypes(stepResultTypes). Remove that one line and the
-    // reference is left unchecked, the app boots, and this test fails.
+    // PipelineFactory.ValidateDefinition supplies via .StepResultTypes(stepResultTypes). Remove that one line and
+    // the reference is left unchecked, the app boots, and this test fails.
     private const string CrossStepTypeMismatchPipeline = """
         processes:
           - id: xtf_matcher

--- a/tests/Geopilot.Pipeline.Test/PipelineDefinitionValidationTest.cs
+++ b/tests/Geopilot.Pipeline.Test/PipelineDefinitionValidationTest.cs
@@ -61,6 +61,21 @@ public class PipelineDefinitionValidationTest
         StringAssert.Contains(message, "Duplicate Id found: ili_validation.");
     }
 
+    // A definition that passes the definition check and fails on a step: the second step wires the first step's
+    // StatusMessage (a LocalizedText) into the IPipelineFile run parameter 'xtfLog'.
+    [TestMethod]
+    public void ValidateDefinitionRejectsCrossStepTypeMismatch()
+    {
+        var result = CreatePipelineFactory("processErrors").ValidateDefinition();
+
+        Assert.IsFalse(result.IsValid);
+        var message = result.ErrorMessage;
+        Assert.IsNotNull(message);
+        Assert.IsTrue(message.StartsWith("Invalid pipeline processes found:", StringComparison.Ordinal), message);
+        StringAssert.Contains(message, "pipeline bad_pipeline, step error_visualization, process xtf_error_visualizer, error:");
+        StringAssert.Contains(message, "is not compatible with the parameter type <IPipelineFile>");
+    }
+
     // The definition check returns before any step is inspected, so an operator fixing a broken definition is not
     // buried in follow-up errors from steps that could not be checked yet. Pinned here so the two phases are not
     // merged by accident.

--- a/tests/Geopilot.Pipeline.Test/PipelineDefinitionValidationTest.cs
+++ b/tests/Geopilot.Pipeline.Test/PipelineDefinitionValidationTest.cs
@@ -1,0 +1,94 @@
+﻿using Geopilot.Pipeline.Config;
+using Geopilot.Pipeline.Ilitools;
+using Geopilot.Pipeline.Process;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Geopilot.Pipeline.Test;
+
+[TestClass]
+public class PipelineDefinitionValidationTest
+{
+    private PipelineProcessFactory pipelineProcessFactory;
+    private Mock<ILoggerFactory> loggerFactoryMock;
+
+    [TestInitialize]
+    public void SetUp()
+    {
+        var pipelineOptionsMock = new Mock<IOptions<PipelineOptions>>();
+        pipelineOptionsMock.SetupGet(o => o.Value).Returns(new PipelineOptions
+        {
+            Definition = "myPipeline.yaml",
+            Plugins = new List<string>(),
+            ProcessConfigs = new Dictionary<string, Parameterization>(),
+        });
+
+        var loggerMock = new Mock<ILogger>();
+        loggerFactoryMock = new Mock<ILoggerFactory>();
+        loggerFactoryMock.Setup(f => f.CreateLogger(It.IsAny<string>())).Returns(loggerMock.Object);
+
+        var ilitoolsOptionsMock = new Mock<IOptions<IlitoolsOptions>>();
+        ilitoolsOptionsMock.SetupGet(o => o.Value).Returns(new IlitoolsOptions { IlitoolsWrapperAddress = "http://localhost:5555" });
+
+        pipelineProcessFactory = new PipelineProcessFactory(pipelineOptionsMock.Object, ilitoolsOptionsMock.Object, loggerFactoryMock.Object);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        pipelineProcessFactory?.Dispose();
+    }
+
+    [TestMethod]
+    public void ValidateDefinitionAcceptsValidDefinition()
+    {
+        var result = CreatePipelineFactory("basicPipeline_01").ValidateDefinition();
+
+        Assert.IsTrue(result.IsValid, result.ErrorMessage);
+        Assert.IsNull(result.ErrorMessage);
+    }
+
+    [TestMethod]
+    public void ValidateDefinitionRejectsInvalidDefinition()
+    {
+        var result = CreatePipelineFactory("pipelineNotUnique").ValidateDefinition();
+
+        Assert.IsFalse(result.IsValid);
+        var message = result.ErrorMessage;
+        Assert.IsNotNull(message);
+        Assert.IsTrue(message.StartsWith("errors in pipeline definition:", StringComparison.Ordinal), message);
+        StringAssert.Contains(message, "Duplicate Id found: ili_validation.");
+    }
+
+    // The definition check returns before any step is inspected, so an operator fixing a broken definition is not
+    // buried in follow-up errors from steps that could not be checked yet. Pinned here so the two phases are not
+    // merged by accident.
+    [TestMethod]
+    public void ValidateDefinitionReportsDefinitionErrorsWithoutProcessErrors()
+    {
+        var result = CreatePipelineFactory("definitionAndProcessErrors").ValidateDefinition();
+
+        Assert.IsFalse(result.IsValid);
+        var message = result.ErrorMessage;
+        Assert.IsNotNull(message);
+        Assert.IsTrue(message.StartsWith("errors in pipeline definition:", StringComparison.Ordinal), message);
+        Assert.IsFalse(
+            message.Contains("Invalid pipeline processes found:", StringComparison.Ordinal),
+            "process errors must not be reported alongside definition errors");
+    }
+
+    private PipelineFactory CreatePipelineFactory(string filename)
+    {
+        var definitionPath = Path.Combine(AppContext.BaseDirectory, "TestData", "Pipeline", filename + ".yaml");
+        var pipelineDirectory = Path.Combine(Path.GetTempPath(), "Pipeline");
+
+        return PipelineFactory
+            .Builder()
+            .File(definitionPath)
+            .PipelineProcessFactory(pipelineProcessFactory)
+            .LoggerFactory(loggerFactoryMock.Object)
+            .PipelineTempDirectory(pipelineDirectory)
+            .Build();
+    }
+}

--- a/tests/Geopilot.Pipeline.Test/TestData/Pipeline/definitionAndProcessErrors.yaml
+++ b/tests/Geopilot.Pipeline.Test/TestData/Pipeline/definitionAndProcessErrors.yaml
@@ -1,0 +1,44 @@
+processes:
+  - id: xtf_matcher
+    implementation: Geopilot.Pipeline.Processes.Matcher.XtfMatcher.XtfMatcherProcess
+    default_config:
+      fileExtensions:
+        - xtf
+  - id: xtf_error_visualizer
+    implementation: Geopilot.Pipeline.Processes.XtfErrorVisualization.XtfErrorVisualizationProcess
+pipelines:
+  - id: bad_pipeline
+    display_name:
+      en: Bad pipeline
+      de: Bad pipeline
+    steps:
+      - id: xtf_matching
+        display_name:
+          en: XTF Matching
+          de: XTF Zuordnung
+        process_id: xtf_matcher
+        input:
+          files: "${upload()}"
+      - id: error_visualization
+        display_name:
+          en: Error Visualization
+          de: Fehlervisualisierung
+        process_id: xtf_error_visualizer
+        input:
+          xtfLog: "${step_output(xtf_matching.StatusMessage)}"
+        output_actions:
+          - property: StatusMessage
+            actions:
+              - StatusMessage
+  - id: bad_pipeline
+    display_name:
+      en: Bad pipeline duplicate
+      de: Bad pipeline duplicate
+    steps:
+      - id: xtf_matching
+        display_name:
+          en: XTF Matching
+          de: XTF Zuordnung
+        process_id: xtf_matcher
+        input:
+          files: "${upload()}"

--- a/tests/Geopilot.Pipeline.Test/TestData/Pipeline/processErrors.yaml
+++ b/tests/Geopilot.Pipeline.Test/TestData/Pipeline/processErrors.yaml
@@ -1,0 +1,32 @@
+processes:
+  - id: xtf_matcher
+    implementation: Geopilot.Pipeline.Processes.Matcher.XtfMatcher.XtfMatcherProcess
+    default_config:
+      fileExtensions:
+        - xtf
+  - id: xtf_error_visualizer
+    implementation: Geopilot.Pipeline.Processes.XtfErrorVisualization.XtfErrorVisualizationProcess
+pipelines:
+  - id: bad_pipeline
+    display_name:
+      en: Bad pipeline
+      de: Bad pipeline
+    steps:
+      - id: xtf_matching
+        display_name:
+          en: XTF Matching
+          de: XTF Zuordnung
+        process_id: xtf_matcher
+        input:
+          files: "${upload()}"
+      - id: error_visualization
+        display_name:
+          en: Error Visualization
+          de: Fehlervisualisierung
+        process_id: xtf_error_visualizer
+        input:
+          xtfLog: "${step_output(xtf_matching.StatusMessage)}"
+        output_actions:
+          - property: StatusMessage
+            actions:
+              - StatusMessage


### PR DESCRIPTION
Closes #897 

Validating the pipeline definition lived in the API project, which had to cast IPipelineFactory to the concrete class to reach the configuration and then assemble the per-step checks itself. The package now answers whether a definition is valid, and the host only calls and decides whether to start.

Behavior is unchanged: same exception type, same messages, and the definition check still returns before any step is inspected, so an operator sees the same output as before.

## Acceptance criteria

**`ValidatePipelineConfiguration` comes without a cast to a concrete class.** It resolves `IPipelineFactory`, calls `ValidateDefinition()` and throws when the result is invalid. The `PipelineFactory is not registered correctly.` branch goes away with the cast that made it necessary; a missing registration is already covered by `GetRequiredService`. `IPipelineProcessFactory` and `IDirectoryProvider` are no longer resolved in startup code, because the factory holds what the check needs.

**An invalid definition still prevents startup, and the message still names all problems at once, with pipeline, step and process.** The two message prefixes, the `HashSet` that collects the per-step errors and the early return after the definition check moved over verbatim, so what is validated and what an operator reads did not change. The host still throws `InvalidOperationException`, so startup still aborts. Checked against the shipped definitions: a broken definition reports every finding of that phase in one message, and a broken process reference reports one line per step naming pipeline, step and process.

**The existing tests for startup validation run unchanged.** `WebApplicationExtensionsTest` is untouched and green. Three tests were added in `Geopilot.Pipeline.Test` for what the move actually made new: that a valid definition yields the valid result, that the definition phase keeps its message prefix, and that the check still stops after the definition phase, which used to be enforced by a `throw` and is now a `return`.

**Recorded whether `InternalsVisibleTo Geopilot.Api` could be dropped.** It cannot, for two reasons that are both out of scope here: the `data is not IVisualization` check in `ProcessingRunner`, and `MapVisualizationBuilder.DefaultBaseMapWmtsCapabilitiesUrl`, which `MapSpaFallback` reads as the default base map for the CSP header and which has nothing to do with validation. This change does remove a third reason: the host no longer calls the internal `PipelineProcessConfig.Validate()` and no longer touches the internal validation error types. `InternalsVisibleTo Geopilot.Api.Test` stays regardless, the visualization serialization and processing runner tests use internal types.