### PR TITLE
Improve job processing robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - The error map in fullscreen can be moved with a single finger and zoomed by scrolling without holding Ctrl (⌘ on macOS). Inline the map keeps asking for two fingers and the modifier key so that it does not swallow the page scroll.
 - Processing job and upload timestamps are now recorded in UTC, so the cleanup retention windows (job, download and visualization) are honored regardless of the container time zone. Previously, with the image default `TZ=Europe/Zurich`, expired downloads and visualizations lingered up to two hours longer than configured.
 - Files can now be selected for upload on iPhone and iPad. When a mandate limits the accepted file types, iOS and iPadOS browsers previously greyed out the matching files (for example `.xtf`) in the native file picker, so a delivery could not be started from those devices.
+- A failure while cleaning up after a processing job no longer stops the instance. When the temporary working directory of a pipeline could not be deleted, because a virus scanner or a process still held a file open, the application shut down and every job running at that moment was lost with it. Such failures are now logged, the leftovers are collected by the job cleanup, and the uploaded files of a job that cannot be delivered are released in any case.
 
 ## v3.0.341 - 2026-06-17
 

--- a/src/Geopilot.Api/FileAccess/AssetHandler.cs
+++ b/src/Geopilot.Api/FileAccess/AssetHandler.cs
@@ -86,7 +86,7 @@ public class AssetHandler : IAssetHandler
 
     private async Task<List<Asset>> PersistPrimaryJobAssetsAsync(ProcessingJob job, CancellationToken cancellationToken)
     {
-        if (job.Files == null || job.Files.Count == 0)
+        if (job.Files.Count == 0)
             throw new InvalidOperationException($"Processing job <{job.Id}> does not have a correctly defined primary data files.");
 
         var assets = new List<Asset>();

--- a/src/Geopilot.Api/Processing/IProcessingJobStore.cs
+++ b/src/Geopilot.Api/Processing/IProcessingJobStore.cs
@@ -51,13 +51,15 @@ public interface IProcessingJobStore
     ProcessingJob MarkAsFailed(Guid jobId);
 
     /// <summary>
-    /// Attempts to mark the job as failed and reports whether it happened, instead of throwing. Returns
-    /// <see langword="false"/> when the job is unknown or already in a terminal state, leaving it untouched.
-    /// This is the variant for error paths: a caller that is itself handling a failure cannot afford a second
-    /// exception, because it escapes to the hosting background service and stops the host instead of recording
-    /// the failure. The throwing <see cref="MarkAsFailed"/> stays correct wherever an invalid transition is a
-    /// programming error that has to surface.
+    /// Marks the job as failed and reports whether it happened, instead of throwing. This is the variant for
+    /// error paths: a caller that is itself handling a failure cannot afford a second exception, because it
+    /// escapes to the hosting background service and stops the host instead of recording the failure. Use the
+    /// throwing <see cref="MarkAsFailed"/> wherever an invalid transition is a programming error that has to
+    /// surface.
     /// </summary>
+    /// <param name="jobId">The job to mark as failed.</param>
+    /// <returns><see langword="true"/> when the job was marked as failed; <see langword="false"/> when it is
+    /// unknown or already in a terminal state, in which case it is left untouched.</returns>
     bool TryMarkAsFailed(Guid jobId);
 
     /// <summary>
@@ -75,11 +77,14 @@ public interface IProcessingJobStore
     ProcessingJob PipelineFinished(Guid jobId, ProcessingState pipelineState);
 
     /// <summary>
-    /// Attempts the terminal transition and reports whether it happened, instead of throwing. Returns
-    /// <see langword="false"/> when the job is unknown, is not in <see cref="ProcessingState.Running"/>, or
-    /// <paramref name="pipelineState"/> is not a terminal state, leaving the job untouched. See
+    /// Transitions the job to its terminal state and reports whether it happened, instead of throwing. See
     /// <see cref="TryMarkAsFailed"/> for when to prefer this over <see cref="PipelineFinished"/>.
     /// </summary>
+    /// <param name="jobId">The job whose pipeline has finished.</param>
+    /// <param name="pipelineState">The terminal state the pipeline ended in.</param>
+    /// <returns><see langword="true"/> when the job was transitioned; <see langword="false"/> when it is
+    /// unknown, is not in <see cref="ProcessingState.Running"/>, or <paramref name="pipelineState"/> is not a
+    /// terminal state, in which case the job is left untouched.</returns>
     bool TryPipelineFinished(Guid jobId, ProcessingState pipelineState);
 
     /// <summary>

--- a/src/Geopilot.Api/Processing/IProcessingJobStore.cs
+++ b/src/Geopilot.Api/Processing/IProcessingJobStore.cs
@@ -51,6 +51,16 @@ public interface IProcessingJobStore
     ProcessingJob MarkAsFailed(Guid jobId);
 
     /// <summary>
+    /// Attempts to mark the job as failed and reports whether it happened, instead of throwing. Returns
+    /// <see langword="false"/> when the job is unknown or already in a terminal state, leaving it untouched.
+    /// This is the variant for error paths: a caller that is itself handling a failure cannot afford a second
+    /// exception, because it escapes to the hosting background service and stops the host instead of recording
+    /// the failure. The throwing <see cref="MarkAsFailed"/> stays correct wherever an invalid transition is a
+    /// programming error that has to surface.
+    /// </summary>
+    bool TryMarkAsFailed(Guid jobId);
+
+    /// <summary>
     /// Transitions the job to its terminal state based on the state the pipeline finished in.
     /// </summary>
     /// <param name="jobId">The job whose pipeline has finished.</param>
@@ -63,6 +73,14 @@ public interface IProcessingJobStore
     /// <exception cref="ArgumentOutOfRangeException">If <paramref name="pipelineState"/> is not a terminal state.</exception>
     /// <exception cref="InvalidOperationException">If the job is not in <see cref="ProcessingState.Running"/>.</exception>
     ProcessingJob PipelineFinished(Guid jobId, ProcessingState pipelineState);
+
+    /// <summary>
+    /// Attempts the terminal transition and reports whether it happened, instead of throwing. Returns
+    /// <see langword="false"/> when the job is unknown, is not in <see cref="ProcessingState.Running"/>, or
+    /// <paramref name="pipelineState"/> is not a terminal state, leaving the job untouched. See
+    /// <see cref="TryMarkAsFailed"/> for when to prefer this over <see cref="PipelineFinished"/>.
+    /// </summary>
+    bool TryPipelineFinished(Guid jobId, ProcessingState pipelineState);
 
     /// <summary>
     /// Associates the given <paramref name="pipeline"/> with the job at creation time, without queuing it.

--- a/src/Geopilot.Api/Processing/ProcessingJob.cs
+++ b/src/Geopilot.Api/Processing/ProcessingJob.cs
@@ -1,4 +1,5 @@
 ﻿using Geopilot.Pipeline;
+using System.Collections.Immutable;
 
 namespace Geopilot.Api.Processing;
 
@@ -10,10 +11,17 @@ namespace Geopilot.Api.Processing;
 public record class ProcessingJob(
     Guid Id,
     Guid UploadId,
-    List<ProcessingJobFile> Files,
     int? MandateId,
     DateTime CreatedAt)
 {
+    /// <summary>
+    /// The uploaded files staged for this job, in the order they were added. Files are only added while the
+    /// job is still pending, but the collection is read while the run is under way, so it is immutable:
+    /// adding a file replaces it instead of mutating it, and a reader iterates a snapshot that cannot change
+    /// underneath it.
+    /// </summary>
+    public ImmutableList<ProcessingJobFile> Files { get; init; } = ImmutableList<ProcessingJobFile>.Empty;
+
     /// <summary>
     /// The pipeline associated with this job. Instantiated when the job is created (before its files are staged)
     /// and started once staging completes, so consumers can render the pipeline's steps while preflight runs.

--- a/src/Geopilot.Api/Processing/ProcessingJob.cs
+++ b/src/Geopilot.Api/Processing/ProcessingJob.cs
@@ -15,10 +15,9 @@ public record class ProcessingJob(
     DateTime CreatedAt)
 {
     /// <summary>
-    /// The uploaded files staged for this job, in the order they were added. Files are only added while the
-    /// job is still pending, but the collection is read while the run is under way, so it is immutable:
-    /// adding a file replaces it instead of mutating it, and a reader iterates a snapshot that cannot change
-    /// underneath it.
+    /// The uploaded files staged for this job, in the order they were added. Files are added only while the
+    /// job is still pending, while the collection is read throughout the run, so it is immutable: adding a
+    /// file yields a new collection, and a reader iterates a snapshot that cannot change underneath it.
     /// </summary>
     public ImmutableList<ProcessingJobFile> Files { get; init; } = ImmutableList<ProcessingJobFile>.Empty;
 

--- a/src/Geopilot.Api/Processing/ProcessingJobStore.cs
+++ b/src/Geopilot.Api/Processing/ProcessingJobStore.cs
@@ -66,7 +66,7 @@ public class ProcessingJobStore : IProcessingJobStore
             id => throw new ArgumentException($"Job with id <{id}> not found.", nameof(jobId)),
             (id, currentJob) =>
             {
-                if (currentJob.State is not (ProcessingState.Pending or ProcessingState.Running))
+                if (!CanMarkAsFailed(currentJob))
                 {
                     throw new InvalidOperationException(
                         $"Cannot transition job <{id}> from <{currentJob.State}> to <{ProcessingState.Failed}>.");
@@ -77,9 +77,13 @@ public class ProcessingJobStore : IProcessingJobStore
     }
 
     /// <inheritdoc/>
+    public bool TryMarkAsFailed(Guid jobId) =>
+        TryTransition(jobId, CanMarkAsFailed, ProcessingState.Failed);
+
+    /// <inheritdoc/>
     public ProcessingJob PipelineFinished(Guid jobId, ProcessingState pipelineState)
     {
-        if (pipelineState is not (ProcessingState.Success or ProcessingState.Warning or ProcessingState.DeliveryRestriction or ProcessingState.Failed or ProcessingState.Cancelled))
+        if (!IsTerminal(pipelineState))
         {
             throw new ArgumentOutOfRangeException(
                 nameof(pipelineState),
@@ -92,7 +96,7 @@ public class ProcessingJobStore : IProcessingJobStore
             id => throw new ArgumentException($"Job with id <{id}> not found.", nameof(jobId)),
             (id, currentJob) =>
             {
-                if (currentJob.State != ProcessingState.Running)
+                if (!CanCompletePipeline(currentJob))
                 {
                     throw new InvalidOperationException(
                         $"Cannot transition job <{id}> from <{currentJob.State}> to <{pipelineState}>.");
@@ -101,6 +105,10 @@ public class ProcessingJobStore : IProcessingJobStore
                 return currentJob with { State = pipelineState };
             });
     }
+
+    /// <inheritdoc/>
+    public bool TryPipelineFinished(Guid jobId, ProcessingState pipelineState) =>
+        IsTerminal(pipelineState) && TryTransition(jobId, CanCompletePipeline, pipelineState);
 
     /// <inheritdoc/>
     public ProcessingJob AttachPipeline(Guid jobId, IPipeline pipeline, int mandateId)
@@ -152,6 +160,36 @@ public class ProcessingJobStore : IProcessingJobStore
         // Idempotent dispose handles the case where the runner already disposed after extracting.
         removed.Pipeline?.Dispose();
         return true;
+    }
+
+    private static bool IsTerminal(ProcessingState state) =>
+        state is ProcessingState.Success or ProcessingState.Warning or ProcessingState.DeliveryRestriction
+            or ProcessingState.Failed or ProcessingState.Cancelled;
+
+    private static bool CanMarkAsFailed(ProcessingJob job) =>
+        job.State is ProcessingState.Pending or ProcessingState.Running;
+
+    private static bool CanCompletePipeline(ProcessingJob job) =>
+        job.State == ProcessingState.Running;
+
+    /// <summary>
+    /// Applies <paramref name="newState"/> when <paramref name="isAllowed"/> accepts the job's current state,
+    /// retrying against the freshly read job whenever a concurrent write wins the compare-and-swap. Reports the
+    /// outcome rather than throwing, so a caller that is already handling a failure cannot make it worse. The
+    /// transition rules are shared with the throwing operations, so both variants can never drift apart.
+    /// </summary>
+    private bool TryTransition(Guid jobId, Func<ProcessingJob, bool> isAllowed, ProcessingState newState)
+    {
+        while (jobs.TryGetValue(jobId, out var currentJob))
+        {
+            if (!isAllowed(currentJob))
+                return false;
+
+            if (jobs.TryUpdate(jobId, currentJob with { State = newState }, currentJob))
+                return true;
+        }
+
+        return false;
     }
 
     private static void EnsureJobIsPrePipeline(Guid jobId, ProcessingJob job, string operation)

--- a/src/Geopilot.Api/Processing/ProcessingJobStore.cs
+++ b/src/Geopilot.Api/Processing/ProcessingJobStore.cs
@@ -53,9 +53,8 @@ public class ProcessingJobStore : IProcessingJobStore
             id => throw new ArgumentException($"Job with id <{id}> not found.", nameof(jobId)),
             (id, currentJob) =>
             {
-                // The factory has to stay free of side effects: AddOrUpdate re-runs it against the freshly
-                // read job whenever the compare-and-swap loses a race, so appending to a shared list here
-                // would add the same file more than once.
+                // AddOrUpdate re-runs this factory against the freshly read job whenever its
+                // compare-and-swap loses a race, so the factory must be free of side effects.
                 EnsureJobIsPending(id, currentJob, "add file");
                 return currentJob with { Files = currentJob.Files.Add(file) };
             });
@@ -178,8 +177,7 @@ public class ProcessingJobStore : IProcessingJobStore
     /// <summary>
     /// Applies <paramref name="newState"/> when <paramref name="isAllowed"/> accepts the job's current state,
     /// retrying against the freshly read job whenever a concurrent write wins the compare-and-swap. Reports the
-    /// outcome rather than throwing, so a caller that is already handling a failure cannot make it worse. The
-    /// transition rules are shared with the throwing operations, so both variants can never drift apart.
+    /// outcome rather than throwing, so a caller that is already handling a failure cannot make it worse.
     /// </summary>
     private bool TryTransition(Guid jobId, Func<ProcessingJob, bool> isAllowed, ProcessingState newState)
     {

--- a/src/Geopilot.Api/Processing/ProcessingJobStore.cs
+++ b/src/Geopilot.Api/Processing/ProcessingJobStore.cs
@@ -36,7 +36,6 @@ public class ProcessingJobStore : IProcessingJobStore
         var newJob = new ProcessingJob(
             Id: Guid.NewGuid(),
             UploadId: uploadId,
-            Files: new List<ProcessingJobFile>(),
             MandateId: null,
             CreatedAt: DateTime.UtcNow);
 
@@ -47,14 +46,18 @@ public class ProcessingJobStore : IProcessingJobStore
     /// <inheritdoc/>
     public ProcessingJob AddFileToJob(Guid jobId, string originalFileName, string tempFileName, string storageKey)
     {
+        var file = new ProcessingJobFile(originalFileName, tempFileName, storageKey);
+
         return jobs.AddOrUpdate(
             jobId,
             id => throw new ArgumentException($"Job with id <{id}> not found.", nameof(jobId)),
             (id, currentJob) =>
             {
+                // The factory has to stay free of side effects: AddOrUpdate re-runs it against the freshly
+                // read job whenever the compare-and-swap loses a race, so appending to a shared list here
+                // would add the same file more than once.
                 EnsureJobIsPending(id, currentJob, "add file");
-                currentJob.Files.Add(new ProcessingJobFile(originalFileName, tempFileName, storageKey));
-                return currentJob;
+                return currentJob with { Files = currentJob.Files.Add(file) };
             });
     }
 

--- a/src/Geopilot.Api/Processing/ProcessingRunner.cs
+++ b/src/Geopilot.Api/Processing/ProcessingRunner.cs
@@ -5,7 +5,6 @@ using Geopilot.Pipeline.Config;
 using Geopilot.Pipeline.Visualization;
 using Geopilot.PipelineCore.Pipeline;
 using Microsoft.Extensions.Options;
-using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -101,13 +100,33 @@ public class ProcessingRunner : BackgroundService
             }
             finally
             {
-                // Free process-owned resources (e.g. HttpClient) immediately. Pipeline state, step
-                // states, status-message dictionaries and PersistedDownloads survive disposal; what
-                // goes is the pipeline's temp directory, including the uploaded files fetched into it
-                // during the run.
-                pipeline.Dispose();
+                // Both cleanup steps run unconditionally and each one is guarded on its own. This is the
+                // body of a Parallel.ForEachAsync inside a BackgroundService: an exception escaping here
+                // aborts the whole loop, so the queue stops draining, and by default it stops the host.
+                // A shared guard would make releasing the upload depend on the disposal succeeding.
+                try
+                {
+                    // Free process-owned resources (e.g. HttpClient) immediately. Pipeline state, step
+                    // states, status-message dictionaries and PersistedDownloads survive disposal; what
+                    // goes is the pipeline's temp directory, including the uploaded files fetched into it
+                    // during the run.
+                    pipeline.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Failed to dispose pipeline <{Pipeline}>.", pipeline.Id);
+                }
 
-                await ReleaseUploadIfNotDeliverableAsync(pipeline.JobId);
+                try
+                {
+                    await ReleaseUploadIfNotDeliverableAsync(pipeline.JobId);
+                }
+                catch (Exception ex)
+                {
+                    // The upload store is remote, so releasing it is a network call. The age-based sweep
+                    // in UploadCleanupService is the backstop for blobs left behind here.
+                    logger.LogError(ex, "Failed to release the upload of job <{JobId}>.", pipeline.JobId);
+                }
             }
         });
     }

--- a/src/Geopilot.Api/Processing/ProcessingRunner.cs
+++ b/src/Geopilot.Api/Processing/ProcessingRunner.cs
@@ -86,7 +86,11 @@ public class ProcessingRunner : BackgroundService
                 // in-flight step's files are lost, and no delivery files are persisted (delivery is staged
                 // only for a successful, deliverable run).
                 logger.LogError("Pipeline <{Pipeline}> timed out after {Timeout}.", pipeline.Id, processingOptions.JobTimeout);
-                jobStore.PipelineFinished(pipeline.JobId, ProcessingState.Cancelled);
+
+                // Tolerant variant: a throwing transition would escape this catch block and take the whole
+                // loop, and by default the host, down instead of recording the timeout.
+                if (!jobStore.TryPipelineFinished(pipeline.JobId, ProcessingState.Cancelled))
+                    logger.LogWarning("Job <{JobId}> was not transitioned to <{State}>: it is unknown or no longer running.", pipeline.JobId, ProcessingState.Cancelled);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -96,7 +100,9 @@ public class ProcessingRunner : BackgroundService
             catch (Exception ex)
             {
                 logger.LogError(ex, "Unexpected error while running pipeline <{Pipeline}>.", pipeline.Id);
-                jobStore.MarkAsFailed(pipeline.JobId);
+
+                if (!jobStore.TryMarkAsFailed(pipeline.JobId))
+                    logger.LogWarning("Job <{JobId}> was not marked as failed: it is unknown or already in a terminal state.", pipeline.JobId);
             }
             finally
             {

--- a/src/Geopilot.Api/Processing/ProcessingRunner.cs
+++ b/src/Geopilot.Api/Processing/ProcessingRunner.cs
@@ -87,8 +87,8 @@ public class ProcessingRunner : BackgroundService
                 // only for a successful, deliverable run).
                 logger.LogError("Pipeline <{Pipeline}> timed out after {Timeout}.", pipeline.Id, processingOptions.JobTimeout);
 
-                // Tolerant variant: a throwing transition would escape this catch block and take the whole
-                // loop, and by default the host, down instead of recording the timeout.
+                // Nothing above this catch block handles an exception, so the reporting variant keeps
+                // an unexpected job state in the log instead of stopping the host.
                 if (!jobStore.TryPipelineFinished(pipeline.JobId, ProcessingState.Cancelled))
                     logger.LogWarning("Job <{JobId}> was not transitioned to <{State}>: it is unknown or no longer running.", pipeline.JobId, ProcessingState.Cancelled);
             }
@@ -106,10 +106,10 @@ public class ProcessingRunner : BackgroundService
             }
             finally
             {
-                // Both cleanup steps run unconditionally and each one is guarded on its own. This is the
-                // body of a Parallel.ForEachAsync inside a BackgroundService: an exception escaping here
-                // aborts the whole loop, so the queue stops draining, and by default it stops the host.
-                // A shared guard would make releasing the upload depend on the disposal succeeding.
+                // This is the body of a Parallel.ForEachAsync inside a BackgroundService: an exception
+                // escaping here aborts the whole loop, so the queue stops draining, and by default it
+                // stops the host. Each cleanup step is guarded on its own, so releasing the upload is
+                // independent of the disposal.
                 try
                 {
                     // Free process-owned resources (e.g. HttpClient) immediately. Pipeline state, step

--- a/src/Geopilot.Api/Services/PreflightBackgroundService.cs
+++ b/src/Geopilot.Api/Services/PreflightBackgroundService.cs
@@ -73,16 +73,17 @@ public class PreflightBackgroundService : BackgroundService
         {
             logger.LogError(ex, "Preflight failed for job <{JobId}>.", request.JobId);
 
+            if (!jobStore.TryMarkAsFailed(request.JobId))
+                logger.LogWarning("Job <{JobId}> was not marked as failed: it is unknown or already in a terminal state.", request.JobId);
+
             try
             {
-                jobStore.MarkAsFailed(request.JobId);
-
                 // The pipeline was instantiated up front but never queued, so the runner will not dispose it.
                 job.Pipeline?.Dispose();
             }
-            catch (Exception statusEx)
+            catch (Exception disposeEx)
             {
-                logger.LogError(statusEx, "Failed to mark job <{JobId}> as failed.", request.JobId);
+                logger.LogError(disposeEx, "Failed to dispose the pipeline of job <{JobId}>.", request.JobId);
             }
 
             try

--- a/src/Geopilot.Pipeline/Pipeline.cs
+++ b/src/Geopilot.Pipeline/Pipeline.cs
@@ -18,12 +18,31 @@ internal sealed class Pipeline : IPipeline
         if (disposed)
             return;
 
-        Steps.ForEach(step => step.Dispose());
-
-        if (Path.Exists(pipelineFileDirectory))
-            Directory.Delete(pipelineFileDirectory, true);
-
+        // Set before the cleanup, not after: a partially failed cleanup must not make Dispose
+        // re-entrant, or a later RemoveJob disposes every step a second time.
         disposed = true;
+
+        foreach (var step in Steps)
+        {
+            try
+            {
+                step.Dispose();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to dispose step <{Step}> of pipeline <{Pipeline}>.", step.Id, Id);
+            }
+        }
+
+        try
+        {
+            if (Path.Exists(pipelineFileDirectory))
+                Directory.Delete(pipelineFileDirectory, true);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to delete the working directory <{Directory}> of pipeline <{Pipeline}>.", pipelineFileDirectory, Id);
+        }
     }
 
     private readonly string pipelineFileDirectory;

--- a/src/Geopilot.Pipeline/Pipeline.cs
+++ b/src/Geopilot.Pipeline/Pipeline.cs
@@ -18,8 +18,8 @@ internal sealed class Pipeline : IPipeline
         if (disposed)
             return;
 
-        // Set before the cleanup, not after: a partially failed cleanup must not make Dispose
-        // re-entrant, or a later RemoveJob disposes every step a second time.
+        // Marked as disposed ahead of the cleanup below, so that a cleanup which partially fails
+        // still leaves Dispose idempotent for the second call RemoveJob may make.
         disposed = true;
 
         foreach (var step in Steps)

--- a/tests/Geopilot.Api.Test/Controllers/DeliveryControllerTest.cs
+++ b/tests/Geopilot.Api.Test/Controllers/DeliveryControllerTest.cs
@@ -421,8 +421,9 @@ public class DeliveryControllerTest
         pipelineMock.SetupGet(p => p.Steps).Returns(new List<IPipelineStep>());
         pipelineMock.SetupGet(p => p.DisplayName).Returns(LocalizedText.Empty);
 
-        var job = new ProcessingJob(guid, Guid.NewGuid(), new List<ProcessingJobFile> { new ProcessingJobFile("ORIGINAL.zip", "TEMP.zip", "uploads/upload/" + "ORIGINAL.zip") }, mandateId, DateTime.Now)
+        var job = new ProcessingJob(guid, Guid.NewGuid(), mandateId, DateTime.Now)
         {
+            Files = [new ProcessingJobFile("ORIGINAL.zip", "TEMP.zip", "uploads/upload/" + "ORIGINAL.zip")],
             Pipeline = pipelineMock.Object,
         };
 

--- a/tests/Geopilot.Api.Test/Controllers/MandateControllerTest.cs
+++ b/tests/Geopilot.Api.Test/Controllers/MandateControllerTest.cs
@@ -319,8 +319,9 @@ namespace Geopilot.Api.Controllers
             pipelineMock.SetupGet(p => p.Steps).Returns(new List<IPipelineStep>());
             pipelineMock.SetupGet(p => p.DisplayName).Returns(LocalizedText.Empty);
 
-            var processingJob = new ProcessingJob(guid, Guid.NewGuid(), new List<ProcessingJobFile>() { new ProcessingJobFile("ORIGINAL.zip", "TEMP.zip", "uploads/upload/" + "ORIGINAL.zip") }, mandateToUpdate.Id, DateTime.Now)
+            var processingJob = new ProcessingJob(guid, Guid.NewGuid(), mandateToUpdate.Id, DateTime.Now)
             {
+                Files = [new ProcessingJobFile("ORIGINAL.zip", "TEMP.zip", "uploads/upload/" + "ORIGINAL.zip")],
                 Pipeline = pipelineMock.Object,
             };
 

--- a/tests/Geopilot.Api.Test/Controllers/ProcessingControllerTest.cs
+++ b/tests/Geopilot.Api.Test/Controllers/ProcessingControllerTest.cs
@@ -62,7 +62,10 @@ public sealed class ProcessingControllerTest
 
         validationServiceMock
             .Setup(x => x.GetJob(jobId))
-            .Returns(new ProcessingJob(jobId, Guid.NewGuid(), new List<ProcessingJobFile>() { new ProcessingJobFile("BIZARRESCAN.xtf", "TEMP.xtf", "uploads/upload/" + "BIZARRESCAN.xtf") }, mandateId, DateTime.Now));
+            .Returns(new ProcessingJob(jobId, Guid.NewGuid(), mandateId, DateTime.Now)
+            {
+                Files = [new ProcessingJobFile("BIZARRESCAN.xtf", "TEMP.xtf", "uploads/upload/" + "BIZARRESCAN.xtf")],
+            });
 
         var response = controller.GetStatus(jobId) as OkObjectResult;
         var jobResponse = response?.Value as ProcessingJobResponse;
@@ -165,9 +168,11 @@ public sealed class ProcessingControllerTest
         var processingJob = new ProcessingJob(
             jobId,
             Guid.NewGuid(),
-            new List<ProcessingJobFile>() { new ProcessingJobFile("test.xtf", "temp.xtf", "uploads/upload/" + "test.xtf") },
             mandate.Id,
-            DateTime.Now);
+            DateTime.Now)
+        {
+            Files = [new ProcessingJobFile("test.xtf", "temp.xtf", "uploads/upload/" + "test.xtf")],
+        };
 
         validationServiceMock.Setup(x => x.StartJobAsync(uploadId, mandate.Id, user)).ReturnsAsync(processingJob);
 
@@ -217,9 +222,11 @@ public sealed class ProcessingControllerTest
         var processingJob = new ProcessingJob(
             jobId,
             Guid.NewGuid(),
-            new List<ProcessingJobFile>() { new ProcessingJobFile("test.xtf", "temp.xtf", "uploads/upload/" + "test.xtf") },
             publicMandate.Entity.Id,
-            DateTime.Now);
+            DateTime.Now)
+        {
+            Files = [new ProcessingJobFile("test.xtf", "temp.xtf", "uploads/upload/" + "test.xtf")],
+        };
 
         validationServiceMock.Setup(x => x.StartJobAsync(uploadId, publicMandate.Entity.Id, It.IsAny<User?>())).ReturnsAsync(processingJob);
 
@@ -352,6 +359,6 @@ public sealed class ProcessingControllerTest
         stepMock.SetupGet(s => s.DeliveryFiles).Returns(deliveryFiles);
         var pipelineMock = new Mock<IPipeline>();
         pipelineMock.SetupGet(p => p.Steps).Returns(new List<IPipelineStep> { stepMock.Object });
-        return new ProcessingJob(jobId, Guid.NewGuid(), new List<ProcessingJobFile>(), null, DateTime.Now) { Pipeline = pipelineMock.Object };
+        return new ProcessingJob(jobId, Guid.NewGuid(), null, DateTime.Now) { Pipeline = pipelineMock.Object };
     }
 }

--- a/tests/Geopilot.Api.Test/DtoMapperExtensionsTest.cs
+++ b/tests/Geopilot.Api.Test/DtoMapperExtensionsTest.cs
@@ -108,7 +108,7 @@ public class DtoMapperExtensionsTest
     }
 
     private static ProcessingJob BuildJob(ProcessingState state, IPipeline? pipeline) =>
-        new(Guid.NewGuid(), Guid.NewGuid(), new List<ProcessingJobFile>(), 1, DateTime.Now) { Pipeline = pipeline, State = state };
+        new(Guid.NewGuid(), Guid.NewGuid(), 1, DateTime.Now) { Pipeline = pipeline, State = state };
 
     private static IPipeline BuildPipeline(ProcessingState state, params string[] stepIds)
     {

--- a/tests/Geopilot.Api.Test/FileAccess/AssetHandlerTest.cs
+++ b/tests/Geopilot.Api.Test/FileAccess/AssetHandlerTest.cs
@@ -124,9 +124,11 @@ public class AssetHandlerTest
         => new ProcessingJob(
             jobId ?? Guid.NewGuid(),
             Guid.NewGuid(),
-            new List<ProcessingJobFile> { new ProcessingJobFile("OriginalName", "TempFileName", "uploads/key/OriginalName") },
             null,
-            DateTime.Now);
+            DateTime.Now)
+        {
+            Files = [new ProcessingJobFile("OriginalName", "TempFileName", "uploads/key/OriginalName")],
+        };
 
     private static IPipeline BuildPipelineWithDeliveryFiles(string stepId, List<PersistedFile> deliveryFiles)
     {

--- a/tests/Geopilot.Api.Test/Processing/ProcessingJobCleanupServiceTest.cs
+++ b/tests/Geopilot.Api.Test/Processing/ProcessingJobCleanupServiceTest.cs
@@ -131,7 +131,6 @@ public class ProcessingJobCleanupServiceTest
         var oldJob = new ProcessingJob(
             jobId,
             Guid.NewGuid(),
-            new List<ProcessingJobFile>(),
             null,
             DateTime.UtcNow.AddHours(-JobRetentionHours - 1))
         {
@@ -161,7 +160,6 @@ public class ProcessingJobCleanupServiceTest
         var oldJob = new ProcessingJob(
             jobId,
             Guid.NewGuid(),
-            new List<ProcessingJobFile>(),
             null,
             DateTime.UtcNow.AddHours(-JobRetentionHours - 1))
         {
@@ -188,7 +186,6 @@ public class ProcessingJobCleanupServiceTest
         var partlyExpiredJob = new ProcessingJob(
             jobId,
             Guid.NewGuid(),
-            new List<ProcessingJobFile>(),
             null,
             DateTime.UtcNow.AddHours(-(DownloadRetentionHours + 1)));
 
@@ -211,7 +208,6 @@ public class ProcessingJobCleanupServiceTest
         var partlyExpiredJob = new ProcessingJob(
             jobId,
             Guid.NewGuid(),
-            new List<ProcessingJobFile>(),
             null,
             DateTime.UtcNow.AddHours(-(VisualizationRetentionHours + 0.25)));
 
@@ -235,7 +231,6 @@ public class ProcessingJobCleanupServiceTest
         var oldJob = new ProcessingJob(
             jobId,
             uploadId,
-            new List<ProcessingJobFile>(),
             null,
             DateTime.UtcNow.AddHours(-JobRetentionHours - 1))
         {
@@ -260,7 +255,6 @@ public class ProcessingJobCleanupServiceTest
         var oldJob = new ProcessingJob(
             jobId,
             uploadId,
-            new List<ProcessingJobFile>(),
             null,
             DateTime.UtcNow.AddHours(-JobRetentionHours - 1))
         {
@@ -291,7 +285,6 @@ public class ProcessingJobCleanupServiceTest
         var stuckJob = new ProcessingJob(
             jobId,
             uploadId,
-            new List<ProcessingJobFile>(),
             null,
             DateTime.UtcNow.AddHours(-JobRetentionHours - 1))
         {
@@ -322,7 +315,6 @@ public class ProcessingJobCleanupServiceTest
         var freshJob = new ProcessingJob(
             jobId,
             Guid.NewGuid(),
-            new List<ProcessingJobFile>(),
             null,
             DateTime.UtcNow);
 

--- a/tests/Geopilot.Api.Test/Processing/ProcessingJobStoreTest.cs
+++ b/tests/Geopilot.Api.Test/Processing/ProcessingJobStoreTest.cs
@@ -76,8 +76,8 @@ public class ProcessingJobStoreTest
 
         Parallel.For(0, fileCount, i => store.AddFileToJob(job.Id, $"file_{i}.xtf", $"temp_{i}.xtf", $"uploads/key/file_{i}.xtf"));
 
-        // AddOrUpdate re-runs its update factory whenever the compare-and-swap loses a race, so a factory
-        // with a side effect drops or duplicates files exactly here.
+        // Concurrent calls make AddOrUpdate re-run its update factory, so this pins that the factory
+        // contributes each file exactly once no matter how often it runs.
         var files = store.GetJob(job.Id)!.Files;
         Assert.HasCount(fileCount, files);
         Assert.HasCount(fileCount, files.Select(f => f.OriginalFileName).Distinct().ToList(), "No file may be added twice.");

--- a/tests/Geopilot.Api.Test/Processing/ProcessingJobStoreTest.cs
+++ b/tests/Geopilot.Api.Test/Processing/ProcessingJobStoreTest.cs
@@ -69,6 +69,21 @@ public class ProcessingJobStoreTest
     }
 
     [TestMethod]
+    public void AddFileToJobUnderConcurrencyAddsEachFileExactlyOnce()
+    {
+        const int fileCount = 100;
+        var job = store.CreateJob(Guid.NewGuid());
+
+        Parallel.For(0, fileCount, i => store.AddFileToJob(job.Id, $"file_{i}.xtf", $"temp_{i}.xtf", $"uploads/key/file_{i}.xtf"));
+
+        // AddOrUpdate re-runs its update factory whenever the compare-and-swap loses a race, so a factory
+        // with a side effect drops or duplicates files exactly here.
+        var files = store.GetJob(job.Id)!.Files;
+        Assert.HasCount(fileCount, files);
+        Assert.HasCount(fileCount, files.Select(f => f.OriginalFileName).Distinct().ToList(), "No file may be added twice.");
+    }
+
+    [TestMethod]
     public void AddFileToJobThrowsIfJobNotFound()
     {
         Assert.ThrowsExactly<ArgumentException>(() => store.AddFileToJob(Guid.NewGuid(), "a", "b", "uploads/upload/a"));

--- a/tests/Geopilot.Api.Test/Processing/ProcessingJobStoreTest.cs
+++ b/tests/Geopilot.Api.Test/Processing/ProcessingJobStoreTest.cs
@@ -255,6 +255,77 @@ public class ProcessingJobStoreTest
     }
 
     [TestMethod]
+    public void TryMarkAsFailedSetsState()
+    {
+        var job = store.CreateJob(Guid.NewGuid());
+
+        Assert.IsTrue(store.TryMarkAsFailed(job.Id));
+        Assert.AreEqual(ProcessingState.Failed, store.GetJob(job.Id)!.State);
+    }
+
+    [TestMethod]
+    public void TryMarkAsFailedReturnsFalseIfAlreadyTerminal()
+    {
+        var job = store.CreateJob(Guid.NewGuid());
+        store.AttachPipeline(job.Id, new Mock<IPipeline>().Object, 1);
+        store.EnqueueForProcessing(job.Id, Array.Empty<IPipelineFile>());
+        store.PipelineFinished(job.Id, ProcessingState.Success);
+
+        Assert.IsFalse(store.TryMarkAsFailed(job.Id));
+        Assert.AreEqual(ProcessingState.Success, store.GetJob(job.Id)!.State, "A rejected transition must leave the job untouched.");
+    }
+
+    [TestMethod]
+    public void TryMarkAsFailedReturnsFalseIfJobNotFound()
+    {
+        Assert.IsFalse(store.TryMarkAsFailed(Guid.NewGuid()));
+    }
+
+    [TestMethod]
+    [DataRow(ProcessingState.Success)]
+    [DataRow(ProcessingState.Warning)]
+    [DataRow(ProcessingState.DeliveryRestriction)]
+    [DataRow(ProcessingState.Failed)]
+    [DataRow(ProcessingState.Cancelled)]
+    public void TryPipelineFinishedTransitionsFromRunning(ProcessingState pipelineState)
+    {
+        var job = store.CreateJob(Guid.NewGuid());
+        store.AttachPipeline(job.Id, new Mock<IPipeline>().Object, 1);
+        store.EnqueueForProcessing(job.Id, Array.Empty<IPipelineFile>());
+
+        Assert.IsTrue(store.TryPipelineFinished(job.Id, pipelineState));
+        Assert.AreEqual(pipelineState, store.GetJob(job.Id)!.State);
+    }
+
+    [TestMethod]
+    public void TryPipelineFinishedReturnsFalseIfNotRunning()
+    {
+        var job = store.CreateJob(Guid.NewGuid());
+
+        Assert.IsFalse(store.TryPipelineFinished(job.Id, ProcessingState.Success));
+        Assert.AreEqual(ProcessingState.Pending, store.GetJob(job.Id)!.State, "A rejected transition must leave the job untouched.");
+    }
+
+    [TestMethod]
+    [DataRow(ProcessingState.Pending)]
+    [DataRow(ProcessingState.Running)]
+    public void TryPipelineFinishedReturnsFalseIfPipelineStateIsNotTerminal(ProcessingState pipelineState)
+    {
+        var job = store.CreateJob(Guid.NewGuid());
+        store.AttachPipeline(job.Id, new Mock<IPipeline>().Object, 1);
+        store.EnqueueForProcessing(job.Id, Array.Empty<IPipelineFile>());
+
+        Assert.IsFalse(store.TryPipelineFinished(job.Id, pipelineState));
+        Assert.AreEqual(ProcessingState.Running, store.GetJob(job.Id)!.State);
+    }
+
+    [TestMethod]
+    public void TryPipelineFinishedReturnsFalseIfJobNotFound()
+    {
+        Assert.IsFalse(store.TryPipelineFinished(Guid.NewGuid(), ProcessingState.Success));
+    }
+
+    [TestMethod]
     public void RemoveJobDisposesPipeline()
     {
         var job = store.CreateJob(Guid.NewGuid());

--- a/tests/Geopilot.Api.Test/Processing/ProcessingRunnerTest.cs
+++ b/tests/Geopilot.Api.Test/Processing/ProcessingRunnerTest.cs
@@ -339,7 +339,7 @@ public class ProcessingRunnerTest
         var step1 = BuildEmittingStep("step_1", "log", "first.log", "first-content", OutputAction.Download);
         var step2 = BuildBlockingStep("step_2", gate.Task);
         using var pipeline = BuildPipeline(jobId, step1, step2);
-        var job = new ProcessingJob(jobId, Guid.NewGuid(), new List<ProcessingJobFile>(), 1, DateTime.UtcNow) { Pipeline = pipeline };
+        var job = new ProcessingJob(jobId, Guid.NewGuid(), 1, DateTime.UtcNow) { Pipeline = pipeline };
 
         var (runner, store) = CreateRunnerWithStore(pipeline);
 
@@ -754,7 +754,7 @@ public class ProcessingRunnerTest
             Options.Create(new ProcessingOptions { JobTimeout = jobTimeout ?? TimeSpan.FromMinutes(5) }));
 
     private static ProcessingJob FinishedJob(Guid jobId, Guid uploadId, ProcessingState state)
-        => new ProcessingJob(jobId, uploadId, new List<ProcessingJobFile>(), 1, DateTime.UtcNow) { State = state };
+        => new ProcessingJob(jobId, uploadId, 1, DateTime.UtcNow) { State = state };
 
     private (ProcessingRunner Runner, Mock<IProcessingJobStore> Store) CreateRunnerWithStore(IPipeline pipeline, TimeSpan? jobTimeout = null)
     {

--- a/tests/Geopilot.Api.Test/Processing/ProcessingRunnerTest.cs
+++ b/tests/Geopilot.Api.Test/Processing/ProcessingRunnerTest.cs
@@ -394,7 +394,7 @@ public class ProcessingRunnerTest
 
         Assert.HasCount(1, step1.Downloads);
         Assert.IsTrue(downloadStore.Exists(jobId, step1.Downloads[0].PersistedFileName), "Earlier step's download must survive a later step failure.");
-        store.Verify(s => s.MarkAsFailed(jobId), Times.Once);
+        store.Verify(s => s.TryMarkAsFailed(jobId), Times.Once);
     }
 
     [TestMethod]
@@ -422,7 +422,7 @@ public class ProcessingRunnerTest
 
         Assert.HasCount(1, step1.Downloads);
         Assert.IsTrue(downloadStore.Exists(jobId, step1.Downloads[0].PersistedFileName), "Pre-timeout step's download must survive the job timeout.");
-        store.Verify(s => s.PipelineFinished(jobId, ProcessingState.Cancelled), Times.Once);
+        store.Verify(s => s.TryPipelineFinished(jobId, ProcessingState.Cancelled), Times.Once);
     }
 
     [TestMethod]
@@ -646,6 +646,58 @@ public class ProcessingRunnerTest
             "The uploaded blobs of a non-deliverable run must be released even when disposing the pipeline failed.");
     }
 
+    [TestMethod]
+    public async Task RunnerSurvivesTerminalTransitionRejectedByTheStore()
+    {
+        var store = new ProcessingJobStore();
+        var gate = new TaskCompletionSource();
+        var uploadReleased = new TaskCompletionSource();
+
+        var job = store.CreateJob(Guid.NewGuid());
+        createdJobIds.Add(job.Id);
+
+        // Releasing the upload is the last thing the runner does for a work item, so it signals that the
+        // body reached the end of its finally block rather than being torn out of it.
+        orchestrationServiceMock
+            .Setup(c => c.ReleaseUploadAsync(job.UploadId))
+            .Callback(() => uploadReleased.TrySetResult())
+            .Returns(Task.CompletedTask);
+
+        using var pipeline = BuildPipeline(job.Id, BuildBlockingStep("step_1", gate.Task));
+        store.AttachPipeline(job.Id, pipeline, 1);
+        store.EnqueueForProcessing(job.Id, Array.Empty<IPipelineFile>());
+
+        using var runner = CreateRunner(store);
+        await runner.StartAsync(CancellationToken.None);
+        try
+        {
+            // The job reaches a terminal state while its pipeline is still running, so the transition the
+            // runner attempts once the pipeline finishes is no longer valid and the strict guard rejects it.
+            await WaitUntilAsync(() => pipeline.State == ProcessingState.Running, TimeSpan.FromSeconds(10));
+            store.MarkAsFailed(job.Id);
+            gate.SetResult();
+
+            await uploadReleased.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            // The real store leaves its queue open, so a runner that survived the rejected transition just
+            // keeps waiting for more work, while one that let the exception escape ends its loop right after
+            // this work item. The check has to happen before StopAsync: cancelling the runner replaces an
+            // already faulted loop with a cancelled one and would hide exactly what is being asserted.
+            var firstToSettle = await Task.WhenAny(runner.ExecuteTask!, Task.Delay(TimeSpan.FromSeconds(2)));
+
+            Assert.AreNotSame(
+                runner.ExecuteTask,
+                firstToSettle,
+                $"The runner loop ended after the rejected transition: {runner.ExecuteTask!.Exception?.InnerException?.Message}");
+            Assert.AreEqual(ProcessingState.Failed, store.GetJob(job.Id)!.State, "The job keeps the state it already reached.");
+        }
+        finally
+        {
+            gate.TrySetResult();
+            await runner.StopAsync(CancellationToken.None);
+        }
+    }
+
     /// <summary>
     /// A pipeline whose run completes in a non-deliverable state and whose disposal then fails, the way
     /// a working directory that cannot be deleted or a step holding a misbehaving process instance fails.
@@ -712,6 +764,11 @@ public class ProcessingRunnerTest
 
         var store = new Mock<IProcessingJobStore>();
         store.SetupGet(s => s.ProcessingQueue).Returns(channel.Reader);
+
+        // Without these the mock answers false, which is the "job unknown or already terminal" case and
+        // would send every test down the runner's warning branch instead of its normal one.
+        store.Setup(s => s.TryMarkAsFailed(It.IsAny<Guid>())).Returns(true);
+        store.Setup(s => s.TryPipelineFinished(It.IsAny<Guid>(), It.IsAny<ProcessingState>())).Returns(true);
 
         return (CreateRunner(store.Object, jobTimeout), store);
     }

--- a/tests/Geopilot.Api.Test/Processing/ProcessingRunnerTest.cs
+++ b/tests/Geopilot.Api.Test/Processing/ProcessingRunnerTest.cs
@@ -607,6 +607,68 @@ public class ProcessingRunnerTest
         store.Verify(s => s.PipelineFinished(jobId, ProcessingState.DeliveryRestriction), Times.Once);
     }
 
+    [TestMethod]
+    public async Task PipelineDisposeFailureDoesNotAbortTheRunner()
+    {
+        var jobId = NewJob();
+        var pipeline = BuildPipelineWithThrowingDispose(jobId);
+
+        var (runner, store) = CreateRunnerWithStore(pipeline.Object);
+        store.Setup(s => s.GetJob(jobId)).Returns(FinishedJob(jobId, Guid.NewGuid(), ProcessingState.Failed));
+
+        await runner.StartAsync(CancellationToken.None);
+        await runner.ExecuteTask!.WaitAsync(TimeSpan.FromSeconds(10));
+        await runner.StopAsync(CancellationToken.None);
+
+        // A faulted ExecuteTask is what tears down the Parallel.ForEachAsync loop and, by default,
+        // the host: the queue would stop draining for every other job as well.
+        Assert.IsTrue(runner.ExecuteTask.IsCompletedSuccessfully, "A failing pipeline disposal must not fault the runner loop.");
+        pipeline.Verify(p => p.Dispose(), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task UploadIsReleasedWhenPipelineDisposeFails()
+    {
+        var jobId = NewJob();
+        var uploadId = Guid.NewGuid();
+        var pipeline = BuildPipelineWithThrowingDispose(jobId);
+
+        var (runner, store) = CreateRunnerWithStore(pipeline.Object);
+        store.Setup(s => s.GetJob(jobId)).Returns(FinishedJob(jobId, uploadId, ProcessingState.Failed));
+
+        await runner.StartAsync(CancellationToken.None);
+        await runner.ExecuteTask!.WaitAsync(TimeSpan.FromSeconds(10));
+        await runner.StopAsync(CancellationToken.None);
+
+        orchestrationServiceMock.Verify(
+            c => c.ReleaseUploadAsync(uploadId),
+            Times.Once,
+            "The uploaded blobs of a non-deliverable run must be released even when disposing the pipeline failed.");
+    }
+
+    /// <summary>
+    /// A pipeline whose run completes in a non-deliverable state and whose disposal then fails, the way
+    /// a working directory that cannot be deleted or a step holding a misbehaving process instance fails.
+    /// </summary>
+    private static Mock<IPipeline> BuildPipelineWithThrowingDispose(Guid jobId)
+    {
+        var pipeline = new Mock<IPipeline>();
+        pipeline.SetupGet(p => p.Id).Returns("throwing_dispose_pipeline");
+        pipeline.SetupGet(p => p.JobId).Returns(jobId);
+        pipeline.SetupGet(p => p.Steps).Returns(new List<IPipelineStep>());
+        pipeline.SetupGet(p => p.State).Returns(ProcessingState.Failed);
+        pipeline
+            .Setup(p => p.Run(It.IsAny<IReadOnlyList<IPipelineFile>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PipelineContext
+            {
+                Upload = Array.Empty<IPipelineFile>(),
+                StepResults = new Dictionary<string, StepResult>(),
+            });
+        pipeline.Setup(p => p.Dispose()).Throws(new IOException("The directory is not empty."));
+
+        return pipeline;
+    }
+
     private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
     {
         var deadline = DateTime.UtcNow + timeout;

--- a/tests/Geopilot.Api.Test/Processing/ProcessingServiceTest.cs
+++ b/tests/Geopilot.Api.Test/Processing/ProcessingServiceTest.cs
@@ -72,7 +72,7 @@ public class ProcessingServiceTest
         var user = new User { Id = 2, FullName = nameof(StartJobSuccessAttachesPipelineAndQueuesPreflight), AuthIdentifier = "auth-123" };
 
         var upload = new UploadInfo(uploadId, ImmutableList.Create(new UploadedFileInfo("test.xtf", "uploads/test.xtf", 1024)), DateTime.Now);
-        var job = new ProcessingJob(jobId, Guid.NewGuid(), new List<ProcessingJobFile>(), null, DateTime.Now);
+        var job = new ProcessingJob(jobId, Guid.NewGuid(), null, DateTime.Now);
         var pipeline = new Mock<IPipeline>().Object;
 
         uploadStoreMock.Setup(x => x.GetUpload(uploadId)).Returns(upload);

--- a/tests/Geopilot.Api.Test/Services/PreflightBackgroundServiceTest.cs
+++ b/tests/Geopilot.Api.Test/Services/PreflightBackgroundServiceTest.cs
@@ -183,7 +183,7 @@ public class PreflightBackgroundServiceTest
     }
 
     private static ProcessingJob CreatePendingJob(Guid jobId, Guid uploadId, IPipeline pipeline)
-        => new ProcessingJob(jobId, uploadId, new List<ProcessingJobFile>(), 1, DateTime.Now) { Pipeline = pipeline };
+        => new ProcessingJob(jobId, uploadId, 1, DateTime.Now) { Pipeline = pipeline };
 
     private static IPipelineFile PipelineFileNamed(string originalFileName)
     {

--- a/tests/Geopilot.Api.Test/Services/PreflightBackgroundServiceTest.cs
+++ b/tests/Geopilot.Api.Test/Services/PreflightBackgroundServiceTest.cs
@@ -78,11 +78,11 @@ public class PreflightBackgroundServiceTest
         orchestrationServiceMock.Setup(x => x.RunPreflightChecksAsync(uploadId))
             .ThrowsAsync(new UploadPreflightException(PreflightFailureReason.IncompleteUpload, "File missing."));
         orchestrationServiceMock.Setup(x => x.ReleaseUploadAsync(uploadId)).Returns(Task.CompletedTask);
-        jobStoreMock.Setup(x => x.MarkAsFailed(jobId)).Returns(pendingJob with { State = ProcessingState.Failed });
+        jobStoreMock.Setup(x => x.TryMarkAsFailed(jobId)).Returns(true);
 
         await service.ProcessRequestAsync(new PreflightRequest(jobId, uploadId));
 
-        jobStoreMock.Verify(x => x.MarkAsFailed(jobId), Times.Once);
+        jobStoreMock.Verify(x => x.TryMarkAsFailed(jobId), Times.Once);
         orchestrationServiceMock.Verify(x => x.ReleaseUploadAsync(uploadId), Times.Once);
         pipeline.Verify(p => p.Dispose(), Times.Once);
     }
@@ -99,11 +99,11 @@ public class PreflightBackgroundServiceTest
         orchestrationServiceMock.Setup(x => x.RunPreflightChecksAsync(uploadId))
             .ThrowsAsync(new InvalidOperationException("Network timeout"));
         orchestrationServiceMock.Setup(x => x.ReleaseUploadAsync(uploadId)).Returns(Task.CompletedTask);
-        jobStoreMock.Setup(x => x.MarkAsFailed(jobId)).Returns(pendingJob with { State = ProcessingState.Failed });
+        jobStoreMock.Setup(x => x.TryMarkAsFailed(jobId)).Returns(true);
 
         await service.ProcessRequestAsync(new PreflightRequest(jobId, uploadId));
 
-        jobStoreMock.Verify(x => x.MarkAsFailed(jobId), Times.Once);
+        jobStoreMock.Verify(x => x.TryMarkAsFailed(jobId), Times.Once);
         orchestrationServiceMock.Verify(x => x.ReleaseUploadAsync(uploadId), Times.Once);
         pipeline.Verify(p => p.Dispose(), Times.Once);
     }
@@ -121,11 +121,11 @@ public class PreflightBackgroundServiceTest
         orchestrationServiceMock.Setup(x => x.RegisterJobFiles(uploadId, jobId))
             .Throws(new InvalidOperationException($"Upload <{uploadId}> has no files to register."));
         orchestrationServiceMock.Setup(x => x.ReleaseUploadAsync(uploadId)).Returns(Task.CompletedTask);
-        jobStoreMock.Setup(x => x.MarkAsFailed(jobId)).Returns(pendingJob with { State = ProcessingState.Failed });
+        jobStoreMock.Setup(x => x.TryMarkAsFailed(jobId)).Returns(true);
 
         await service.ProcessRequestAsync(new PreflightRequest(jobId, uploadId));
 
-        jobStoreMock.Verify(x => x.MarkAsFailed(jobId), Times.Once);
+        jobStoreMock.Verify(x => x.TryMarkAsFailed(jobId), Times.Once);
         jobStoreMock.Verify(x => x.EnqueueForProcessing(It.IsAny<Guid>(), It.IsAny<IReadOnlyList<IPipelineFile>>()), Times.Never);
         orchestrationServiceMock.Verify(x => x.ReleaseUploadAsync(uploadId), Times.Once);
         pipeline.Verify(p => p.Dispose(), Times.Once);
@@ -144,11 +144,11 @@ public class PreflightBackgroundServiceTest
             .ThrowsAsync(new UploadPreflightException(PreflightFailureReason.IncompleteUpload, "File missing."));
         orchestrationServiceMock.Setup(x => x.ReleaseUploadAsync(uploadId))
             .ThrowsAsync(new InvalidOperationException("Storage unavailable."));
-        jobStoreMock.Setup(x => x.MarkAsFailed(jobId)).Returns(pendingJob with { State = ProcessingState.Failed });
+        jobStoreMock.Setup(x => x.TryMarkAsFailed(jobId)).Returns(true);
 
         await service.ProcessRequestAsync(new PreflightRequest(jobId, uploadId));
 
-        jobStoreMock.Verify(x => x.MarkAsFailed(jobId), Times.Once);
+        jobStoreMock.Verify(x => x.TryMarkAsFailed(jobId), Times.Once);
         pipeline.Verify(p => p.Dispose(), Times.Once);
     }
 


### PR DESCRIPTION
Closes #889

Eine Ausnahme aus dem `catch` oder dem `finally` des Schleifenkörpers hat niemanden mehr über sich,
entkommt `Parallel.ForEachAsync` und beendet über `BackgroundServiceExceptionBehavior.StopHost` die
ganze Instanz. Bei einem Host pro Kunde kostet ein blockierter Ordner damit die Umgebung und alle
gleichzeitig laufenden Jobs.

## Was sich ändert

| Befund | Vorher | Nachher |
|---|---|---|
| 1 (M11) | `Dispose` löscht das Arbeitsverzeichnis ungeschützt, Runner ruft es aus einem ungeschützten `finally` | Löschfehler und fehlgeschlagene Step-Freigaben werden protokolliert; im `finally` hat jeder Aufräumschritt einen eigenen Auffangblock |
| 2 (M4) | `Files` ist eine offene `List`, die in der Update-Factory von `AddOrUpdate` mutiert wird | `ImmutableList` als `init`-Property, die Factory gibt einen neuen Job zurück und ist seiteneffektfrei |
| 3 (M3) | `MarkAsFailed` und `PipelineFinished` werfen, aufgerufen aus `catch`-Blöcken | `TryMarkAsFailed` und `TryPipelineFinished` melden das Ergebnis; die werfenden Varianten bleiben für den Normalpfad |

Im Normalpfad ändert sich kein Verhalten. Der strenge Aufruf in `ExecuteAsync` bleibt strengweil er
innerhalb des `try` steht und vom `catch` darunter aufgefangen wird. Genau zwei Aufrufe wandern auf
die tolerante Variante, sechs bleiben, was sich in den Tests spiegelt.

## Ergänzungen gegenüber dem Issue

- **Zwei weitere Fluchtrouten im selben `finally`.** `Steps.ForEach(step => step.Dispose())` läuft vor
  dem Löschen und disposet fremden Plugin-Code; wirft das, bleiben zusätzlich alle weiteren Steps
  liegen. Und `ReleaseUploadIfNotDeliverableAsync` ist im Cloud-Betrieb ein Netzwerkaufruf, also selbst
  eine Wurfquelle. Deshalb zwei getrennte Auffangblöcke: ein gemeinsamer würde den Host retten, aber die
  Upload-Freigabe weiterhin vom Erfolg des Dispose abhängig machen.
- **`Dispose` war nicht idempotent.** `disposed = true` stand am Ende, ein fehlgeschlagenes Löschen
  setzte das Flag also nie, obwohl `RemoveJob` sich darauf verlässt. Steht jetzt vor dem Aufräumen.
- **Der Nebenläufigkeitsfehler verliert Dateien, statt sie zu duplizieren.** 100 gleichzeitige
  `AddFileToJob`-Aufrufe gegen den alten Code liefern reproduzierbar 91 von 100. Produktiv wird
  sequenziell gestaged, es ist nichts verloren gegangen.
- **Irreführendes Log im Preflight.** Ein `catch` deckte `MarkAsFailed` und `Pipeline?.Dispose()`
  gemeinsam ab, meldete aber immer "Failed to mark job as failed". Mit der toleranten Variante fällt das
  verschachtelte `try` weg und beide Fehler bekommen zutreffende Meldungen.

## Entscheide zu den offenen Punkten

**Löschfehler nur protokollieren.** Kein Zähler: es gibt im Repo keine Metrik-Infrastruktur (kein
`Meter`, kein `Counter<>`), und eine Insellösung dafür baut man später wieder aus. Ein strukturierter
`LogWarning` mit Job-Id und Verzeichnis ist auswertbar, und `ProcessingJobCleanupService` macht ein
sich häufendes Problem ohnehin sichtbar.

**Tolerant nur im Fehlerpfad.** Streng, solange ein `catch` darüber liegt; tolerant, sobald man selbst
das `catch` ist. Beide Varianten teilen dieselben Übergangsregeln (`CanMarkAsFailed`,
`CanCompletePipeline`), damit sie nicht auseinanderlaufen.
äche und kein Versionssprung.