### PR TITLE
Improve job processing robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - The error map in fullscreen can be moved with a single finger and zoomed by scrolling without holding Ctrl (⌘ on macOS). Inline the map keeps asking for two fingers and the modifier key so that it does not swallow the page scroll.
 - Processing job and upload timestamps are now recorded in UTC, so the cleanup retention windows (job, download and visualization) are honored regardless of the container time zone. Previously, with the image default `TZ=Europe/Zurich`, expired downloads and visualizations lingered up to two hours longer than configured.
 - Files can now be selected for upload on iPhone and iPad. When a mandate limits the accepted file types, iOS and iPadOS browsers previously greyed out the matching files (for example `.xtf`) in the native file picker, so a delivery could not be started from those devices.
+- A failure while cleaning up after a processing job no longer stops the instance. When the temporary working directory of a pipeline could not be deleted, because a virus scanner or a process still held a file open, the application shut down and every job running at that moment was lost with it. Such failures are now logged, the leftovers are collected by the job cleanup, and the uploaded files of a job that cannot be delivered are released in any case.
 
 ## v3.0.341 - 2026-06-17
 

--- a/src/Geopilot.Api/Processing/IProcessingJobStore.cs
+++ b/src/Geopilot.Api/Processing/IProcessingJobStore.cs
@@ -37,18 +37,11 @@ public interface IProcessingJobStore
     ProcessingJob CreateJob(Guid uploadId);
 
     /// <summary>
-    /// Marks the specified job as failed (e.g. preflight failure before a pipeline could be created).
-    /// </summary>
-    /// <exception cref="ArgumentException">If no job with the <paramref name="jobId"/> was found.</exception>
-    /// <exception cref="InvalidOperationException">If the job is already in a terminal state.</exception>
-    ProcessingJob MarkAsFailed(Guid jobId);
-
-    /// <summary>
-    /// Marks the job as failed and reports whether it happened, instead of throwing when the transition is
-    /// not allowed. This is the variant for error paths: a caller that is itself handling a failure cannot
-    /// afford a second exception, because it escapes to the hosting background service and stops the host
-    /// instead of recording the failure. Use the throwing <see cref="MarkAsFailed"/> wherever an invalid
-    /// transition is a programming error that has to surface.
+    /// Marks the job as failed (e.g. a preflight failure before a pipeline could be created) and reports
+    /// whether it happened, instead of throwing when the transition is not allowed. There is no throwing
+    /// counterpart: a job is only ever marked as failed by a caller that is already handling a failure, and
+    /// such a caller cannot afford a second exception, because it escapes to the hosting background service
+    /// and stops the host instead of recording the failure.
     /// </summary>
     /// <param name="jobId">The job to mark as failed.</param>
     /// <returns><see langword="true"/> when the job was marked as failed; <see langword="false"/> when it is

--- a/src/Geopilot.Api/Processing/IProcessingJobStore.cs
+++ b/src/Geopilot.Api/Processing/IProcessingJobStore.cs
@@ -64,8 +64,10 @@ public interface IProcessingJobStore
 
     /// <summary>
     /// Transitions the job to its terminal state and reports whether it happened, instead of throwing when
-    /// the transition is not allowed. See <see cref="TryMarkAsFailed"/> for when to prefer this over
-    /// <see cref="PipelineFinished"/>.
+    /// the transition is not allowed. Prefer it over <see cref="PipelineFinished"/> in an error path, for the
+    /// reason given on <see cref="TryMarkAsFailed"/>. The caller has to pass a state it already knows to be
+    /// terminal: that argument check still throws, and out of an error path the exception escapes to the
+    /// hosting background service just like the one it replaces.
     /// </summary>
     /// <param name="jobId">The job whose pipeline has finished.</param>
     /// <param name="pipelineState">The terminal state the pipeline ended in.</param>

--- a/src/Geopilot.Api/Processing/IProcessingJobStore.cs
+++ b/src/Geopilot.Api/Processing/IProcessingJobStore.cs
@@ -44,13 +44,15 @@ public interface IProcessingJobStore
     ProcessingJob MarkAsFailed(Guid jobId);
 
     /// <summary>
-    /// Attempts to mark the job as failed and reports whether it happened, instead of throwing. Returns
-    /// <see langword="false"/> when the job is unknown or already in a terminal state, leaving it untouched.
-    /// This is the variant for error paths: a caller that is itself handling a failure cannot afford a second
-    /// exception, because it escapes to the hosting background service and stops the host instead of recording
-    /// the failure. The throwing <see cref="MarkAsFailed"/> stays correct wherever an invalid transition is a
-    /// programming error that has to surface.
+    /// Marks the job as failed and reports whether it happened, instead of throwing. This is the variant for
+    /// error paths: a caller that is itself handling a failure cannot afford a second exception, because it
+    /// escapes to the hosting background service and stops the host instead of recording the failure. Use the
+    /// throwing <see cref="MarkAsFailed"/> wherever an invalid transition is a programming error that has to
+    /// surface.
     /// </summary>
+    /// <param name="jobId">The job to mark as failed.</param>
+    /// <returns><see langword="true"/> when the job was marked as failed; <see langword="false"/> when it is
+    /// unknown or already in a terminal state, in which case it is left untouched.</returns>
     bool TryMarkAsFailed(Guid jobId);
 
     /// <summary>
@@ -68,11 +70,14 @@ public interface IProcessingJobStore
     ProcessingJob PipelineFinished(Guid jobId, ProcessingState pipelineState);
 
     /// <summary>
-    /// Attempts the terminal transition and reports whether it happened, instead of throwing. Returns
-    /// <see langword="false"/> when the job is unknown, is not in <see cref="ProcessingState.Running"/>, or
-    /// <paramref name="pipelineState"/> is not a terminal state, leaving the job untouched. See
+    /// Transitions the job to its terminal state and reports whether it happened, instead of throwing. See
     /// <see cref="TryMarkAsFailed"/> for when to prefer this over <see cref="PipelineFinished"/>.
     /// </summary>
+    /// <param name="jobId">The job whose pipeline has finished.</param>
+    /// <param name="pipelineState">The terminal state the pipeline ended in.</param>
+    /// <returns><see langword="true"/> when the job was transitioned; <see langword="false"/> when it is
+    /// unknown, is not in <see cref="ProcessingState.Running"/>, or <paramref name="pipelineState"/> is not a
+    /// terminal state, in which case the job is left untouched.</returns>
     bool TryPipelineFinished(Guid jobId, ProcessingState pipelineState);
 
     /// <summary>

--- a/src/Geopilot.Api/Processing/IProcessingJobStore.cs
+++ b/src/Geopilot.Api/Processing/IProcessingJobStore.cs
@@ -44,6 +44,16 @@ public interface IProcessingJobStore
     ProcessingJob MarkAsFailed(Guid jobId);
 
     /// <summary>
+    /// Attempts to mark the job as failed and reports whether it happened, instead of throwing. Returns
+    /// <see langword="false"/> when the job is unknown or already in a terminal state, leaving it untouched.
+    /// This is the variant for error paths: a caller that is itself handling a failure cannot afford a second
+    /// exception, because it escapes to the hosting background service and stops the host instead of recording
+    /// the failure. The throwing <see cref="MarkAsFailed"/> stays correct wherever an invalid transition is a
+    /// programming error that has to surface.
+    /// </summary>
+    bool TryMarkAsFailed(Guid jobId);
+
+    /// <summary>
     /// Transitions the job to its terminal state based on the state the pipeline finished in.
     /// </summary>
     /// <param name="jobId">The job whose pipeline has finished.</param>
@@ -56,6 +66,14 @@ public interface IProcessingJobStore
     /// <exception cref="ArgumentOutOfRangeException">If <paramref name="pipelineState"/> is not a terminal state.</exception>
     /// <exception cref="InvalidOperationException">If the job is not in <see cref="ProcessingState.Running"/>.</exception>
     ProcessingJob PipelineFinished(Guid jobId, ProcessingState pipelineState);
+
+    /// <summary>
+    /// Attempts the terminal transition and reports whether it happened, instead of throwing. Returns
+    /// <see langword="false"/> when the job is unknown, is not in <see cref="ProcessingState.Running"/>, or
+    /// <paramref name="pipelineState"/> is not a terminal state, leaving the job untouched. See
+    /// <see cref="TryMarkAsFailed"/> for when to prefer this over <see cref="PipelineFinished"/>.
+    /// </summary>
+    bool TryPipelineFinished(Guid jobId, ProcessingState pipelineState);
 
     /// <summary>
     /// Associates the given <paramref name="pipeline"/> with the job at creation time, without queuing it.

--- a/src/Geopilot.Api/Processing/IProcessingJobStore.cs
+++ b/src/Geopilot.Api/Processing/IProcessingJobStore.cs
@@ -44,11 +44,11 @@ public interface IProcessingJobStore
     ProcessingJob MarkAsFailed(Guid jobId);
 
     /// <summary>
-    /// Marks the job as failed and reports whether it happened, instead of throwing. This is the variant for
-    /// error paths: a caller that is itself handling a failure cannot afford a second exception, because it
-    /// escapes to the hosting background service and stops the host instead of recording the failure. Use the
-    /// throwing <see cref="MarkAsFailed"/> wherever an invalid transition is a programming error that has to
-    /// surface.
+    /// Marks the job as failed and reports whether it happened, instead of throwing when the transition is
+    /// not allowed. This is the variant for error paths: a caller that is itself handling a failure cannot
+    /// afford a second exception, because it escapes to the hosting background service and stops the host
+    /// instead of recording the failure. Use the throwing <see cref="MarkAsFailed"/> wherever an invalid
+    /// transition is a programming error that has to surface.
     /// </summary>
     /// <param name="jobId">The job to mark as failed.</param>
     /// <returns><see langword="true"/> when the job was marked as failed; <see langword="false"/> when it is
@@ -70,14 +70,16 @@ public interface IProcessingJobStore
     ProcessingJob PipelineFinished(Guid jobId, ProcessingState pipelineState);
 
     /// <summary>
-    /// Transitions the job to its terminal state and reports whether it happened, instead of throwing. See
-    /// <see cref="TryMarkAsFailed"/> for when to prefer this over <see cref="PipelineFinished"/>.
+    /// Transitions the job to its terminal state and reports whether it happened, instead of throwing when
+    /// the transition is not allowed. See <see cref="TryMarkAsFailed"/> for when to prefer this over
+    /// <see cref="PipelineFinished"/>.
     /// </summary>
     /// <param name="jobId">The job whose pipeline has finished.</param>
     /// <param name="pipelineState">The terminal state the pipeline ended in.</param>
     /// <returns><see langword="true"/> when the job was transitioned; <see langword="false"/> when it is
-    /// unknown, is not in <see cref="ProcessingState.Running"/>, or <paramref name="pipelineState"/> is not a
-    /// terminal state, in which case the job is left untouched.</returns>
+    /// unknown or not in <see cref="ProcessingState.Running"/>, in which case it is left untouched.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">If <paramref name="pipelineState"/> is not a terminal
+    /// state, which is a defect at the call site rather than a job that moved on.</exception>
     bool TryPipelineFinished(Guid jobId, ProcessingState pipelineState);
 
     /// <summary>

--- a/src/Geopilot.Api/Processing/ProcessingJobStore.cs
+++ b/src/Geopilot.Api/Processing/ProcessingJobStore.cs
@@ -160,8 +160,7 @@ public class ProcessingJobStore : IProcessingJobStore
     /// <summary>
     /// Applies <paramref name="newState"/> when <paramref name="isAllowed"/> accepts the job's current state,
     /// retrying against the freshly read job whenever a concurrent write wins the compare-and-swap. Reports the
-    /// outcome rather than throwing, so a caller that is already handling a failure cannot make it worse. The
-    /// transition rules are shared with the throwing operations, so both variants can never drift apart.
+    /// outcome rather than throwing, so a caller that is already handling a failure cannot make it worse.
     /// </summary>
     private bool TryTransition(Guid jobId, Func<ProcessingJob, bool> isAllowed, ProcessingState newState)
     {

--- a/src/Geopilot.Api/Processing/ProcessingJobStore.cs
+++ b/src/Geopilot.Api/Processing/ProcessingJobStore.cs
@@ -68,13 +68,7 @@ public class ProcessingJobStore : IProcessingJobStore
     /// <inheritdoc/>
     public ProcessingJob PipelineFinished(Guid jobId, ProcessingState pipelineState)
     {
-        if (!IsTerminal(pipelineState))
-        {
-            throw new ArgumentOutOfRangeException(
-                nameof(pipelineState),
-                pipelineState,
-                "Pipeline must have finished in a terminal state.");
-        }
+        EnsureStateIsTerminal(pipelineState);
 
         return jobs.AddOrUpdate(
             jobId,
@@ -92,8 +86,15 @@ public class ProcessingJobStore : IProcessingJobStore
     }
 
     /// <inheritdoc/>
-    public bool TryPipelineFinished(Guid jobId, ProcessingState pipelineState) =>
-        IsTerminal(pipelineState) && TryTransition(jobId, CanCompletePipeline, pipelineState);
+    public bool TryPipelineFinished(Guid jobId, ProcessingState pipelineState)
+    {
+        // A state that is not terminal is a defect at the call site and cannot be caused by a race, so
+        // it surfaces here just as it does in the throwing operation. What this operation tolerates is
+        // a job that moved on, not a wrong argument.
+        EnsureStateIsTerminal(pipelineState);
+
+        return TryTransition(jobId, CanCompletePipeline, pipelineState);
+    }
 
     /// <inheritdoc/>
     public ProcessingJob AttachPipeline(Guid jobId, IPipeline pipeline, int mandateId)
@@ -150,6 +151,17 @@ public class ProcessingJobStore : IProcessingJobStore
     private static bool IsTerminal(ProcessingState state) =>
         state is ProcessingState.Success or ProcessingState.Warning or ProcessingState.DeliveryRestriction
             or ProcessingState.Failed or ProcessingState.Cancelled;
+
+    private static void EnsureStateIsTerminal(ProcessingState pipelineState)
+    {
+        if (!IsTerminal(pipelineState))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(pipelineState),
+                pipelineState,
+                "Pipeline must have finished in a terminal state.");
+        }
+    }
 
     private static bool CanMarkAsFailed(ProcessingJob job) =>
         job.State is ProcessingState.Pending or ProcessingState.Running;

--- a/src/Geopilot.Api/Processing/ProcessingJobStore.cs
+++ b/src/Geopilot.Api/Processing/ProcessingJobStore.cs
@@ -51,7 +51,7 @@ public class ProcessingJobStore : IProcessingJobStore
             id => throw new ArgumentException($"Job with id <{id}> not found.", nameof(jobId)),
             (id, currentJob) =>
             {
-                if (currentJob.State is not (ProcessingState.Pending or ProcessingState.Running))
+                if (!CanMarkAsFailed(currentJob))
                 {
                     throw new InvalidOperationException(
                         $"Cannot transition job <{id}> from <{currentJob.State}> to <{ProcessingState.Failed}>.");
@@ -62,9 +62,13 @@ public class ProcessingJobStore : IProcessingJobStore
     }
 
     /// <inheritdoc/>
+    public bool TryMarkAsFailed(Guid jobId) =>
+        TryTransition(jobId, CanMarkAsFailed, ProcessingState.Failed);
+
+    /// <inheritdoc/>
     public ProcessingJob PipelineFinished(Guid jobId, ProcessingState pipelineState)
     {
-        if (pipelineState is not (ProcessingState.Success or ProcessingState.Warning or ProcessingState.DeliveryRestriction or ProcessingState.Failed or ProcessingState.Cancelled))
+        if (!IsTerminal(pipelineState))
         {
             throw new ArgumentOutOfRangeException(
                 nameof(pipelineState),
@@ -77,7 +81,7 @@ public class ProcessingJobStore : IProcessingJobStore
             id => throw new ArgumentException($"Job with id <{id}> not found.", nameof(jobId)),
             (id, currentJob) =>
             {
-                if (currentJob.State != ProcessingState.Running)
+                if (!CanCompletePipeline(currentJob))
                 {
                     throw new InvalidOperationException(
                         $"Cannot transition job <{id}> from <{currentJob.State}> to <{pipelineState}>.");
@@ -86,6 +90,10 @@ public class ProcessingJobStore : IProcessingJobStore
                 return currentJob with { State = pipelineState };
             });
     }
+
+    /// <inheritdoc/>
+    public bool TryPipelineFinished(Guid jobId, ProcessingState pipelineState) =>
+        IsTerminal(pipelineState) && TryTransition(jobId, CanCompletePipeline, pipelineState);
 
     /// <inheritdoc/>
     public ProcessingJob AttachPipeline(Guid jobId, IPipeline pipeline, int mandateId)
@@ -137,6 +145,36 @@ public class ProcessingJobStore : IProcessingJobStore
         // Idempotent dispose handles the case where the runner already disposed after extracting.
         removed.Pipeline?.Dispose();
         return true;
+    }
+
+    private static bool IsTerminal(ProcessingState state) =>
+        state is ProcessingState.Success or ProcessingState.Warning or ProcessingState.DeliveryRestriction
+            or ProcessingState.Failed or ProcessingState.Cancelled;
+
+    private static bool CanMarkAsFailed(ProcessingJob job) =>
+        job.State is ProcessingState.Pending or ProcessingState.Running;
+
+    private static bool CanCompletePipeline(ProcessingJob job) =>
+        job.State == ProcessingState.Running;
+
+    /// <summary>
+    /// Applies <paramref name="newState"/> when <paramref name="isAllowed"/> accepts the job's current state,
+    /// retrying against the freshly read job whenever a concurrent write wins the compare-and-swap. Reports the
+    /// outcome rather than throwing, so a caller that is already handling a failure cannot make it worse. The
+    /// transition rules are shared with the throwing operations, so both variants can never drift apart.
+    /// </summary>
+    private bool TryTransition(Guid jobId, Func<ProcessingJob, bool> isAllowed, ProcessingState newState)
+    {
+        while (jobs.TryGetValue(jobId, out var currentJob))
+        {
+            if (!isAllowed(currentJob))
+                return false;
+
+            if (jobs.TryUpdate(jobId, currentJob with { State = newState }, currentJob))
+                return true;
+        }
+
+        return false;
     }
 
     private static void EnsureJobIsPrePipeline(Guid jobId, ProcessingJob job, string operation)

--- a/src/Geopilot.Api/Processing/ProcessingJobStore.cs
+++ b/src/Geopilot.Api/Processing/ProcessingJobStore.cs
@@ -44,24 +44,6 @@ public class ProcessingJobStore : IProcessingJobStore
     }
 
     /// <inheritdoc/>
-    public ProcessingJob MarkAsFailed(Guid jobId)
-    {
-        return jobs.AddOrUpdate(
-            jobId,
-            id => throw new ArgumentException($"Job with id <{id}> not found.", nameof(jobId)),
-            (id, currentJob) =>
-            {
-                if (!CanMarkAsFailed(currentJob))
-                {
-                    throw new InvalidOperationException(
-                        $"Cannot transition job <{id}> from <{currentJob.State}> to <{ProcessingState.Failed}>.");
-                }
-
-                return currentJob with { State = ProcessingState.Failed };
-            });
-    }
-
-    /// <inheritdoc/>
     public bool TryMarkAsFailed(Guid jobId) =>
         TryTransition(jobId, CanMarkAsFailed, ProcessingState.Failed);
 

--- a/src/Geopilot.Api/Processing/ProcessingRunner.cs
+++ b/src/Geopilot.Api/Processing/ProcessingRunner.cs
@@ -5,7 +5,6 @@ using Geopilot.Pipeline.Config;
 using Geopilot.Pipeline.Visualization;
 using Geopilot.PipelineCore.Pipeline;
 using Microsoft.Extensions.Options;
-using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -101,13 +100,33 @@ public class ProcessingRunner : BackgroundService
             }
             finally
             {
-                // Free process-owned resources (e.g. HttpClient) immediately. Pipeline state, step
-                // states, status-message dictionaries and PersistedDownloads survive disposal; what
-                // goes is the pipeline's temp directory, including the uploaded files fetched into it
-                // during the run.
-                pipeline.Dispose();
+                // Both cleanup steps run unconditionally and each one is guarded on its own. This is the
+                // body of a Parallel.ForEachAsync inside a BackgroundService: an exception escaping here
+                // aborts the whole loop, so the queue stops draining, and by default it stops the host.
+                // A shared guard would make releasing the upload depend on the disposal succeeding.
+                try
+                {
+                    // Free process-owned resources (e.g. HttpClient) immediately. Pipeline state, step
+                    // states, status-message dictionaries and PersistedDownloads survive disposal; what
+                    // goes is the pipeline's temp directory, including the uploaded files fetched into it
+                    // during the run.
+                    pipeline.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Failed to dispose pipeline <{Pipeline}>.", pipeline.Id);
+                }
 
-                await ReleaseUploadIfNotDeliverableAsync(pipeline.JobId);
+                try
+                {
+                    await ReleaseUploadIfNotDeliverableAsync(pipeline.JobId);
+                }
+                catch (Exception ex)
+                {
+                    // The upload store is remote, so releasing it is a network call. The age-based sweep
+                    // in UploadCleanupService is the backstop for blobs left behind here.
+                    logger.LogError(ex, "Failed to release the upload of job <{JobId}>.", pipeline.JobId);
+                }
             }
         });
     }

--- a/src/Geopilot.Api/Processing/ProcessingRunner.cs
+++ b/src/Geopilot.Api/Processing/ProcessingRunner.cs
@@ -86,7 +86,11 @@ public class ProcessingRunner : BackgroundService
                 // in-flight step's files are lost, and no delivery files are persisted (delivery is staged
                 // only for a successful, deliverable run).
                 logger.LogError("Pipeline <{Pipeline}> timed out after {Timeout}.", pipeline.Id, processingOptions.JobTimeout);
-                jobStore.PipelineFinished(pipeline.JobId, ProcessingState.Cancelled);
+
+                // Tolerant variant: a throwing transition would escape this catch block and take the whole
+                // loop, and by default the host, down instead of recording the timeout.
+                if (!jobStore.TryPipelineFinished(pipeline.JobId, ProcessingState.Cancelled))
+                    logger.LogWarning("Job <{JobId}> was not transitioned to <{State}>: it is unknown or no longer running.", pipeline.JobId, ProcessingState.Cancelled);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -96,7 +100,9 @@ public class ProcessingRunner : BackgroundService
             catch (Exception ex)
             {
                 logger.LogError(ex, "Unexpected error while running pipeline <{Pipeline}>.", pipeline.Id);
-                jobStore.MarkAsFailed(pipeline.JobId);
+
+                if (!jobStore.TryMarkAsFailed(pipeline.JobId))
+                    logger.LogWarning("Job <{JobId}> was not marked as failed: it is unknown or already in a terminal state.", pipeline.JobId);
             }
             finally
             {

--- a/src/Geopilot.Api/Processing/ProcessingRunner.cs
+++ b/src/Geopilot.Api/Processing/ProcessingRunner.cs
@@ -87,8 +87,8 @@ public class ProcessingRunner : BackgroundService
                 // only for a successful, deliverable run).
                 logger.LogError("Pipeline <{Pipeline}> timed out after {Timeout}.", pipeline.Id, processingOptions.JobTimeout);
 
-                // Tolerant variant: a throwing transition would escape this catch block and take the whole
-                // loop, and by default the host, down instead of recording the timeout.
+                // Nothing above this catch block handles an exception, so the reporting variant keeps
+                // an unexpected job state in the log instead of stopping the host.
                 if (!jobStore.TryPipelineFinished(pipeline.JobId, ProcessingState.Cancelled))
                     logger.LogWarning("Job <{JobId}> was not transitioned to <{State}>: it is unknown or no longer running.", pipeline.JobId, ProcessingState.Cancelled);
             }
@@ -106,10 +106,10 @@ public class ProcessingRunner : BackgroundService
             }
             finally
             {
-                // Both cleanup steps run unconditionally and each one is guarded on its own. This is the
-                // body of a Parallel.ForEachAsync inside a BackgroundService: an exception escaping here
-                // aborts the whole loop, so the queue stops draining, and by default it stops the host.
-                // A shared guard would make releasing the upload depend on the disposal succeeding.
+                // This is the body of a Parallel.ForEachAsync inside a BackgroundService: an exception
+                // escaping here aborts the whole loop, so the queue stops draining, and by default it
+                // stops the host. Each cleanup step is guarded on its own, so releasing the upload is
+                // independent of the disposal.
                 try
                 {
                     // Free process-owned resources (e.g. HttpClient) immediately. Pipeline state, step

--- a/src/Geopilot.Api/Services/PreflightBackgroundService.cs
+++ b/src/Geopilot.Api/Services/PreflightBackgroundService.cs
@@ -73,16 +73,17 @@ public class PreflightBackgroundService : BackgroundService
         {
             logger.LogError(ex, "Preflight failed for job <{JobId}>.", request.JobId);
 
+            if (!jobStore.TryMarkAsFailed(request.JobId))
+                logger.LogWarning("Job <{JobId}> was not marked as failed: it is unknown or already in a terminal state.", request.JobId);
+
             try
             {
-                jobStore.MarkAsFailed(request.JobId);
-
                 // The pipeline was instantiated up front but never queued, so the runner will not dispose it.
                 job.Pipeline?.Dispose();
             }
-            catch (Exception statusEx)
+            catch (Exception disposeEx)
             {
-                logger.LogError(statusEx, "Failed to mark job <{JobId}> as failed.", request.JobId);
+                logger.LogError(disposeEx, "Failed to dispose the pipeline of job <{JobId}>.", request.JobId);
             }
 
             try

--- a/src/Geopilot.Pipeline/Pipeline.cs
+++ b/src/Geopilot.Pipeline/Pipeline.cs
@@ -18,12 +18,31 @@ internal sealed class Pipeline : IPipeline
         if (disposed)
             return;
 
-        Steps.ForEach(step => step.Dispose());
-
-        if (Path.Exists(pipelineFileDirectory))
-            Directory.Delete(pipelineFileDirectory, true);
-
+        // Set before the cleanup, not after: a partially failed cleanup must not make Dispose
+        // re-entrant, or a later RemoveJob disposes every step a second time.
         disposed = true;
+
+        foreach (var step in Steps)
+        {
+            try
+            {
+                step.Dispose();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to dispose step <{Step}> of pipeline <{Pipeline}>.", step.Id, Id);
+            }
+        }
+
+        try
+        {
+            if (Path.Exists(pipelineFileDirectory))
+                Directory.Delete(pipelineFileDirectory, true);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to delete the working directory <{Directory}> of pipeline <{Pipeline}>.", pipelineFileDirectory, Id);
+        }
     }
 
     private readonly string pipelineFileDirectory;

--- a/src/Geopilot.Pipeline/Pipeline.cs
+++ b/src/Geopilot.Pipeline/Pipeline.cs
@@ -18,8 +18,8 @@ internal sealed class Pipeline : IPipeline
         if (disposed)
             return;
 
-        // Set before the cleanup, not after: a partially failed cleanup must not make Dispose
-        // re-entrant, or a later RemoveJob disposes every step a second time.
+        // Marked as disposed ahead of the cleanup below, so that a cleanup which partially fails
+        // still leaves Dispose idempotent for the second call RemoveJob may make.
         disposed = true;
 
         foreach (var step in Steps)

--- a/tests/Geopilot.Api.Test/Processing/ProcessingJobStoreTest.cs
+++ b/tests/Geopilot.Api.Test/Processing/ProcessingJobStoreTest.cs
@@ -266,13 +266,13 @@ public class ProcessingJobStoreTest
     [TestMethod]
     [DataRow(ProcessingState.Pending)]
     [DataRow(ProcessingState.Running)]
-    public void TryPipelineFinishedReturnsFalseIfPipelineStateIsNotTerminal(ProcessingState pipelineState)
+    public void TryPipelineFinishedThrowsIfPipelineStateIsNotTerminal(ProcessingState pipelineState)
     {
         var job = store.CreateJob(Guid.NewGuid());
         store.AttachPipeline(job.Id, new Mock<IPipeline>().Object, 1);
         store.EnqueueForProcessing(job.Id, Array.Empty<IPipelineFile>());
 
-        Assert.IsFalse(store.TryPipelineFinished(job.Id, pipelineState));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => store.TryPipelineFinished(job.Id, pipelineState));
         Assert.AreEqual(ProcessingState.Running, store.GetJob(job.Id)!.State);
     }
 

--- a/tests/Geopilot.Api.Test/Processing/ProcessingJobStoreTest.cs
+++ b/tests/Geopilot.Api.Test/Processing/ProcessingJobStoreTest.cs
@@ -94,7 +94,7 @@ public class ProcessingJobStoreTest
     public void AttachPipelineThrowsIfJobFailed()
     {
         var job = store.CreateJob(Guid.NewGuid());
-        store.MarkAsFailed(job.Id);
+        store.TryMarkAsFailed(job.Id);
 
         Assert.ThrowsExactly<InvalidOperationException>(() => store.AttachPipeline(job.Id, new Mock<IPipeline>().Object, 0));
     }
@@ -183,32 +183,6 @@ public class ProcessingJobStoreTest
         store.EnqueueForProcessing(job.Id, Array.Empty<IPipelineFile>());
 
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => store.PipelineFinished(job.Id, pipelineState));
-    }
-
-    [TestMethod]
-    public void MarkAsFailedSetsState()
-    {
-        var job = store.CreateJob(Guid.NewGuid());
-        var updated = store.MarkAsFailed(job.Id);
-
-        Assert.AreEqual(ProcessingState.Failed, updated.State);
-    }
-
-    [TestMethod]
-    public void MarkAsFailedThrowsIfAlreadyTerminal()
-    {
-        var job = store.CreateJob(Guid.NewGuid());
-        store.AttachPipeline(job.Id, new Mock<IPipeline>().Object, 1);
-        store.EnqueueForProcessing(job.Id, Array.Empty<IPipelineFile>());
-        store.PipelineFinished(job.Id, ProcessingState.Success);
-
-        Assert.ThrowsExactly<InvalidOperationException>(() => store.MarkAsFailed(job.Id));
-    }
-
-    [TestMethod]
-    public void MarkAsFailedThrowsIfJobNotFound()
-    {
-        Assert.ThrowsExactly<ArgumentException>(() => store.MarkAsFailed(Guid.NewGuid()));
     }
 
     [TestMethod]

--- a/tests/Geopilot.Api.Test/Processing/ProcessingJobStoreTest.cs
+++ b/tests/Geopilot.Api.Test/Processing/ProcessingJobStoreTest.cs
@@ -212,6 +212,77 @@ public class ProcessingJobStoreTest
     }
 
     [TestMethod]
+    public void TryMarkAsFailedSetsState()
+    {
+        var job = store.CreateJob(Guid.NewGuid());
+
+        Assert.IsTrue(store.TryMarkAsFailed(job.Id));
+        Assert.AreEqual(ProcessingState.Failed, store.GetJob(job.Id)!.State);
+    }
+
+    [TestMethod]
+    public void TryMarkAsFailedReturnsFalseIfAlreadyTerminal()
+    {
+        var job = store.CreateJob(Guid.NewGuid());
+        store.AttachPipeline(job.Id, new Mock<IPipeline>().Object, 1);
+        store.EnqueueForProcessing(job.Id, Array.Empty<IPipelineFile>());
+        store.PipelineFinished(job.Id, ProcessingState.Success);
+
+        Assert.IsFalse(store.TryMarkAsFailed(job.Id));
+        Assert.AreEqual(ProcessingState.Success, store.GetJob(job.Id)!.State, "A rejected transition must leave the job untouched.");
+    }
+
+    [TestMethod]
+    public void TryMarkAsFailedReturnsFalseIfJobNotFound()
+    {
+        Assert.IsFalse(store.TryMarkAsFailed(Guid.NewGuid()));
+    }
+
+    [TestMethod]
+    [DataRow(ProcessingState.Success)]
+    [DataRow(ProcessingState.Warning)]
+    [DataRow(ProcessingState.DeliveryRestriction)]
+    [DataRow(ProcessingState.Failed)]
+    [DataRow(ProcessingState.Cancelled)]
+    public void TryPipelineFinishedTransitionsFromRunning(ProcessingState pipelineState)
+    {
+        var job = store.CreateJob(Guid.NewGuid());
+        store.AttachPipeline(job.Id, new Mock<IPipeline>().Object, 1);
+        store.EnqueueForProcessing(job.Id, Array.Empty<IPipelineFile>());
+
+        Assert.IsTrue(store.TryPipelineFinished(job.Id, pipelineState));
+        Assert.AreEqual(pipelineState, store.GetJob(job.Id)!.State);
+    }
+
+    [TestMethod]
+    public void TryPipelineFinishedReturnsFalseIfNotRunning()
+    {
+        var job = store.CreateJob(Guid.NewGuid());
+
+        Assert.IsFalse(store.TryPipelineFinished(job.Id, ProcessingState.Success));
+        Assert.AreEqual(ProcessingState.Pending, store.GetJob(job.Id)!.State, "A rejected transition must leave the job untouched.");
+    }
+
+    [TestMethod]
+    [DataRow(ProcessingState.Pending)]
+    [DataRow(ProcessingState.Running)]
+    public void TryPipelineFinishedReturnsFalseIfPipelineStateIsNotTerminal(ProcessingState pipelineState)
+    {
+        var job = store.CreateJob(Guid.NewGuid());
+        store.AttachPipeline(job.Id, new Mock<IPipeline>().Object, 1);
+        store.EnqueueForProcessing(job.Id, Array.Empty<IPipelineFile>());
+
+        Assert.IsFalse(store.TryPipelineFinished(job.Id, pipelineState));
+        Assert.AreEqual(ProcessingState.Running, store.GetJob(job.Id)!.State);
+    }
+
+    [TestMethod]
+    public void TryPipelineFinishedReturnsFalseIfJobNotFound()
+    {
+        Assert.IsFalse(store.TryPipelineFinished(Guid.NewGuid(), ProcessingState.Success));
+    }
+
+    [TestMethod]
     public void RemoveJobDisposesPipeline()
     {
         var job = store.CreateJob(Guid.NewGuid());

--- a/tests/Geopilot.Api.Test/Processing/ProcessingRunnerTest.cs
+++ b/tests/Geopilot.Api.Test/Processing/ProcessingRunnerTest.cs
@@ -766,7 +766,7 @@ public class ProcessingRunnerTest
             // The job reaches a terminal state while its pipeline is still running, so the transition the
             // runner attempts once the pipeline finishes is no longer valid and the strict guard rejects it.
             await WaitUntilAsync(() => pipeline.State == ProcessingState.Running, TimeSpan.FromSeconds(10));
-            store.MarkAsFailed(job.Id);
+            Assert.IsTrue(store.TryMarkAsFailed(job.Id), "The job has to reach its terminal state before the pipeline does.");
             gate.SetResult();
 
             await uploadReleased.Task.WaitAsync(TimeSpan.FromSeconds(10));

--- a/tests/Geopilot.Api.Test/Processing/ProcessingRunnerTest.cs
+++ b/tests/Geopilot.Api.Test/Processing/ProcessingRunnerTest.cs
@@ -677,7 +677,8 @@ public class ProcessingRunnerTest
     public async Task PipelineDisposeFailureDoesNotAbortTheRunner()
     {
         var jobId = NewJob();
-        var pipeline = BuildPipelineWithThrowingDispose(jobId);
+        var pipeline = BuildStubPipeline(jobId);
+        pipeline.Setup(p => p.Dispose()).Throws(new IOException("The directory is not empty."));
 
         var (runner, store) = CreateRunnerWithStore(pipeline.Object);
         store.Setup(s => s.GetJob(jobId)).Returns(FinishedJob(jobId, Guid.NewGuid(), ProcessingState.Failed));
@@ -697,7 +698,8 @@ public class ProcessingRunnerTest
     {
         var jobId = NewJob();
         var uploadId = Guid.NewGuid();
-        var pipeline = BuildPipelineWithThrowingDispose(jobId);
+        var pipeline = BuildStubPipeline(jobId);
+        pipeline.Setup(p => p.Dispose()).Throws(new IOException("The directory is not empty."));
 
         var (runner, store) = CreateRunnerWithStore(pipeline.Object);
         store.Setup(s => s.GetJob(jobId)).Returns(FinishedJob(jobId, uploadId, ProcessingState.Failed));
@@ -710,6 +712,30 @@ public class ProcessingRunnerTest
             c => c.ReleaseUploadAsync(uploadId),
             Times.Once,
             "The uploaded blobs of a non-deliverable run must be released even when disposing the pipeline failed.");
+    }
+
+    [TestMethod]
+    public async Task ReleasingTheUploadFailingDoesNotAbortTheRunner()
+    {
+        var jobId = NewJob();
+        var uploadId = Guid.NewGuid();
+        var pipeline = BuildStubPipeline(jobId);
+
+        var (runner, store) = CreateRunnerWithStore(pipeline.Object);
+        store.Setup(s => s.GetJob(jobId)).Returns(FinishedJob(jobId, uploadId, ProcessingState.Failed));
+
+        // Releasing the upload reaches the upload store over the network, so it fails for reasons that have
+        // nothing to do with the job: an expired token, a timeout, a storage that is briefly unreachable.
+        orchestrationServiceMock
+            .Setup(c => c.ReleaseUploadAsync(uploadId))
+            .ThrowsAsync(new InvalidOperationException("Storage unavailable."));
+
+        await runner.StartAsync(CancellationToken.None);
+        await runner.ExecuteTask!.WaitAsync(TimeSpan.FromSeconds(10));
+        await runner.StopAsync(CancellationToken.None);
+
+        Assert.IsTrue(runner.ExecuteTask.IsCompletedSuccessfully, "A failing upload release must not fault the runner loop.");
+        orchestrationServiceMock.Verify(c => c.ReleaseUploadAsync(uploadId), Times.Once);
     }
 
     [TestMethod]
@@ -765,13 +791,13 @@ public class ProcessingRunnerTest
     }
 
     /// <summary>
-    /// A pipeline whose run completes in a non-deliverable state and whose disposal then fails, the way
-    /// a working directory that cannot be deleted or a step holding a misbehaving process instance fails.
+    /// A stand-in pipeline whose run completes without steps in a state that is not deliverable, so the
+    /// runner reaches its cleanup with the upload still to release.
     /// </summary>
-    private static Mock<IPipeline> BuildPipelineWithThrowingDispose(Guid jobId)
+    private static Mock<IPipeline> BuildStubPipeline(Guid jobId)
     {
         var pipeline = new Mock<IPipeline>();
-        pipeline.SetupGet(p => p.Id).Returns("throwing_dispose_pipeline");
+        pipeline.SetupGet(p => p.Id).Returns("stub_pipeline");
         pipeline.SetupGet(p => p.JobId).Returns(jobId);
         pipeline.SetupGet(p => p.Steps).Returns(new List<IPipelineStep>());
         pipeline.SetupGet(p => p.State).Returns(ProcessingState.Failed);
@@ -782,7 +808,6 @@ public class ProcessingRunnerTest
                 Upload = Array.Empty<IPipelineFile>(),
                 StepResults = new Dictionary<string, StepResult>(),
             });
-        pipeline.Setup(p => p.Dispose()).Throws(new IOException("The directory is not empty."));
 
         return pipeline;
     }

--- a/tests/Geopilot.Api.Test/Processing/ProcessingRunnerTest.cs
+++ b/tests/Geopilot.Api.Test/Processing/ProcessingRunnerTest.cs
@@ -460,7 +460,7 @@ public class ProcessingRunnerTest
 
         Assert.HasCount(1, step1.Downloads);
         Assert.IsTrue(downloadStore.Exists(jobId, step1.Downloads[0].PersistedFileName), "Earlier step's download must survive a later step failure.");
-        store.Verify(s => s.MarkAsFailed(jobId), Times.Once);
+        store.Verify(s => s.TryMarkAsFailed(jobId), Times.Once);
     }
 
     [TestMethod]
@@ -488,7 +488,7 @@ public class ProcessingRunnerTest
 
         Assert.HasCount(1, step1.Downloads);
         Assert.IsTrue(downloadStore.Exists(jobId, step1.Downloads[0].PersistedFileName), "Pre-timeout step's download must survive the job timeout.");
-        store.Verify(s => s.PipelineFinished(jobId, ProcessingState.Cancelled), Times.Once);
+        store.Verify(s => s.TryPipelineFinished(jobId, ProcessingState.Cancelled), Times.Once);
     }
 
     [TestMethod]
@@ -712,6 +712,58 @@ public class ProcessingRunnerTest
             "The uploaded blobs of a non-deliverable run must be released even when disposing the pipeline failed.");
     }
 
+    [TestMethod]
+    public async Task RunnerSurvivesTerminalTransitionRejectedByTheStore()
+    {
+        var store = new ProcessingJobStore();
+        var gate = new TaskCompletionSource();
+        var uploadReleased = new TaskCompletionSource();
+
+        var job = store.CreateJob(Guid.NewGuid());
+        createdJobIds.Add(job.Id);
+
+        // Releasing the upload is the last thing the runner does for a work item, so it signals that the
+        // body reached the end of its finally block rather than being torn out of it.
+        orchestrationServiceMock
+            .Setup(c => c.ReleaseUploadAsync(job.UploadId))
+            .Callback(() => uploadReleased.TrySetResult())
+            .Returns(Task.CompletedTask);
+
+        using var pipeline = BuildPipeline(job.Id, BuildBlockingStep("step_1", gate.Task));
+        store.AttachPipeline(job.Id, pipeline, 1);
+        store.EnqueueForProcessing(job.Id, Array.Empty<IPipelineFile>());
+
+        using var runner = CreateRunner(store);
+        await runner.StartAsync(CancellationToken.None);
+        try
+        {
+            // The job reaches a terminal state while its pipeline is still running, so the transition the
+            // runner attempts once the pipeline finishes is no longer valid and the strict guard rejects it.
+            await WaitUntilAsync(() => pipeline.State == ProcessingState.Running, TimeSpan.FromSeconds(10));
+            store.MarkAsFailed(job.Id);
+            gate.SetResult();
+
+            await uploadReleased.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            // The real store leaves its queue open, so a runner that survived the rejected transition just
+            // keeps waiting for more work, while one that let the exception escape ends its loop right after
+            // this work item. The check has to happen before StopAsync: cancelling the runner replaces an
+            // already faulted loop with a cancelled one and would hide exactly what is being asserted.
+            var firstToSettle = await Task.WhenAny(runner.ExecuteTask!, Task.Delay(TimeSpan.FromSeconds(2)));
+
+            Assert.AreNotSame(
+                runner.ExecuteTask,
+                firstToSettle,
+                $"The runner loop ended after the rejected transition: {runner.ExecuteTask!.Exception?.InnerException?.Message}");
+            Assert.AreEqual(ProcessingState.Failed, store.GetJob(job.Id)!.State, "The job keeps the state it already reached.");
+        }
+        finally
+        {
+            gate.TrySetResult();
+            await runner.StopAsync(CancellationToken.None);
+        }
+    }
+
     /// <summary>
     /// A pipeline whose run completes in a non-deliverable state and whose disposal then fails, the way
     /// a working directory that cannot be deleted or a step holding a misbehaving process instance fails.
@@ -778,6 +830,11 @@ public class ProcessingRunnerTest
 
         var store = new Mock<IProcessingJobStore>();
         store.SetupGet(s => s.ProcessingQueue).Returns(channel.Reader);
+
+        // Without these the mock answers false, which is the "job unknown or already terminal" case and
+        // would send every test down the runner's warning branch instead of its normal one.
+        store.Setup(s => s.TryMarkAsFailed(It.IsAny<Guid>())).Returns(true);
+        store.Setup(s => s.TryPipelineFinished(It.IsAny<Guid>(), It.IsAny<ProcessingState>())).Returns(true);
 
         return (CreateRunner(store.Object, jobTimeout), store);
     }

--- a/tests/Geopilot.Api.Test/Processing/ProcessingRunnerTest.cs
+++ b/tests/Geopilot.Api.Test/Processing/ProcessingRunnerTest.cs
@@ -673,6 +673,68 @@ public class ProcessingRunnerTest
         store.Verify(s => s.PipelineFinished(jobId, ProcessingState.DeliveryRestriction), Times.Once);
     }
 
+    [TestMethod]
+    public async Task PipelineDisposeFailureDoesNotAbortTheRunner()
+    {
+        var jobId = NewJob();
+        var pipeline = BuildPipelineWithThrowingDispose(jobId);
+
+        var (runner, store) = CreateRunnerWithStore(pipeline.Object);
+        store.Setup(s => s.GetJob(jobId)).Returns(FinishedJob(jobId, Guid.NewGuid(), ProcessingState.Failed));
+
+        await runner.StartAsync(CancellationToken.None);
+        await runner.ExecuteTask!.WaitAsync(TimeSpan.FromSeconds(10));
+        await runner.StopAsync(CancellationToken.None);
+
+        // A faulted ExecuteTask is what tears down the Parallel.ForEachAsync loop and, by default,
+        // the host: the queue would stop draining for every other job as well.
+        Assert.IsTrue(runner.ExecuteTask.IsCompletedSuccessfully, "A failing pipeline disposal must not fault the runner loop.");
+        pipeline.Verify(p => p.Dispose(), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task UploadIsReleasedWhenPipelineDisposeFails()
+    {
+        var jobId = NewJob();
+        var uploadId = Guid.NewGuid();
+        var pipeline = BuildPipelineWithThrowingDispose(jobId);
+
+        var (runner, store) = CreateRunnerWithStore(pipeline.Object);
+        store.Setup(s => s.GetJob(jobId)).Returns(FinishedJob(jobId, uploadId, ProcessingState.Failed));
+
+        await runner.StartAsync(CancellationToken.None);
+        await runner.ExecuteTask!.WaitAsync(TimeSpan.FromSeconds(10));
+        await runner.StopAsync(CancellationToken.None);
+
+        orchestrationServiceMock.Verify(
+            c => c.ReleaseUploadAsync(uploadId),
+            Times.Once,
+            "The uploaded blobs of a non-deliverable run must be released even when disposing the pipeline failed.");
+    }
+
+    /// <summary>
+    /// A pipeline whose run completes in a non-deliverable state and whose disposal then fails, the way
+    /// a working directory that cannot be deleted or a step holding a misbehaving process instance fails.
+    /// </summary>
+    private static Mock<IPipeline> BuildPipelineWithThrowingDispose(Guid jobId)
+    {
+        var pipeline = new Mock<IPipeline>();
+        pipeline.SetupGet(p => p.Id).Returns("throwing_dispose_pipeline");
+        pipeline.SetupGet(p => p.JobId).Returns(jobId);
+        pipeline.SetupGet(p => p.Steps).Returns(new List<IPipelineStep>());
+        pipeline.SetupGet(p => p.State).Returns(ProcessingState.Failed);
+        pipeline
+            .Setup(p => p.Run(It.IsAny<IReadOnlyList<IPipelineFile>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PipelineContext
+            {
+                Upload = Array.Empty<IPipelineFile>(),
+                StepResults = new Dictionary<string, StepResult>(),
+            });
+        pipeline.Setup(p => p.Dispose()).Throws(new IOException("The directory is not empty."));
+
+        return pipeline;
+    }
+
     private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
     {
         var deadline = DateTime.UtcNow + timeout;

--- a/tests/Geopilot.Api.Test/Services/PreflightBackgroundServiceTest.cs
+++ b/tests/Geopilot.Api.Test/Services/PreflightBackgroundServiceTest.cs
@@ -78,11 +78,11 @@ public class PreflightBackgroundServiceTest
         orchestrationServiceMock.Setup(x => x.RunPreflightChecksAsync(uploadId))
             .ThrowsAsync(new UploadPreflightException(PreflightFailureReason.IncompleteUpload, "File missing."));
         orchestrationServiceMock.Setup(x => x.ReleaseUploadAsync(uploadId)).Returns(Task.CompletedTask);
-        jobStoreMock.Setup(x => x.MarkAsFailed(jobId)).Returns(pendingJob with { State = ProcessingState.Failed });
+        jobStoreMock.Setup(x => x.TryMarkAsFailed(jobId)).Returns(true);
 
         await service.ProcessRequestAsync(new PreflightRequest(jobId, uploadId));
 
-        jobStoreMock.Verify(x => x.MarkAsFailed(jobId), Times.Once);
+        jobStoreMock.Verify(x => x.TryMarkAsFailed(jobId), Times.Once);
         orchestrationServiceMock.Verify(x => x.ReleaseUploadAsync(uploadId), Times.Once);
         pipeline.Verify(p => p.Dispose(), Times.Once);
     }
@@ -99,11 +99,11 @@ public class PreflightBackgroundServiceTest
         orchestrationServiceMock.Setup(x => x.RunPreflightChecksAsync(uploadId))
             .ThrowsAsync(new InvalidOperationException("Network timeout"));
         orchestrationServiceMock.Setup(x => x.ReleaseUploadAsync(uploadId)).Returns(Task.CompletedTask);
-        jobStoreMock.Setup(x => x.MarkAsFailed(jobId)).Returns(pendingJob with { State = ProcessingState.Failed });
+        jobStoreMock.Setup(x => x.TryMarkAsFailed(jobId)).Returns(true);
 
         await service.ProcessRequestAsync(new PreflightRequest(jobId, uploadId));
 
-        jobStoreMock.Verify(x => x.MarkAsFailed(jobId), Times.Once);
+        jobStoreMock.Verify(x => x.TryMarkAsFailed(jobId), Times.Once);
         orchestrationServiceMock.Verify(x => x.ReleaseUploadAsync(uploadId), Times.Once);
         pipeline.Verify(p => p.Dispose(), Times.Once);
     }
@@ -121,11 +121,11 @@ public class PreflightBackgroundServiceTest
         orchestrationServiceMock.Setup(x => x.RegisterJobFiles(uploadId, jobId))
             .Throws(new InvalidOperationException($"Upload <{uploadId}> has no files to register."));
         orchestrationServiceMock.Setup(x => x.ReleaseUploadAsync(uploadId)).Returns(Task.CompletedTask);
-        jobStoreMock.Setup(x => x.MarkAsFailed(jobId)).Returns(pendingJob with { State = ProcessingState.Failed });
+        jobStoreMock.Setup(x => x.TryMarkAsFailed(jobId)).Returns(true);
 
         await service.ProcessRequestAsync(new PreflightRequest(jobId, uploadId));
 
-        jobStoreMock.Verify(x => x.MarkAsFailed(jobId), Times.Once);
+        jobStoreMock.Verify(x => x.TryMarkAsFailed(jobId), Times.Once);
         jobStoreMock.Verify(x => x.EnqueueForProcessing(It.IsAny<Guid>(), It.IsAny<IReadOnlyList<IPipelineFile>>()), Times.Never);
         orchestrationServiceMock.Verify(x => x.ReleaseUploadAsync(uploadId), Times.Once);
         pipeline.Verify(p => p.Dispose(), Times.Once);
@@ -144,11 +144,11 @@ public class PreflightBackgroundServiceTest
             .ThrowsAsync(new UploadPreflightException(PreflightFailureReason.IncompleteUpload, "File missing."));
         orchestrationServiceMock.Setup(x => x.ReleaseUploadAsync(uploadId))
             .ThrowsAsync(new InvalidOperationException("Storage unavailable."));
-        jobStoreMock.Setup(x => x.MarkAsFailed(jobId)).Returns(pendingJob with { State = ProcessingState.Failed });
+        jobStoreMock.Setup(x => x.TryMarkAsFailed(jobId)).Returns(true);
 
         await service.ProcessRequestAsync(new PreflightRequest(jobId, uploadId));
 
-        jobStoreMock.Verify(x => x.MarkAsFailed(jobId), Times.Once);
+        jobStoreMock.Verify(x => x.TryMarkAsFailed(jobId), Times.Once);
         pipeline.Verify(p => p.Dispose(), Times.Once);
     }
 

--- a/tests/Geopilot.Pipeline.Test/PipelineTest.cs
+++ b/tests/Geopilot.Pipeline.Test/PipelineTest.cs
@@ -238,14 +238,83 @@ public class PipelineTest
         return step;
     }
 
+    [TestMethod]
+    public void DisposeSurvivesAWorkingDirectoryThatCannotBeDeleted()
+    {
+        // A file where the working directory is expected makes Path.Exists report true while
+        // Directory.Delete fails, on Windows as well as on Linux.
+        var blockedDirectory = NewTempPath();
+        File.WriteAllText(blockedDirectory, "not a directory");
+
+        try
+        {
+            var step = NewDisposableStep("step_1");
+            var pipeline = BuildPipelineIn(blockedDirectory, step.Object);
+
+            pipeline.Dispose();
+            pipeline.Dispose();
+
+            step.Verify(
+                s => s.Dispose(),
+                Times.Once,
+                "The steps are released once even when the working directory cannot be deleted.");
+        }
+        finally
+        {
+            File.Delete(blockedDirectory);
+        }
+    }
+
+    [TestMethod]
+    public void DisposeReleasesTheRemainingStepsWhenOneStepFails()
+    {
+        var directory = NewTempPath();
+        Directory.CreateDirectory(directory);
+
+        try
+        {
+            // A step releases the process instance a plugin provided, so its disposal runs third-party code.
+            var failingStep = NewDisposableStep("failing_step");
+            failingStep.Setup(s => s.Dispose()).Throws(new InvalidOperationException("process disposal failed"));
+            var followingStep = NewDisposableStep("following_step");
+
+            var pipeline = BuildPipelineIn(directory, failingStep.Object, followingStep.Object);
+
+            pipeline.Dispose();
+
+            followingStep.Verify(
+                s => s.Dispose(),
+                Times.Once,
+                "A step that fails to release must not keep the following steps from being released.");
+            Assert.IsFalse(Directory.Exists(directory), "The working directory is removed even when a step fails to release.");
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+                Directory.Delete(directory, true);
+        }
+    }
+
+    private static string NewTempPath() => Path.Combine(Path.GetTempPath(), $"geopilot-test-{Guid.NewGuid()}");
+
+    private static Mock<IPipelineStep> NewDisposableStep(string id)
+    {
+        var step = new Mock<IPipelineStep>();
+        step.SetupGet(s => s.Id).Returns(id);
+        return step;
+    }
+
     private Geopilot.Pipeline.Pipeline BuildPipeline(params IPipelineStep[] steps) =>
+        BuildPipelineIn(NewTempPath(), steps);
+
+    private Geopilot.Pipeline.Pipeline BuildPipelineIn(string pipelineDirectory, params IPipelineStep[] steps) =>
         Geopilot.Pipeline.Pipeline
             .Builder()
             .Id("test_pipeline")
             .DisplayName(new Dictionary<string, string> { { "de", "test pipeline" } })
             .Steps(steps.ToList())
             .Logger(loggerMock.Object)
-            .PipelineDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()))
+            .PipelineDirectory(pipelineDirectory)
             .JobId(Guid.NewGuid())
             .Build();
 }


### PR DESCRIPTION
Closes #889

Setzt Befund 1 und 3 des Issues um. Befund 2 ist durch #945 gegenstandslos geworden.

- `Pipeline.Dispose` protokolliert Löschfehler und fehlgeschlagene Step-Freigaben, statt zu werfen,
  und markiert sich vor dem Aufräumen als disposed.
- Im `finally` des Runners hat jeder der beiden Aufräumschritte einen eigenen Auffangblock, damit die
  Freigabe der Upload-Blobs nicht am Dispose hängt.
- `IProcessingJobStore` bekommt `TryMarkAsFailed` und `TryPipelineFinished`, die das Ergebnis melden
  statt zu werfen. Verwendet werden sie in den `catch`-Blöcken von `ProcessingRunner` und
  `PreflightBackgroundService`. Ein ungültiger `pipelineState` wirft weiterhin in beiden Varianten.
- Die werfende `MarkAsFailed` entfällt. Ein Job wird ausschliesslich aus einem Fehlerpfad als
  gescheitert markiert, die strenge Variante hatte also keinen Aufrufer mehr. Stehengelassen wäre sie
  eine Einladung, im nächsten `catch` wieder danach zu greifen.

Im Normalpfad ändert sich kein Verhalten: der Aufruf in `ExecuteAsync` bleibt die strenge Variante,
weil er im `try` steht und vom `catch` darunter aufgefangen wird. Wo es beide Varianten gibt, teilen
sie ihre Regeln (`CanCompletePipeline`, `EnsureStateIsTerminal`) und können nicht auseinanderlaufen.