### PR TITLE
Document the single-instance assumption

### DIFF
--- a/src/Geopilot.Api/Processing/ProcessingJobStore.cs
+++ b/src/Geopilot.Api/Processing/ProcessingJobStore.cs
@@ -8,6 +8,14 @@ namespace Geopilot.Api.Processing;
 /// <summary>
 /// Stores, retrieves and updates <see cref="ProcessingJob"/> instances in memory in a thread-safe manner.
 /// </summary>
+/// <remarks>
+/// Jobs and the processing queue are process-local, so the API has to run as exactly one instance. A second
+/// instance does not see the jobs of the first one: a status request routed to the wrong instance answers 404,
+/// so jobs appear to vanish at random while their pipeline runs where nobody asks for it. The state is not
+/// persisted because a running <see cref="IPipeline"/> owns processor instances and temporary directories that
+/// cannot be serialized, so recovery would mean re-running a job from its uploaded files rather than resuming
+/// it. Running more than one instance therefore requires a persisted job store and shared file storage first.
+/// </remarks>
 public class ProcessingJobStore : IProcessingJobStore
 {
     private readonly ConcurrentDictionary<Guid, ProcessingJob> jobs = new();

--- a/src/Geopilot.Api/Processing/UploadStore.cs
+++ b/src/Geopilot.Api/Processing/UploadStore.cs
@@ -6,6 +6,12 @@ namespace Geopilot.Api.Processing;
 /// <summary>
 /// Stores, retrieves and removes <see cref="UploadInfo"/> instances in memory in a thread-safe manner.
 /// </summary>
+/// <remarks>
+/// Uploads are process-local, so the API has to run as exactly one instance. A second instance does not see
+/// the uploads of the first one: starting a job answers 404 for an upload that was initiated elsewhere, even
+/// though its files sit in cloud storage and would be readable from any instance. Only this bookkeeping is in
+/// memory, so scaling the API out means persisting it together with the processing job state.
+/// </remarks>
 public class UploadStore : IUploadStore
 {
     private readonly ConcurrentDictionary<Guid, UploadInfo> uploads = new();


### PR DESCRIPTION
Closes #890

`ProcessingJobStore` und `UploadStore` halten Jobs, Queue und Uploads im Speicher des
API-Prozesses. Diese Betriebsannahme stand bisher nirgends im Code. Beide Klassen tragen jetzt
einen `<remarks>`-Block, der sie benennt und die Folge nennt: Eine zweite Instanz sieht die Jobs
der ersten nicht, Statusabfragen landen auf der falschen Instanz und geben 404, Jobs verschwinden
scheinbar zufällig.

Nur Kommentare, kein Verhalten und keine Signatur geändert, `dotnet build` bleibt ohne Warnungen.
Der Hinweis fürs Hosting ist ein eigener PR in geopilot-hosting.
https://github.com/geowerkstatt/geopilot-hosting/pull/151
## Abweichung vom Akzeptanzkriterium

Die Kommentare verweisen nicht auf die interne Entscheid-Dokumentation, sondern tragen deren
Begründung ausgeschrieben. Ein Kommentar in diesem Repo soll ohne Zugriff auf ein anderes
verständlich sein.